### PR TITLE
apple openssl include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,7 +725,7 @@ if(${use_openssl})
         ./inc/azure_c_shared_utility/tlsio_openssl.h
     ./inc/azure_c_shared_utility/x509_openssl.h
     )
-    if(WIN32)
+    if(WIN32 OR APPLE)
         include_directories($ENV{OpenSSLDir}/include)
     endif()
 endif()


### PR DESCRIPTION
Errors when building on OS X for openssl header files not found. I have openssl installed with homebrew and adding this enabled a successful build with `OpenSSLDir='/usr/local/opt/openssl'`