### PR TITLE
Enable CMake policy to use @rpath on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ project(azure_c_shared_utility)
 
 set(C_SHARED_VERSION 1.0.25)
 
+if(POLICY CMP0042)
+    cmake_policy(SET CMP0042 NEW)
+endif()
+
 option(run_valgrind "set run_valgrind to ON if tests are to be run under valgrind/helgrind/drd. Default is OFF" OFF)
 
 #making a nice global variable to know if we are on linux or not.


### PR DESCRIPTION
I hit a CMake warning while trying to compile the gateway SDK, which depends on azure-c-shared-utility. The warning recommended that I explicitly enable a Mac-specific policy that directs CMake to use `@rpath`.