### PR TITLE
Now possible to use OpenSSL on Windows by setting -Duse_openssl:BOOL=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,15 @@ if(MSVC)
         SET_SOURCE_FILES_PROPERTIES(src/consolelogger.c src/xlogging.c src/map.c adapters/uniqueid_win32.c adapters/httpapi_wince.c src/tlsio_schannel.c src/x509_schannel.c PROPERTIES LANGUAGE CXX)
         add_definitions(-DWIN32) #WEC 2013 
     ELSE()
+	
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
-  
+		
+		if(${use_openssl})
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_OPENSSL")
+			set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_OPENSSL")
+		endif()
+
     endif()
 elseif(LINUX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")

--- a/adapters/platform_win32.c
+++ b/adapters/platform_win32.c
@@ -7,8 +7,14 @@
 #endif
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/tlsio_schannel.h"
+
 #include "winsock2.h"
+
+#ifdef USE_OPENSSL
+#include "azure_c_shared_utility/tlsio_openssl.h"
+#else
+#include "azure_c_shared_utility/tlsio_schannel.h"
+#endif
 
 int platform_init(void)
 {
@@ -24,20 +30,32 @@ int platform_init(void)
         result = 0;
     }
 
-    return result;
+#ifdef USE_OPENSSL
+	tlsio_openssl_init();
+#endif
+	
+	return result;
 }
 
 const IO_INTERFACE_DESCRIPTION* platform_get_default_tlsio(void)
 {
+#ifdef USE_OPENSSL
+	return tlsio_openssl_get_interface_description();
+#else
 #ifndef WINCE
     return tlsio_schannel_get_interface_description();
 #else
 	LogError("TLS IO interface currently not supported on WEC 2013");
 	return (IO_INTERFACE_DESCRIPTION*)NULL;
 #endif
+#endif
 }
 
 void platform_deinit(void)
 {
     (void)WSACleanup();
+
+#ifdef USE_OPENSSL
+	tlsio_openssl_deinit();
+#endif
 }


### PR DESCRIPTION
These updates have been tested with the azure-amqp-c project.
The message_receive_sample and message_sender_sample have been updated in a separate pull request.

They add 3 new IO options that:
1) set the TLS version
2) set the OpenSSL certificate verification callback.
3) set that data passed with 2)
