### PR TITLE
Don't add VS unit test include path to target in VS2017

### DIFF
--- a/testtools/micromock/CMakeLists.txt
+++ b/testtools/micromock/CMakeLists.txt
@@ -58,9 +58,13 @@ IF(WIN32)
     target_compile_definitions(micromock_cpp_unittest PUBLIC CPP_UNITTEST)
     target_compile_options(micromock_cpp_unittest PUBLIC /EHsc)
 
-    #flip VCInstallDir path
-    file(TO_CMAKE_PATH $ENV{VCInstallDir} VCInstallDir)
-    target_include_directories(micromock_cpp_unittest PUBLIC ${VCInstallDir}/UnitTest/include)
+    if(EXISTS "$ENV{VCInstallDir}/UnitTest/include")
+        #flip VCInstallDir path
+        file(TO_CMAKE_PATH $ENV{VCInstallDir} VCInstallDir)
+        #pre-VS2017 build environment doesn't appear to include the path to unit
+        #test headers, so add it here
+        target_include_directories(micromock_cpp_unittest PUBLIC ${VCInstallDir}/UnitTest/include)
+    endif()
 
     set_target_properties(micromock_cpp_unittest
        PROPERTIES


### PR DESCRIPTION
This fixes a problem that prevents the gateway from building in VS 2017. The gateway has several unit test projects that use the older cpp-based micromock framework. In VS 2017, the directory being added to the `micromock_cpp_unittest` target doesn't exist, but the environment already has the *right* include path, so we can simply skip this CMake command.