### PR TITLE
Enable gcc 4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /build_all/windows/nuget.exe
 /cmake
 /devdoc/~$o_requirements.docm
+#### Manully added section
+# Ignore eclipse project file
+.project

--- a/testtools/ctest/inc/ctest.h
+++ b/testtools/ctest/inc/ctest.h
@@ -179,13 +179,14 @@ extern C_LINKAGE int int64_t_Compare(int64_t left, int64_t right);
 
 #endif
 
+#define CTEST_REGISTER_TYPE(toStringType, cType) \
+	typedef cType toStringType;
+
 #define CTEST_COMPARE(toStringType, cType) \
-    typedef cType toStringType; \
     static int toStringType##_Compare(toStringType left, toStringType right)
 
 #define CTEST_TO_STRING(toStringType, cType, string, bufferSize, value) \
-typedef cType toStringType; \
-static void toStringType##_ToString(char* string, size_t bufferSize, cType value)
+	static void toStringType##_ToString(char* string, size_t bufferSize, cType value)
 
 
 #define EAT_2(X1,X2, NAME,...) NAME

--- a/testtools/ctest/unittests/ctestunittests/assertfailurestests.c
+++ b/testtools/ctest/unittests/ctestunittests/assertfailurestests.c
@@ -10,6 +10,8 @@ typedef struct mystruct_tag
     unsigned char x;
 } mystruct;
 
+CTEST_REGISTER_TYPE(mystruct_ptr, mystruct*)
+
 CTEST_COMPARE(mystruct_ptr, mystruct*)
 {
     return (left->x != right->x);

--- a/testtools/ctest/unittests/ctestunittests/assertsuccesstests.c
+++ b/testtools/ctest/unittests/ctestunittests/assertsuccesstests.c
@@ -10,6 +10,8 @@ typedef struct mystruct_tag
     unsigned char x;
 } mystruct;
 
+CTEST_REGISTER_TYPE(mystruct_ptr, mystruct*)
+
 CTEST_COMPARE(mystruct_ptr, mystruct*)
 {
     return (left->x != right->x);


### PR DESCRIPTION
Hi,

Here is part of the way to be able to use the SDK with gcc 4.4.
It adds a new macro to avoid multiple typedef with the same base type.

See https://github.com/Azure/azure-iot-sdks/issues/466

