### PR TITLE
Fix lib install locations for multilib environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(LINUX TRUE)
 endif()
 
+# Set CMAKE_INSTALL_LIBDIR if not defined
+include(GNUInstallDirs)
+
 include (CTest)
 
 #these are the include folders

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,11 @@ option(compileOption_C "passes a string to the command line of the C compiler" O
 option(compileOption_CXX "passes a string to the command line of the C++ compiler" OFF)
 
 # Start of variables used during install
-set (LIB_INSTALL_DIR lib CACHE PATH "Library object file directory")
+if (CMAKE_INSTALL_LIBDIR)
+  set (LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Library object file directory")
+else ()
+  set (LIB_INSTALL_DIR "lib" CACHE PATH "Library object file directory")
+endif ()
 
 #Use solution folders. 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -807,7 +811,7 @@ endif()
 
 if(WIN32)
 else()
-    install (TARGETS aziotsharedutil DESTINATION lib)
-    install (FILES ${source_h_files} DESTINATION include/azureiot/azure_c_shared_utility)
+    install (TARGETS aziotsharedutil DESTINATION ${LIB_INSTALL_DIR})
+    install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot/azure_c_shared_utility)
 endif (WIN32)
 


### PR DESCRIPTION
When installing libs or header files CMake variables should be used rather than using hard-coded paths. This can cause issues with multilib environments for example.