### PR TITLE
NO_LOGGING flag also applied for normal log output

### DIFF
--- a/inc/azure_c_shared_utility/xlogging.h
+++ b/inc/azure_c_shared_utility/xlogging.h
@@ -13,7 +13,11 @@ typedef void(*LOGGER_LOG)(unsigned int options, char* format, ...);
 
 #define LOG_LINE 0x01
 
+#ifndef NO_LOGGING
 #define LOG(logger, ...) if (logger != NULL) logger(__VA_ARGS__)
+#else
+#define LOG(logger, ...)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adding option to supress all the log output to console via existing NO_LOGGING flag.
Giving users a choice if they really *always* want to see the connection log outputs.
Most of the time this output is probably no longer needed once the program is deemed functional.
I found that it was only one line needed to be expanded for the unwanted logging output to go away.

For clarification, output such as the following will get eliminated adding the flag
`-> Header (AMQP 0.1.0.0)
<- Header (AMQP 0.1.0.0)
-> [OPEN]* {default_container_id,mytarget.azure-devices.net,4294967295,65535}
<- [OPEN]* {DeviceGateway_b8ce818551884a2184e1dec56d30ded4,10.0.0.60,65536,8191,240000,NULL,NULL,NULL,NULL,NULL}
-> [BEGIN]* {NULL,0,4294967295,100,4294967295}
<- [BEGIN]* {0,1,100,5000,262143,NULL,NULL,NULL}
-> [ATTACH]* {cbs-sender,0,false,0,0,* {$cbs},* {$cbs},NULL,NULL,0,65535}
-> [ATTACH]* {cbs-receiver,1,true,0,0,* {$cbs},* {$cbs},NULL,NULL,NULL,65535}
<- [ATTACH]* {cbs-sender,0,true,0,0,* {$cbs,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},* {$cbs,NULL,NULL,NULL,NULL,NULL,NULL},NULL,NULL,NULL,65535,NULL,NULL,NULL}
<- [FLOW]* {0,100,1,5000,0,0,100,0,NULL,false,NULL}
<- [ATTACH]* {cbs-receiver,1,false,0,0,* {$cbs,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},* {$cbs,NULL,NULL,NULL,NULL,NULL,NULL},NULL,NULL,0,65535,NULL,NULL,NULL}
-> [FLOW]* {NULL,4294968305,0,100,1,0,10000}
-> [TRANSFER]* {0,0,<00 00 00 00>,0,false,false}
<- [DISPOSITION]* {true,0,NULL,true,* {},NULL}
<- [TRANSFER]* {1,0,<01 00 00 00>,0,NULL,false,NULL,NULL,NULL,NULL,false}
-> [DISPOSITION]* {true,0,0,true,* {}}
-> [ATTACH]* {receiver-link,2,true,0,0,* {amqps://mytarget.azure-devices.net/devices/Device1/messages/devicebound},* {ingress-rx},NULL,NULL,NULL,65536,NULL,NULL,{[com.microsoft:client-version:iothubclient/1.0.3]}}
-> [ATTACH]* {sender-link,3,false,0,0,* {ingress},* {amqps://mytarget.azure-devices.net/devices/Device1/messages/events},NULL,NULL,0,18446744073709431615,NULL,NULL,{[com.microsoft:client-version:iothubclient/1.0.3]}}
<- [ATTACH]* {receiver-link,2,false,0,0,* {amqps://mytarget.azure-devices.net/devices/Device1/messages/devicebound,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},* {ingress-rx,NULL,NULL,NULL,NULL,NULL,NULL},NULL,NULL,0,65536,NULL,NULL,{[com.microsoft:client-version:iothubclient/1.0.3]}}
-> [FLOW]* {NULL,4294967281,1,99,2,0,10000}`

Signed-off-by: Simon Egli <simon.egli@bbv.ch>