### PR TITLE
Update WolfSSL driver to use TLS1.2

### DIFF
--- a/src/tlsio_wolfssl.c
+++ b/src/tlsio_wolfssl.c
@@ -584,7 +584,7 @@ CONCRETE_IO_HANDLE tlsio_wolfssl_create(void* io_create_parameters)
 
                 result->tlsio_state = TLSIO_STATE_NOT_OPEN;
 
-                result->ssl_context = wolfSSL_CTX_new(wolfTLSv1_client_method());
+                result->ssl_context = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
                 if (result->ssl_context == NULL)
                 {
                     LogError("Cannot create the wolfSSL context");


### PR DESCRIPTION
Updates the WolfSSL TLS driver to negotiate TLS1.2, which has a number of security improvements over its previous use of TLS1.0.

All unit tests pass, basic manual testing of an app creating an AMQP connection passes.