### PR TITLE
Add missing link library UUID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -793,7 +793,7 @@ endif()
 
 if(WIN32)
 else()
-    target_link_libraries(aziotsharedutil pthread m)
+    target_link_libraries(aziotsharedutil pthread uuid m)
 endif()
 
 if(LINUX)


### PR DESCRIPTION
When building with Yocto I get multiple 'undefined reference' errors relating to uuid functions when linking against the shared utility library unless 'uuid' is included as a target link library.