### PR TITLE
Fix errors when building unittests with VS2008

### DIFF
--- a/adapters/httpapi_compact.c
+++ b/adapters/httpapi_compact.c
@@ -16,6 +16,10 @@
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/shared_util_options.h"
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 /*Codes_SRS_HTTPAPI_COMPACT_21_001: [ The httpapi_compact shall implement the methods defined by the `httpapi.h`. ]*/
 /*Codes_SRS_HTTPAPI_COMPACT_21_002: [ The httpapi_compact shall support the http requests. ]*/
 /*Codes_SRS_HTTPAPI_COMPACT_21_003: [ The httpapi_compact shall return error codes defined by HTTPAPI_RESULT. ]*/
@@ -731,10 +735,11 @@ static HTTPAPI_RESULT OpenXIOConnection(HTTP_HANDLE_DATA* http_instance)
             }
             else
             {
+				int countRetry;
                 /*Codes_SRS_HTTPAPI_COMPACT_21_033: [ If the whole process succeed, the HTTPAPI_ExecuteRequest shall retur HTTPAPI_OK. ]*/
                 result = HTTPAPI_OK;
                 /*Codes_SRS_HTTPAPI_COMPACT_21_077: [ The HTTPAPI_ExecuteRequest shall wait, at least, 10 seconds for the SSL open process. ]*/
-                int countRetry = MAX_OPEN_RETRY;
+                countRetry = MAX_OPEN_RETRY;
                 while ((http_instance->is_connected == 0) &&
                     (http_instance->is_io_error == 0))
                 {
@@ -835,9 +840,10 @@ static HTTPAPI_RESULT SendHeadsToXIO(HTTP_HANDLE_DATA* http_instance, HTTPAPI_RE
         /*Codes_SRS_HTTPAPI_COMPACT_21_028: [ If the HTTPAPI_ExecuteRequest cannot send the request header, it shall return HTTPAPI_HTTP_HEADERS_FAILED. ]*/
     else if ((result = conn_send_all(http_instance, (const unsigned char*)buf, strlen(buf))) == HTTPAPI_OK)
     {
+		size_t i;
         //Send default headers
         /*Codes_SRS_HTTPAPI_COMPACT_21_033: [ If the whole process succeed, the HTTPAPI_ExecuteRequest shall retur HTTPAPI_OK. ]*/
-        for (size_t i = 0; ((i < headersCount) && (result == HTTPAPI_OK)); i++)
+        for (i = 0; ((i < headersCount) && (result == HTTPAPI_OK)); i++)
         {
             char* header;
             if (HTTPHeaders_GetHeader(httpHeadersHandle, i, &header) != HTTP_HEADERS_OK)
@@ -1254,12 +1260,14 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
     }
     else if (strcmp("TrustedCerts", optionName) == 0)
     {
+		int len;
+
         if (http_instance->certificate)
         {
             free(http_instance->certificate);
         }
 
-        int len = (int)strlen((char*)value);
+        len = (int)strlen((char*)value);
         http_instance->certificate = (char*)malloc((len + 1) * sizeof(char));
         if (http_instance->certificate == NULL)
         {
@@ -1276,12 +1284,13 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
     }
     else if (strcmp(SU_OPTION_X509_CERT, optionName) == 0)
     {
+		int len;
         if (http_instance->x509ClientCertificate)
         {
             free(http_instance->x509ClientCertificate);
         }
 
-        int len = (int)strlen((char*)value);
+        len = (int)strlen((char*)value);
         http_instance->x509ClientCertificate = (char*)malloc((len + 1) * sizeof(char));
         if (http_instance->x509ClientCertificate == NULL)
         {
@@ -1298,12 +1307,13 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
     }
     else if (strcmp(SU_OPTION_X509_PRIVATE_KEY, optionName) == 0)
     {
+		int len;
         if (http_instance->x509ClientPrivateKey)
         {
             free(http_instance->x509ClientPrivateKey);
         }
 
-        int len = (int)strlen((char*)value);
+        len = (int)strlen((char*)value);
         http_instance->x509ClientPrivateKey = (char*)malloc((len + 1) * sizeof(char));
         if (http_instance->x509ClientPrivateKey == NULL)
         {

--- a/adapters/tlsio_arduino.c
+++ b/adapters/tlsio_arduino.c
@@ -55,9 +55,9 @@ static const IO_INTERFACE_DESCRIPTION tlsio_handle_interface_description =
 #define MAX_TLS_CLOSING_RETRY  10
 #define RECEIVE_BUFFER_SIZE    128
 
-#define CallErrorCallback() do { if (tlsio_instance->on_io_error != NULL) (void)tlsio_instance->on_io_error(tlsio_instance->on_io_error_context); } while(0)
-#define CallOpenCallback(status) do { if (tlsio_instance->on_io_open_complete != NULL) (void)tlsio_instance->on_io_open_complete(tlsio_instance->on_io_open_complete_context, status); } while(0)
-#define CallCloseCallback() do { if (tlsio_instance->on_io_close_complete != NULL) (void)tlsio_instance->on_io_close_complete(tlsio_instance->on_io_close_complete_context); } while(0)
+#define CallErrorCallback() do { if (tlsio_instance->on_io_error != NULL) (void)tlsio_instance->on_io_error(tlsio_instance->on_io_error_context); } while((void)0,0)
+#define CallOpenCallback(status) do { if (tlsio_instance->on_io_open_complete != NULL) (void)tlsio_instance->on_io_open_complete(tlsio_instance->on_io_open_complete_context, status); } while((void)0,0)
+#define CallCloseCallback() do { if (tlsio_instance->on_io_close_complete != NULL) (void)tlsio_instance->on_io_close_complete(tlsio_instance->on_io_close_complete_context); } while((void)0,0)
 
 
 typedef struct ArduinoTLS_tag

--- a/inc/azure_c_shared_utility/xlogging.h
+++ b/inc/azure_c_shared_utility/xlogging.h
@@ -10,12 +10,6 @@
 #include <stdio.h>
 #endif /* __cplusplus */
 
-#if defined _MSC_VER
-#if _MSC_VER <= 1500
-#pragma warning (disable : 4127)
-#endif
-#endif
-
 #include "azure_c_shared_utility/agenttime.h"
 #include "azure_c_shared_utility/optimize_size.h"
 
@@ -66,7 +60,7 @@ typedef void(*LOGGER_LOG_GETLASTERROR)(const char* file, const char* func, int l
         static const char flash_str[] ICACHE_RODATA_ATTR STORE_ATTR = FORMAT;  \
         printf(flash_str, ##__VA_ARGS__);   \
         printf("\n");\
-    } while(0)
+    } while((void)0,0)
     
 #define LogError LogInfo
 #define LOG(log_category, log_options, FORMAT, ...)  { \
@@ -112,9 +106,9 @@ so we compacted the log in the macro LogInfo.
 #endif
 
 #if defined _MSC_VER
-#define LogInfo(FORMAT, ...) do{LOG(AZ_LOG_INFO, LOG_LINE, FORMAT, __VA_ARGS__); }while(0)
+#define LogInfo(FORMAT, ...) do{LOG(AZ_LOG_INFO, LOG_LINE, FORMAT, __VA_ARGS__); }while((void)0,0)
 #else
-#define LogInfo(FORMAT, ...) do{LOG(AZ_LOG_INFO, LOG_LINE, FORMAT, ##__VA_ARGS__); }while(0)
+#define LogInfo(FORMAT, ...) do{LOG(AZ_LOG_INFO, LOG_LINE, FORMAT, ##__VA_ARGS__); }while((void)0,0)
 #endif
 
 #if defined _MSC_VER
@@ -122,10 +116,10 @@ so we compacted the log in the macro LogInfo.
 #if !defined(WINCE)
 extern void xlogging_set_log_function_GetLastError(LOGGER_LOG_GETLASTERROR log_function);
 extern LOGGER_LOG_GETLASTERROR xlogging_get_log_function_GetLastError(void);
-#define LogLastError(FORMAT, ...) do{ LOGGER_LOG_GETLASTERROR l = xlogging_get_log_function_GetLastError(); if(l!=NULL) l(__FILE__, FUNC_NAME, __LINE__, FORMAT, __VA_ARGS__); }while(0)
+#define LogLastError(FORMAT, ...) do{ LOGGER_LOG_GETLASTERROR l = xlogging_get_log_function_GetLastError(); if(l!=NULL) l(__FILE__, FUNC_NAME, __LINE__, FORMAT, __VA_ARGS__); }while((void)0,0)
 #endif
 
-#define LogError(FORMAT, ...) do{ LOG(AZ_LOG_ERROR, LOG_LINE, FORMAT, __VA_ARGS__); }while(0)
+#define LogError(FORMAT, ...) do{ LOG(AZ_LOG_ERROR, LOG_LINE, FORMAT, __VA_ARGS__); }while((void)0,0)
 #define TEMP_BUFFER_SIZE 1024
 #define MESSAGE_BUFFER_SIZE 260
 #define LogErrorWinHTTPWithGetLastErrorAsString(FORMAT, ...) do { \
@@ -157,9 +151,9 @@ extern LOGGER_LOG_GETLASTERROR xlogging_get_log_function_GetLastError(void);
                         LogError("GetLastError: %s.", messageBuffer); \
                     }\
                 }\
-            } while(0)
+            } while((void)0,0)
 #else
-#define LogError(FORMAT, ...) do{ LOG(AZ_LOG_ERROR, LOG_LINE, FORMAT, ##__VA_ARGS__); }while(0)
+#define LogError(FORMAT, ...) do{ LOG(AZ_LOG_ERROR, LOG_LINE, FORMAT, ##__VA_ARGS__); }while((void)0,0)
 #endif
 
 #ifdef __cplusplus

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -115,6 +115,15 @@ static char* lastErrorToString(DWORD lastError)
 /*the function will also attempt to produce some human readable strings for GetLastError*/
 void consolelogger_log_with_GetLastError(const char* file, const char* func, int line, const char* format, ...)
 {
+	DWORD lastError;
+	char* lastErrorAsString;
+	int lastErrorAsString_should_be_freed;
+	time_t t;
+    int systemMessage_should_be_freed;
+	char* systemMessage;
+    int userMessage_should_be_freed;
+	char* userMessage;
+
     va_list args;
     va_start(args, format);
 
@@ -124,11 +133,10 @@ void consolelogger_log_with_GetLastError(const char* file, const char* func, int
     3. printf the system message (__FILE__, __LINE__ etc) + the last error + whatever the user wanted
     */
     /*1. snip the last error*/
-    DWORD lastError = GetLastError();
+    lastError = GetLastError();
 
     /*2. create a string with what that last error means*/
-    char* lastErrorAsString = lastErrorToString(lastError);
-    int lastErrorAsString_should_be_freed;
+    lastErrorAsString = lastErrorToString(lastError);
     if (lastErrorAsString == NULL)
     {
         (void)printf("failure in lastErrorToString");
@@ -140,9 +148,8 @@ void consolelogger_log_with_GetLastError(const char* file, const char* func, int
         lastErrorAsString_should_be_freed = 1;
     }
 
-    time_t t = time(NULL);
-    int systemMessage_should_be_freed;
-    char* systemMessage = printf_alloc("Error: Time:%.24s File:%s Func:%s Line:%d %s", ctime(&t), file, func, line, lastErrorAsString);
+    t = time(NULL);
+    systemMessage = printf_alloc("Error: Time:%.24s File:%s Func:%s Line:%d %s", ctime(&t), file, func, line, lastErrorAsString);
 
     if (systemMessage == NULL)
     {
@@ -155,8 +162,7 @@ void consolelogger_log_with_GetLastError(const char* file, const char* func, int
         systemMessage_should_be_freed = 1;
     }
 
-    int userMessage_should_be_freed;
-    char* userMessage = vprintf_alloc(format, args);
+    userMessage = vprintf_alloc(format, args);
     if (userMessage == NULL)
     {
         (void)printf("[FAILED] ");

--- a/src/crt_abstractions.c
+++ b/src/crt_abstractions.c
@@ -28,7 +28,7 @@
 
 #if defined DEFINE_INFINITY
 
-#pragma warning(disable:4756) // warning C4756: overflow in constant arithmetic
+#pragma warning(disable:4756 4056) // warning C4756: overflow in constant arithmetic
 
 // These defines are missing in math.h for WEC2013 SDK
 #ifndef _HUGE_ENUF

--- a/tests/agenttime_ut/agenttime_ut.c
+++ b/tests/agenttime_ut/agenttime_ut.c
@@ -91,9 +91,9 @@ BEGIN_TEST_SUITE(agenttime_unittests)
         TEST_FUNCTION(get_difftime_success)
         {
             time_t now, sometimeAfterNow;
+            double diff;
             now = get_time(NULL);
             sometimeAfterNow = now + 42; /*whatever this is*/
-            double diff;
 
             ///act
             diff = get_difftime(sometimeAfterNow, now);

--- a/tests/base64_ut/base64_ut.c
+++ b/tests/base64_ut/base64_ut.c
@@ -1540,8 +1540,9 @@ TEST_FUNCTION(Base64_Encode_leviathan_succeeds)
 TEST_FUNCTION(Base64_Encode_exhaustive_succeeds)
 {
     ///arrange
+	size_t i;
 
-    for (size_t i = 0; i < sizeof(testVector_BINARY_with_equal_signs) / sizeof(testVector_BINARY_with_equal_signs[0]); i++)
+    for (i = 0; i < sizeof(testVector_BINARY_with_equal_signs) / sizeof(testVector_BINARY_with_equal_signs[0]); i++)
     {
         ///arrange
         BUFFER_HANDLE input = BUFFER_new();
@@ -1598,8 +1599,9 @@ TEST_FUNCTION(Base64_Encode_Bytes_with_zero_size_returns_empty_string)
 TEST_FUNCTION(Base64_Encode_Bytes_exhaustive_succeeds)
 {
     ///arrange
+	size_t i;
 
-    for (size_t i = 0; i < sizeof(testVector_BINARY_with_equal_signs) / sizeof(testVector_BINARY_with_equal_signs[0]); i++)
+    for (i = 0; i < sizeof(testVector_BINARY_with_equal_signs) / sizeof(testVector_BINARY_with_equal_signs[0]); i++)
     {
         ///arrange
         STRING_HANDLE result;
@@ -1618,7 +1620,8 @@ TEST_FUNCTION(Base64_Encode_Bytes_exhaustive_succeeds)
 
 TEST_FUNCTION(Base64_Decoder_exhaustive_succeeds)
 {
-    for (size_t i = 0; i < sizeof(testVector_BINARY_with_equal_signs) / sizeof(testVector_BINARY_with_equal_signs[0]); i++)
+	size_t i;
+    for (i = 0; i < sizeof(testVector_BINARY_with_equal_signs) / sizeof(testVector_BINARY_with_equal_signs[0]); i++)
     {
         ///Arrange
         BUFFER_HANDLE result;

--- a/tests/buffer_ut/buffer_ut.c
+++ b/tests/buffer_ut/buffer_ut.c
@@ -144,11 +144,12 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_new_Succeed)
     {
         ///arrange
+		BUFFER_HANDLE g_hBuffer;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
         
         ///act
-        BUFFER_HANDLE g_hBuffer = BUFFER_new();
+        g_hBuffer = BUFFER_new();
 
         ///assert
         ASSERT_IS_NOT_NULL(g_hBuffer);
@@ -221,6 +222,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_pre_build_Succeed)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
@@ -228,7 +230,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         STRICT_EXPECTED_CALL(gballoc_malloc(ALLOCATION_SIZE));
 
         ///act
-        int nResult = BUFFER_pre_build(g_hBuffer, ALLOCATION_SIZE);
+        nResult = BUFFER_pre_build(g_hBuffer, ALLOCATION_SIZE);
 
         ///assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
@@ -260,12 +262,13 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_pre_Size_Zero_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_pre_build(g_hBuffer, 0);
+        nResult = BUFFER_pre_build(g_hBuffer, 0);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -294,8 +297,9 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     {
         ///arrange
         BUFFER_HANDLE g_hBuffer;
+		int nResult;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_pre_build(g_hBuffer, ALLOCATION_SIZE);
+        nResult = BUFFER_pre_build(g_hBuffer, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
@@ -313,6 +317,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_build_Succeed)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
 
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
@@ -324,7 +329,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         ///act
         g_hBuffer = BUFFER_new();
 
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
 
         ///assert
         ASSERT_ARE_EQUAL(size_t, BUFFER_length(g_hBuffer), ALLOCATION_SIZE);
@@ -353,12 +358,13 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_build_Content_NULL_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_build(g_hBuffer, NULL, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, NULL, ALLOCATION_SIZE);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -372,6 +378,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_build_Size_Zero_non_NULL_buffer_Succeeds)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
@@ -380,7 +387,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, 0);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, 0);
 
         ///assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
@@ -394,6 +401,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_build_Size_Zero_NULL_buffer_Succeeds)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
@@ -402,7 +410,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = BUFFER_build(g_hBuffer, NULL, 0);
+        nResult = BUFFER_build(g_hBuffer, NULL, 0);
 
         ///assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
@@ -416,12 +424,13 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_build_handle_NULL_fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_append_build(NULL, BUFFER_Test1, BUFFER_TEST1_SIZE);
+        nResult = BUFFER_append_build(NULL, BUFFER_Test1, BUFFER_TEST1_SIZE);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -435,12 +444,13 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_build_buffer_NULL_buffer_fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_append_build(hBuffer, NULL, BUFFER_TEST1_SIZE);
+        nResult = BUFFER_append_build(hBuffer, NULL, BUFFER_TEST1_SIZE);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -454,12 +464,13 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_build_Size_Zero_NULL_buffer_fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_append_build(hBuffer, BUFFER_Test1, 0);
+        nResult = BUFFER_append_build(hBuffer, BUFFER_Test1, 0);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -475,6 +486,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_build_buffer_NULL_succeed)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
@@ -482,7 +494,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
         //act
-        int nResult = BUFFER_append_build(hBuffer, BUFFER_Test1, BUFFER_TEST1_SIZE);
+        nResult = BUFFER_append_build(hBuffer, BUFFER_Test1, BUFFER_TEST1_SIZE);
 
         //assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
@@ -497,6 +509,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_build_buffer_NULL_fail)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
         umock_c_reset_all_calls();
@@ -504,7 +517,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG)).SetReturn(NULL);
 
         //act
-        int nResult = BUFFER_append_build(hBuffer, BUFFER_Test1, BUFFER_TEST1_SIZE);
+        nResult = BUFFER_append_build(hBuffer, BUFFER_Test1, BUFFER_TEST1_SIZE);
 
         //assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -520,6 +533,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_build_succeed)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_create(BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         
@@ -528,7 +542,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
 
         //act
-        int nResult = BUFFER_append_build(hBuffer, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
+        nResult = BUFFER_append_build(hBuffer, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
 
         //assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
@@ -545,6 +559,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_build_fail)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_create(BUFFER_TEST_VALUE, ALLOCATION_SIZE);
 
@@ -553,7 +568,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, IGNORED_NUM_ARG)).SetReturn(NULL);
 
         //act
-        int nResult = BUFFER_append_build(hBuffer, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
+        nResult = BUFFER_append_build(hBuffer, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
 
         //assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -567,9 +582,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_build_when_the_buffer_is_already_allocated_and_the_same_amount_of_bytes_is_needed_succeeds)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, ALLOCATION_SIZE))
@@ -590,9 +606,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_build_when_the_buffer_is_already_allocated_and_more_bytes_are_needed_succeeds)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE - 1);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE - 1);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, ALLOCATION_SIZE))
@@ -613,9 +630,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_build_when_the_buffer_is_already_allocated_and_less_bytes_are_needed_succeeds)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, ALLOCATION_SIZE - 1))
@@ -637,9 +655,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_unbuild_Succeed)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
@@ -673,9 +692,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_unbuild_Multiple_Alloc_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         nResult = BUFFER_unbuild(g_hBuffer);
         umock_c_reset_all_calls();
 
@@ -695,9 +715,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_enlarge_Succeed)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, 2 * ALLOCATION_SIZE))
@@ -748,9 +769,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_shrink_decrease_size_0_fail)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
+        nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         //act
@@ -770,9 +792,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_shrink_decrease_size_less_than_len_succeed)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
+        nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         //act
@@ -792,9 +815,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_shrink_malloc_fail)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
+        nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_malloc(TOTAL_ALLOCATION_SIZE - ALLOCATION_SIZE)).SetReturn(NULL);
@@ -817,9 +841,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_shrink_from_end_succeed)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
+        nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_malloc(TOTAL_ALLOCATION_SIZE-ALLOCATION_SIZE));
@@ -844,9 +869,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_shrink_all_buffer_succeed)
     {
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
+        nResult = BUFFER_build(hBuffer, TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
@@ -871,9 +897,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         const unsigned char TEST_TOTAL_BUFFER[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26 };
 
         //arrange
+		int nResult;
         BUFFER_HANDLE hBuffer;
         hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(hBuffer, TEST_TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
+        nResult = BUFFER_build(hBuffer, TEST_TOTAL_BUFFER, TOTAL_ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_malloc(TOTAL_ALLOCATION_SIZE-ALLOCATION_SIZE));
@@ -898,9 +925,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_enlarge_Size_Zero_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
@@ -919,13 +947,15 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_content_Succeed)
     {
         ///arrange
+		int nResult;
+		const unsigned char* content;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
-        const unsigned char* content = NULL;
+        content = NULL;
         nResult = BUFFER_content(g_hBuffer, &content);
 
         ///assert
@@ -959,9 +989,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_content_Char_NULL_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
@@ -980,13 +1011,15 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_size_Succeed)
     {
         ///arrange
+		int nResult;
+		size_t size;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
-        size_t size = 0;
+        size = 0;
         nResult = BUFFER_size(g_hBuffer, &size);
 
         ///assert
@@ -1017,9 +1050,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_size_Size_t_NULL_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
@@ -1038,10 +1072,12 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_Succeed)
     {
         ///arrange
+		int nResult;
+		BUFFER_HANDLE hAppend;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
-        BUFFER_HANDLE hAppend = BUFFER_new();
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        hAppend = BUFFER_new();
         nResult = BUFFER_build(hAppend, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
@@ -1066,8 +1102,9 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_HANDLE_NULL_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE hAppend = BUFFER_new();
-        int nResult = BUFFER_build(hAppend, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
+        nResult = BUFFER_build(hAppend, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
@@ -1085,9 +1122,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_APPEND_HANDLE_NULL_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
@@ -1105,17 +1143,18 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_HANDLE2_SIZE_ZERO_SUCCEED)
     {
         ///arrange
-        
+		int nResult;
+        size_t howBig;
         BUFFER_HANDLE handle1 = BUFFER_create(BUFFER_Test1, BUFFER_TEST1_SIZE);
         BUFFER_HANDLE handle2 = BUFFER_create(BUFFER_Test2, 0);
         // umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_append(handle1, handle2);
+        nResult = BUFFER_append(handle1, handle2);
 
         ///assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
-        size_t howBig = BUFFER_length(handle1);
+        howBig = BUFFER_length(handle1);
         ASSERT_ARE_EQUAL(int, 0, memcmp(BUFFER_u_char(handle1), BUFFER_Test1, BUFFER_TEST1_SIZE));
         ASSERT_ARE_EQUAL(size_t, BUFFER_TEST1_SIZE, howBig);
 
@@ -1130,16 +1169,18 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_append_HANDLE1_SIZE_ZERO_SUCCEED)
     {
         ///arrange
+		int nResult;
+		size_t howBig;
         BUFFER_HANDLE handle1 = BUFFER_create(BUFFER_Test1, 0);
         BUFFER_HANDLE handle2 = BUFFER_create(BUFFER_Test2, BUFFER_TEST2_SIZE);
         // umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_append(handle1, handle2);
+        nResult = BUFFER_append(handle1, handle2);
 
         ///assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
-        size_t howBig = BUFFER_length(handle1);
+        howBig = BUFFER_length(handle1);
         ASSERT_ARE_EQUAL(int, 0, memcmp(BUFFER_u_char(handle1), BUFFER_Test2, BUFFER_TEST2_SIZE));
         ASSERT_ARE_EQUAL(size_t, BUFFER_TEST2_SIZE, howBig);
 
@@ -1154,16 +1195,18 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_prepend_HANDLE1_SIZE_ZERO_SUCCEED)
     {
         ///arrange
+		int nResult;
+		size_t howBig;
         BUFFER_HANDLE handle1 = BUFFER_create(BUFFER_Test1, 0);
         BUFFER_HANDLE handle2 = BUFFER_create(BUFFER_Test2, BUFFER_TEST2_SIZE);
         // umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_prepend(handle1, handle2);
+        nResult = BUFFER_prepend(handle1, handle2);
 
         ///assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
-        size_t howBig = BUFFER_length(handle1);
+        howBig = BUFFER_length(handle1);
         ASSERT_ARE_EQUAL(int, 0, memcmp(BUFFER_u_char(handle1), BUFFER_Test2, BUFFER_TEST2_SIZE));
         ASSERT_ARE_EQUAL(size_t, BUFFER_TEST2_SIZE, howBig);
 
@@ -1178,16 +1221,18 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_prepend_HANDLE2_SIZE_ZERO_SUCCEED)
     {
         ///arrange
+		int nResult;
+		size_t howBig;
         BUFFER_HANDLE handle1 = BUFFER_create(BUFFER_Test1, BUFFER_TEST1_SIZE);
         BUFFER_HANDLE handle2 = BUFFER_create(BUFFER_Test2, 0);
         // umock_c_reset_all_calls();
 
         ///act
-        int nResult = BUFFER_prepend(handle1, handle2);
+        nResult = BUFFER_prepend(handle1, handle2);
 
         ///assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
-        size_t howBig = BUFFER_length(handle1);
+        howBig = BUFFER_length(handle1);
         ASSERT_ARE_EQUAL(int, 0, memcmp(BUFFER_u_char(handle1), BUFFER_Test1, BUFFER_TEST1_SIZE));
         ASSERT_ARE_EQUAL(size_t, BUFFER_TEST1_SIZE, howBig);
 
@@ -1203,9 +1248,10 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_prepend_APPEND_HANDLE1_NULL_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
+        nResult = BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
@@ -1223,8 +1269,9 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_prepend_APPEND_HANDLE2_NULL_Fail)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE hAppend = BUFFER_new();
-        int nResult = BUFFER_build(hAppend, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
+        nResult = BUFFER_build(hAppend, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
@@ -1242,10 +1289,12 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_prepend_Succeed)
     {
         ///arrange
+		int nResult;
         BUFFER_HANDLE g_hBuffer;
+		BUFFER_HANDLE hAppend;
         g_hBuffer = BUFFER_new();
-        int nResult = BUFFER_build(g_hBuffer, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
-        BUFFER_HANDLE hAppend = BUFFER_new();
+        nResult = BUFFER_build(g_hBuffer, ADDITIONAL_BUFFER, ALLOCATION_SIZE);
+        hAppend = BUFFER_new();
         nResult = BUFFER_build(hAppend, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
@@ -1275,12 +1324,13 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     {
         ///arrange
         BUFFER_HANDLE g_hBuffer;
+		unsigned char* u;
         g_hBuffer = BUFFER_new();
         (void)BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
         
         ///act
-        unsigned char* u = BUFFER_u_char(g_hBuffer);
+        u = BUFFER_u_char(g_hBuffer);
 
         ///assert
         ASSERT_ARE_EQUAL(int, 0, memcmp(u, BUFFER_TEST_VALUE, ALLOCATION_SIZE) );
@@ -1327,12 +1377,13 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     {
         ///arrange
         BUFFER_HANDLE g_hBuffer;
+		size_t l;
         g_hBuffer = BUFFER_new();
         (void)BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
 
         ///act
-        size_t l = BUFFER_length(g_hBuffer);
+        l = BUFFER_length(g_hBuffer);
 
         ///assert
         ASSERT_ARE_EQUAL(size_t, l, ALLOCATION_SIZE);
@@ -1359,6 +1410,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     {
         ///arrange
         BUFFER_HANDLE g_hBuffer;
+		BUFFER_HANDLE hclone;
         g_hBuffer = BUFFER_new();
         (void)BUFFER_build(g_hBuffer, BUFFER_TEST_VALUE, ALLOCATION_SIZE);
         umock_c_reset_all_calls();
@@ -1370,7 +1422,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
             .IgnoreArgument(1);
 
         ///act
-        BUFFER_HANDLE hclone = BUFFER_clone(g_hBuffer);
+        hclone = BUFFER_clone(g_hBuffer);
 
         ///assert
         ASSERT_ARE_EQUAL(int, 0, memcmp(BUFFER_u_char(hclone), BUFFER_TEST_VALUE, ALLOCATION_SIZE) );
@@ -1413,6 +1465,9 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_create_happy_path)
     {
         ///arrange
+		BUFFER_HANDLE res;
+		const unsigned char* data;
+		size_t howBig;
         char c = '3';
 
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
@@ -1421,13 +1476,13 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         STRICT_EXPECTED_CALL(gballoc_malloc(1));
 
         ///act
-        BUFFER_HANDLE res = BUFFER_create((const unsigned char*)&c, 1);
+        res = BUFFER_create((const unsigned char*)&c, 1);
 
         ///assert
         ASSERT_IS_NOT_NULL(res);
-        size_t howBig = BUFFER_length(res);
+        howBig = BUFFER_length(res);
         ASSERT_ARE_EQUAL(size_t, 1, howBig);
-        const unsigned char* data = BUFFER_u_char(res);
+        data = BUFFER_u_char(res);
         ASSERT_ARE_EQUAL(uint8_t, '3', data[0]);
 
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1441,6 +1496,9 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     TEST_FUNCTION(BUFFER_create_ZERO_SIZE_SUCCEED)
     {
         ///arrange
+		size_t howBig;
+		BUFFER_HANDLE res;
+		const unsigned char* data;
         char c = '3';
 
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
@@ -1449,11 +1507,11 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         STRICT_EXPECTED_CALL(gballoc_malloc(1));
 
         ///act
-        BUFFER_HANDLE res = BUFFER_create((const unsigned char*)&c, 0);
+        res = BUFFER_create((const unsigned char*)&c, 0);
         ///assert
         ASSERT_IS_NOT_NULL(res);
-        size_t howBig = BUFFER_length(res);
-        const unsigned char* data = BUFFER_u_char(res);
+        howBig = BUFFER_length(res);
+        data = BUFFER_u_char(res);
         ASSERT_IS_NULL(data);
         ASSERT_ARE_EQUAL(size_t, 0, howBig);
 
@@ -1469,6 +1527,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     {
         ///arrange
         char c = '3';
+		BUFFER_HANDLE res;
 
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
@@ -1479,7 +1538,7 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
         whenShallmalloc_fail = 2;
 
         ///act
-        BUFFER_HANDLE res = BUFFER_create((const unsigned char*)&c, 1);
+        res = BUFFER_create((const unsigned char*)&c, 1);
 
         ///assert
         ASSERT_IS_NULL(res);
@@ -1494,13 +1553,14 @@ BEGIN_TEST_SUITE(Buffer_UnitTests)
     {
         ///arrange
         char c = '3';
+		BUFFER_HANDLE res;
 
         whenShallmalloc_fail = 1;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
 
         ///act
-        BUFFER_HANDLE res = BUFFER_create((const unsigned char*)&c, 1);
+        res = BUFFER_create((const unsigned char*)&c, 1);
 
         ///assert
         ASSERT_IS_NULL(res);

--- a/tests/condition_ut/condition_ut.c
+++ b/tests/condition_ut/condition_ut.c
@@ -324,13 +324,15 @@ TEST_FUNCTION(Condition_Wait_ok_on_trigger_and_zero_timeout)
 {
     // arrange
     LockAndCondition m;
+	THREAD_HANDLE th;
+	COND_RESULT result;
     m.condition = Condition_Init();
     m.lock = Lock_Init();
     
     // act
-    THREAD_HANDLE th = trigger_after_50_ms(&m);
+    th = trigger_after_50_ms(&m);
     Lock(m.lock);
-    COND_RESULT result = Condition_Wait(m.condition, m.lock, 0);
+    result = Condition_Wait(m.condition, m.lock, 0);
     ThreadAPI_Join(th, NULL);
     Unlock(m.lock);
 
@@ -346,12 +348,13 @@ TEST_FUNCTION(Condition_Wait_timeout_when_not_triggered)
 {
     // arrange
     LockAndCondition m; 
+	COND_RESULT result;
     m.condition = Condition_Init();
     m.lock = Lock_Init();
 
     // act
     Lock(m.lock);
-    COND_RESULT result = Condition_Wait(m.condition, m.lock, 150);
+    result = Condition_Wait(m.condition, m.lock, 150);
     Unlock(m.lock);
 
     // assert
@@ -366,13 +369,15 @@ TEST_FUNCTION(Condition_Wait_ok_on_trigger_with_timeout)
 {
     // arrange
     LockAndCondition m;
+	COND_RESULT result;
+	THREAD_HANDLE th;
     m.condition = Condition_Init();
     m.lock = Lock_Init();
 
     // act
-    THREAD_HANDLE th = trigger_after_50_ms(&m);
+    th = trigger_after_50_ms(&m);
     Lock(m.lock);
-    COND_RESULT result = Condition_Wait(m.condition, m.lock, 1000);
+    result = Condition_Wait(m.condition, m.lock, 1000);
     Unlock(m.lock);
     ThreadAPI_Join(th, NULL);
 

--- a/tests/connectionstringparser_ut/connectionstringparser_ut.c
+++ b/tests/connectionstringparser_ut/connectionstringparser_ut.c
@@ -151,6 +151,7 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
 TEST_FUNCTION(connectionstringparser_parse_with_an_empty_string_yields_an_empty_map)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE connectionString = STRING_new();
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
@@ -167,7 +168,7 @@ TEST_FUNCTION(connectionstringparser_parse_with_an_empty_string_yields_an_empty_
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(connectionString);
+    result = connectionstringparser_parse(connectionString);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, result);
@@ -194,11 +195,12 @@ TEST_FUNCTION(connectionstringparser_parse_with_NULL_connection_string_fails)
 TEST_FUNCTION(when_creating_the_string_tokenizer_fails_then_connectionstringparser_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_create(TEST_STRING_HANDLE_PAIR))
         .SetReturn((STRING_TOKENIZER_HANDLE)NULL);
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, NULL, result);
@@ -210,6 +212,7 @@ TEST_FUNCTION(when_creating_the_string_tokenizer_fails_then_connectionstringpars
 TEST_FUNCTION(when_allocating_the_key_token_string_fails_then_connectionstringparser_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_TOKENIZER_HANDLE tokens = STRING_TOKENIZER_create(TEST_STRING_HANDLE_PAIR);
 
     umock_c_reset_all_calls();
@@ -218,7 +221,7 @@ TEST_FUNCTION(when_allocating_the_key_token_string_fails_then_connectionstringpa
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, NULL, result);
@@ -231,6 +234,7 @@ TEST_FUNCTION(when_allocating_the_key_token_string_fails_then_connectionstringpa
 TEST_FUNCTION(when_allocating_the_value_token_string_fails_then_connectionstringparser_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_TOKENIZER_HANDLE tokens = STRING_TOKENIZER_create(TEST_STRING_HANDLE_PAIR);
 
@@ -242,7 +246,7 @@ TEST_FUNCTION(when_allocating_the_value_token_string_fails_then_connectionstring
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, NULL, result);
@@ -255,6 +259,7 @@ TEST_FUNCTION(when_allocating_the_value_token_string_fails_then_connectionstring
 TEST_FUNCTION(when_allocating_the_result_map_fails_then_connectionstringparser_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     STRING_TOKENIZER_HANDLE tokens = STRING_TOKENIZER_create(TEST_STRING_HANDLE_PAIR);
@@ -269,7 +274,7 @@ TEST_FUNCTION(when_allocating_the_result_map_fails_then_connectionstringparser_f
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, NULL, result);
@@ -292,6 +297,7 @@ TEST_FUNCTION(when_allocating_the_result_map_fails_then_connectionstringparser_f
 TEST_FUNCTION(connectionstringparser_parse_with_a_key_value_pair_adds_it_to_the_result_map)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     STRING_TOKENIZER_HANDLE tokens = STRING_TOKENIZER_create(TEST_STRING_HANDLE_PAIR);
@@ -318,7 +324,7 @@ TEST_FUNCTION(connectionstringparser_parse_with_a_key_value_pair_adds_it_to_the_
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -333,6 +339,7 @@ TEST_FUNCTION(connectionstringparser_parse_with_a_key_value_pair_adds_it_to_the_
 TEST_FUNCTION(when_getting_the_value_token_fails_then_connectionstringparser_parse_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     MAP_HANDLE map = Map_Create(NULL);
@@ -354,7 +361,7 @@ TEST_FUNCTION(when_getting_the_value_token_fails_then_connectionstringparser_par
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_KEY);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_KEY);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -365,6 +372,7 @@ TEST_FUNCTION(when_getting_the_value_token_fails_then_connectionstringparser_par
 TEST_FUNCTION(when_the_key_is_zero_length_then_connectionstringparser_parse_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     MAP_HANDLE map = Map_Create(NULL);
@@ -387,7 +395,7 @@ TEST_FUNCTION(when_the_key_is_zero_length_then_connectionstringparser_parse_fail
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(IGNORED_PTR_ARG)).IgnoreArgument(1);
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -398,6 +406,7 @@ TEST_FUNCTION(when_the_key_is_zero_length_then_connectionstringparser_parse_fail
 TEST_FUNCTION(when_adding_the_key_value_pair_to_the_map_fails_then_connectionstringparser_parse_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     MAP_HANDLE map = Map_Create(NULL);
@@ -423,7 +432,7 @@ TEST_FUNCTION(when_adding_the_key_value_pair_to_the_map_fails_then_connectionstr
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -434,6 +443,7 @@ TEST_FUNCTION(when_adding_the_key_value_pair_to_the_map_fails_then_connectionstr
 TEST_FUNCTION(when_getting_the_C_string_for_the_key_fails_then_connectionstringparser_parse_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     MAP_HANDLE map = Map_Create(NULL);
@@ -456,7 +466,7 @@ TEST_FUNCTION(when_getting_the_C_string_for_the_key_fails_then_connectionstringp
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(IGNORED_PTR_ARG)).IgnoreArgument(1);
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -467,6 +477,7 @@ TEST_FUNCTION(when_getting_the_C_string_for_the_key_fails_then_connectionstringp
 TEST_FUNCTION(when_getting_the_C_string_for_the_value_fails_then_connectionstringparser_parse_fails)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     MAP_HANDLE map = Map_Create(NULL);
@@ -491,7 +502,7 @@ TEST_FUNCTION(when_getting_the_C_string_for_the_value_fails_then_connectionstrin
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -512,6 +523,7 @@ TEST_FUNCTION(when_getting_the_C_string_for_the_value_fails_then_connectionstrin
 TEST_FUNCTION(connectionstringparser_parse_with_2_key_value_pairs_adds_them_to_the_result_map)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     MAP_HANDLE map = Map_Create(NULL);
@@ -553,7 +565,7 @@ TEST_FUNCTION(connectionstringparser_parse_with_2_key_value_pairs_adds_them_to_t
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_2_PAIR);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_2_PAIR);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -580,6 +592,7 @@ TEST_FUNCTION(connectionstringparser_parse_with_2_key_value_pairs_adds_them_to_t
 TEST_FUNCTION(connectionstringparser_parse_with_2_key_value_pairs_ended_with_semicolon_adds_them_to_the_result_map)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     MAP_HANDLE map = Map_Create(NULL);
@@ -621,7 +634,7 @@ TEST_FUNCTION(connectionstringparser_parse_with_2_key_value_pairs_ended_with_sem
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse(TEST_STRING_HANDLE_2_PAIR_SEMICOLON);
+    result = connectionstringparser_parse(TEST_STRING_HANDLE_2_PAIR_SEMICOLON);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -637,6 +650,7 @@ TEST_FUNCTION(connectionstringparser_parse_with_2_key_value_pairs_ended_with_sem
 TEST_FUNCTION(connectionstringparser_parse_from_char_with_2_key_value_pairs_ended_with_semicolon_adds_them_to_the_result_map)
 {
     // arrange
+	MAP_HANDLE result;
     STRING_HANDLE key = STRING_new();
     STRING_HANDLE value = STRING_new();
     MAP_HANDLE map = Map_Create(NULL);
@@ -679,7 +693,7 @@ TEST_FUNCTION(connectionstringparser_parse_from_char_with_2_key_value_pairs_ende
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(tokens));
 
     // act
-    MAP_HANDLE result = connectionstringparser_parse_from_char(TEST_STRING_2_PAIR_SEMICOLON);
+    result = connectionstringparser_parse_from_char(TEST_STRING_2_PAIR_SEMICOLON);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -710,6 +724,7 @@ TEST_FUNCTION(connectionstringparser_parse_from_char_with_NULL_connection_string
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_success)
 {
     // arrange
+	int result;
     const char* hostName = "abc.bcd.efg";
     const char* startSuffix = hostName + 4;
     STRING_HANDLE nameString = STRING_new();
@@ -722,7 +737,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_success)
     STRICT_EXPECTED_CALL(STRING_copy(suffixString, startSuffix));
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
+    result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -739,6 +754,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_success)
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_hostName_failed)
 {
     // arrange
+	int result;
     STRING_HANDLE nameString = STRING_new();
     STRING_HANDLE suffixString = STRING_new();
     ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, nameString);
@@ -747,7 +763,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_hostName_
     umock_c_reset_all_calls();
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(NULL, nameString, suffixString);
+    result = connectionstringparser_splitHostName_from_char(NULL, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -764,6 +780,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_hostName_
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_hostName_failed)
 {
     // arrange
+	int result;
     const char* hostName = "";
     STRING_HANDLE nameString = STRING_new();
     STRING_HANDLE suffixString = STRING_new();
@@ -773,7 +790,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_hostName
     umock_c_reset_all_calls();
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
+    result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -790,6 +807,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_hostName
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_nameString_failed)
 {
     // arrange
+	int result;
     const char* hostName = "abc.bcd.efg";
     STRING_HANDLE suffixString = STRING_new();
     ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, suffixString);
@@ -797,7 +815,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_nameStrin
     umock_c_reset_all_calls();
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(hostName, NULL, suffixString);
+    result = connectionstringparser_splitHostName_from_char(hostName, NULL, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -812,6 +830,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_nameStrin
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_suffixString_failed)
 {
     // arrange
+	int result;
     const char* hostName = "abc.bcd.efg";
     STRING_HANDLE nameString = STRING_new();
     ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, nameString);
@@ -819,7 +838,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_suffixStr
     umock_c_reset_all_calls();
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(hostName, nameString, NULL);
+    result = connectionstringparser_splitHostName_from_char(hostName, nameString, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -834,6 +853,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_NULL_suffixStr
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_name_failed)
 {
     // arrange
+	int result;
     const char* hostName = ".bcd.efg";
     STRING_HANDLE nameString = STRING_new();
     STRING_HANDLE suffixString = STRING_new();
@@ -843,7 +863,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_name_fai
     umock_c_reset_all_calls();
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
+    result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -860,6 +880,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_name_fai
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_suffix_failed)
 {
     // arrange
+	int result;
     const char* hostName = "abc.";
     STRING_HANDLE nameString = STRING_new();
     STRING_HANDLE suffixString = STRING_new();
@@ -869,7 +890,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_suffix_f
     umock_c_reset_all_calls();
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
+    result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -886,6 +907,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_with_empty_suffix_f
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_error_on_nameString_copy_failed)
 {
     // arrange
+	int result;
     const char* hostName = "abc.bcd.efg";
     STRING_HANDLE nameString = STRING_new();
     STRING_HANDLE suffixString = STRING_new();
@@ -896,7 +918,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_error_on_nameString
     STRICT_EXPECTED_CALL(STRING_copy_n(nameString, hostName, 3)).SetReturn(10);
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
+    result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -913,6 +935,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_error_on_nameString
 TEST_FUNCTION(connectionstringparser_splitHostName_from_char_error_on_suffixString_copy_failed)
 {
     // arrange
+	int result;
     const char* hostName = "abc.bcd.efg";
     const char* startSuffix = hostName + 4;
     STRING_HANDLE nameString = STRING_new();
@@ -925,7 +948,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_error_on_suffixStri
     STRICT_EXPECTED_CALL(STRING_copy(suffixString, startSuffix)).SetReturn(10);
 
     // act
-    int result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
+    result = connectionstringparser_splitHostName_from_char(hostName, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -942,12 +965,15 @@ TEST_FUNCTION(connectionstringparser_splitHostName_from_char_error_on_suffixStri
 TEST_FUNCTION(connectionstringparser_splitHostName_with_success)
 {
     // arrange
-    STRING_HANDLE hostNameString = STRING_construct("abc.bcd.efg");
-    ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, hostNameString);
-    const char* hostName = STRING_c_str(hostNameString);
-    const char* startSuffix = hostName + 4;
+	int result;
+	const char* hostName;
+	const char* startSuffix;
     STRING_HANDLE nameString = STRING_new();
     STRING_HANDLE suffixString = STRING_new();
+    STRING_HANDLE hostNameString = STRING_construct("abc.bcd.efg");
+    ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, hostNameString);
+    hostName = STRING_c_str(hostNameString);
+    startSuffix = hostName + 4;
     ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, nameString);
     ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, suffixString);
 
@@ -957,7 +983,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_with_success)
     STRICT_EXPECTED_CALL(STRING_copy(suffixString, startSuffix));
 
     // act
-    int result = connectionstringparser_splitHostName(hostNameString, nameString, suffixString);
+    result = connectionstringparser_splitHostName(hostNameString, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -975,6 +1001,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_with_success)
 TEST_FUNCTION(connectionstringparser_splitHostName_with_NULL_hostName_failed)
 {
     // arrange
+	int result;
     STRING_HANDLE nameString = STRING_new();
     STRING_HANDLE suffixString = STRING_new();
     ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, nameString);
@@ -983,7 +1010,7 @@ TEST_FUNCTION(connectionstringparser_splitHostName_with_NULL_hostName_failed)
     umock_c_reset_all_calls();
 
     // act
-    int result = connectionstringparser_splitHostName(NULL, nameString, suffixString);
+    result = connectionstringparser_splitHostName(NULL, nameString, suffixString);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/tests/constbuffer_ut/constbuffer_ut.c
+++ b/tests/constbuffer_ut/constbuffer_ut.c
@@ -172,6 +172,8 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_Create_succeeds)
     {
         ///arrange
+		CONSTBUFFER_HANDLE handle;
+		const CONSTBUFFER* content;
 
         ///act
         /*this is the handle*/
@@ -180,12 +182,12 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         /*this is the content*/
         STRICT_EXPECTED_CALL(gballoc_malloc(BUFFER1_length));
 
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
+        handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
 
         ///assert
         ASSERT_IS_NOT_NULL(handle);
         /*testing the "copy"*/
-        const CONSTBUFFER* content = CONSTBUFFER_GetContent(handle);
+        content = CONSTBUFFER_GetContent(handle);
         ASSERT_ARE_EQUAL(size_t, BUFFER1_length, content->size);
         ASSERT_ARE_EQUAL(int, 0, memcmp(BUFFER1_u_char, content->buffer, BUFFER1_length));
         /*testing that it is a copy and not a pointer assignment*/
@@ -201,9 +203,10 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_CreateFromBuffer_succeeds)
     {
         ///arrange
+		CONSTBUFFER_HANDLE handle;
+		const CONSTBUFFER* content;
 
         ///act
-
         STRICT_EXPECTED_CALL(BUFFER_length(BUFFER1_HANDLE));
         STRICT_EXPECTED_CALL(BUFFER_u_char(BUFFER1_HANDLE));
         /*this is the handle*/
@@ -212,12 +215,12 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         /*this is the content*/
         STRICT_EXPECTED_CALL(gballoc_malloc(BUFFER1_length));
 
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
+        handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
 
         ///assert
         ASSERT_IS_NOT_NULL(handle);
         /*testing the "copy"*/
-        const CONSTBUFFER* content = CONSTBUFFER_GetContent(handle);
+        content = CONSTBUFFER_GetContent(handle);
         ASSERT_ARE_EQUAL(size_t, BUFFER1_length, content->size);
         ASSERT_ARE_EQUAL(int, 0, memcmp(BUFFER1_u_char, content->buffer, BUFFER1_length));
         /*testing that it is a copy and not a pointer assignment*/
@@ -232,6 +235,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_CreateFromBuffer_fails_when_malloc_fails_1)
     {
         ///arrange
+		CONSTBUFFER_HANDLE handle;
 
         ///act
         STRICT_EXPECTED_CALL(BUFFER_length(BUFFER1_HANDLE));
@@ -248,7 +252,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
             .IgnoreArgument(1);
 
 
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
+        handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
 
         ///assert
         ASSERT_IS_NULL(handle);
@@ -262,6 +266,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_CreateFromBuffer_fails_when_malloc_fails_2)
     {
         ///arrange
+		CONSTBUFFER_HANDLE handle;
 
         ///act
         STRICT_EXPECTED_CALL(BUFFER_length(BUFFER1_HANDLE));
@@ -272,7 +277,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
 
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
+        handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
 
         ///assert
         ASSERT_IS_NULL(handle);
@@ -327,6 +332,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_Create_fails_when_malloc_fails_1)
     {
         ///arrange
+		CONSTBUFFER_HANDLE handle;
 
         ///act
         /*this is the handle*/
@@ -338,7 +344,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
             .IgnoreArgument(1);
 
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
+        handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
 
         ///assert
         ASSERT_IS_NULL(handle);
@@ -351,6 +357,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_Create_fails_when_malloc_fails_2)
     {
         ///arrange
+		CONSTBUFFER_HANDLE handle;
 
         ///act
         /*this is the handle*/
@@ -358,7 +365,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
 
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
+        handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
 
         ///assert
         ASSERT_IS_NULL(handle);
@@ -395,18 +402,20 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_Create_from_0_size_succeeds_1)
     {
         ///arrange
+		CONSTBUFFER_HANDLE handle;
+		const CONSTBUFFER* content;
 
         ///act
         /*this is the handle*/
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
 
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER2_u_char, BUFFER2_length);
+        handle = CONSTBUFFER_Create(BUFFER2_u_char, BUFFER2_length);
 
         ///assert
         ASSERT_IS_NOT_NULL(handle);
         /*testing the "copy"*/
-        const CONSTBUFFER* content = CONSTBUFFER_GetContent(handle);
+        content = CONSTBUFFER_GetContent(handle);
         ASSERT_ARE_EQUAL(size_t, BUFFER2_length, content->size);
         /*testing that it is a copy and not a pointer assignment*/
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -420,18 +429,20 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_Create_from_0_size_succeeds_2)
     {
         ///arrange
+		CONSTBUFFER_HANDLE handle;
+		const CONSTBUFFER* content;
 
         ///act
         /*this is the handle*/
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
 
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER3_u_char, BUFFER3_length);
+        handle = CONSTBUFFER_Create(BUFFER3_u_char, BUFFER3_length);
 
         ///assert
         ASSERT_IS_NOT_NULL(handle);
         /*testing the "copy"*/
-        const CONSTBUFFER* content = CONSTBUFFER_GetContent(handle);
+        content = CONSTBUFFER_GetContent(handle);
         ASSERT_ARE_EQUAL(size_t, BUFFER3_length, content->size);
         /*testing that it is a copy and not a pointer assignment*/
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -459,11 +470,14 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_GetContent_succeeds_1)
     {
         ///arrange
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
+		CONSTBUFFER_HANDLE handle;
+		const CONSTBUFFER* content;
+
+		handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
         umock_c_reset_all_calls();
 
         ///act
-        const CONSTBUFFER* content = CONSTBUFFER_GetContent(handle);
+        content = CONSTBUFFER_GetContent(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(content);
@@ -482,11 +496,13 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_GetContent_succeeds_2)
     {
         ///arrange
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(NULL, 0);
+		CONSTBUFFER_HANDLE handle;
+		const CONSTBUFFER* content;
+        handle = CONSTBUFFER_Create(NULL, 0);
         umock_c_reset_all_calls();
 
         ///act
-        const CONSTBUFFER* content = CONSTBUFFER_GetContent(handle);
+        content = CONSTBUFFER_GetContent(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(content);
@@ -516,11 +532,12 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     TEST_FUNCTION(CONSTBUFFER_Clone_increments_ref_count_1)
     {
         ///arrange
+		CONSTBUFFER_HANDLE clone;
         CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
         umock_c_reset_all_calls();
 
         ///act
-        CONSTBUFFER_HANDLE clone = CONSTBUFFER_Clone(handle);
+        clone = CONSTBUFFER_Clone(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(void_ptr, handle, clone);

--- a/tests/constmap_ut/constmap_ut.c
+++ b/tests/constmap_ut/constmap_ut.c
@@ -206,6 +206,8 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_Create_Destroy_Success)
     {
         // Arrange
+		MAP_HANDLE sourceMap;
+		CONSTMAP_HANDLE aHandle;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
         STRICT_EXPECTED_CALL(Map_Clone(VALID_MAP_HANDLE));
@@ -214,10 +216,10 @@ BEGIN_TEST_SUITE(constmap_unittests)
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
             .IgnoreArgument(1);
 
-        MAP_HANDLE sourceMap = VALID_MAP_HANDLE;
+        sourceMap = VALID_MAP_HANDLE;
 
         ///Act
-        CONSTMAP_HANDLE aHandle = ConstMap_Create(sourceMap);
+        aHandle = ConstMap_Create(sourceMap);
 
         ASSERT_IS_NOT_NULL(aHandle);
 
@@ -234,14 +236,16 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_Create_Malloc_Failed)
     {
         // Arrange
+		MAP_HANDLE sourceMap;
+		CONSTMAP_HANDLE aHandle;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
         whenShallmalloc_fail = 1;
 
-        MAP_HANDLE sourceMap = VALID_MAP_HANDLE;
+        sourceMap = VALID_MAP_HANDLE;
 
         ///Act
-        CONSTMAP_HANDLE aHandle = ConstMap_Create(sourceMap);
+        aHandle = ConstMap_Create(sourceMap);
 
         ///Assert
         ASSERT_IS_NULL(aHandle);
@@ -256,16 +260,18 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_Clone_Map_Failed)
     {
         // Arrange
+		MAP_HANDLE sourceMap;
+		CONSTMAP_HANDLE aHandle;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
         STRICT_EXPECTED_CALL(Map_Clone(INVALID_MAP_HANDLE));
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
             .IgnoreArgument(1);
 
-        MAP_HANDLE sourceMap = INVALID_MAP_HANDLE;
+        sourceMap = INVALID_MAP_HANDLE;
 
         ///Act
-        CONSTMAP_HANDLE aHandle = ConstMap_Create(sourceMap);
+        aHandle = ConstMap_Create(sourceMap);
 
         ///Assert
         ASSERT_IS_NULL(aHandle);
@@ -316,13 +322,14 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_Clone_Success)
     {
         // Arrange
+		CONSTMAP_HANDLE aClone;
         MAP_HANDLE sourceMap = VALID_MAP_HANDLE;
         CONSTMAP_HANDLE aHandle = ConstMap_Create(sourceMap);
 
         umock_c_reset_all_calls();
 
         ///Act
-        CONSTMAP_HANDLE aClone = ConstMap_Clone(aHandle);
+        aClone = ConstMap_Clone(aHandle);
 
         ///Assert
         ASSERT_ARE_EQUAL(void_ptr, aHandle, aClone);
@@ -486,6 +493,15 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_ContainsKey_Failures)
     {
         // Arrange
+        MAP_RESULT mapErrorList[] = {
+            MAP_ERROR,
+            MAP_INVALIDARG, 
+            MAP_KEYEXISTS, 
+            MAP_KEYNOTFOUND, 
+            MAP_FILTER_REJECT
+        };
+        size_t errors = sizeof(mapErrorList) / sizeof(MAP_RESULT);
+		size_t e;
         const char * key = "aKey";
         bool keyExists;
 
@@ -507,16 +523,7 @@ BEGIN_TEST_SUITE(constmap_unittests)
 
 
         ///Act
-        MAP_RESULT mapErrorList[] = {
-            MAP_ERROR,
-            MAP_INVALIDARG, 
-            MAP_KEYEXISTS, 
-            MAP_KEYNOTFOUND, 
-            MAP_FILTER_REJECT
-        };
-        size_t errors = sizeof(mapErrorList) / sizeof(MAP_RESULT);
-
-        for (size_t e = 0; e < errors; e++)
+        for (e = 0; e < errors; e++)
         {
             currentMapResult = mapErrorList[e];
             keyExists = ConstMap_ContainsKey(aHandle, key);
@@ -594,6 +601,15 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_ContainsValue_Failures)
     {
         // Arrange
+        MAP_RESULT mapErrorList[] = {
+            MAP_ERROR,
+            MAP_INVALIDARG,
+            MAP_KEYEXISTS,
+            MAP_KEYNOTFOUND,
+            MAP_FILTER_REJECT
+        };
+        size_t errors = sizeof(mapErrorList) / sizeof(MAP_RESULT);
+		size_t e;
         const char * value = "aValue";
         bool valueExists;
 
@@ -614,16 +630,7 @@ BEGIN_TEST_SUITE(constmap_unittests)
             .IgnoreArgument(1).IgnoreArgument(3);
 
         ///Act
-        MAP_RESULT mapErrorList[] = {
-            MAP_ERROR,
-            MAP_INVALIDARG,
-            MAP_KEYEXISTS,
-            MAP_KEYNOTFOUND,
-            MAP_FILTER_REJECT
-        };
-        size_t errors = sizeof(mapErrorList) / sizeof(MAP_RESULT);
-
-        for (size_t e = 0; e < errors; e++)
+        for (e = 0; e < errors; e++)
         {
             currentMapResult = mapErrorList[e];
             valueExists = ConstMap_ContainsValue(aHandle, value);
@@ -700,6 +707,15 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_GetValue_Failures)
     {
         // Arrange
+        MAP_RESULT mapErrorList[] = {
+            MAP_ERROR,
+            MAP_INVALIDARG,
+            MAP_KEYEXISTS,
+            MAP_KEYNOTFOUND,
+            MAP_FILTER_REJECT
+        };
+        size_t errors = sizeof(mapErrorList) / sizeof(MAP_RESULT);
+		size_t e;
         const char * key = "aKey";
         const char * value;
 
@@ -721,16 +737,8 @@ BEGIN_TEST_SUITE(constmap_unittests)
 
 
         ///Act
-        MAP_RESULT mapErrorList[] = {
-            MAP_ERROR,
-            MAP_INVALIDARG,
-            MAP_KEYEXISTS,
-            MAP_KEYNOTFOUND,
-            MAP_FILTER_REJECT
-        };
-        size_t errors = sizeof(mapErrorList) / sizeof(MAP_RESULT);
         // Errors from Map_GetValueFromKey
-        for (size_t e = 0; e < errors; e++)
+        for (e = 0; e < errors; e++)
         {
             currentMapResult = mapErrorList[e];
             value = ConstMap_GetValue(aHandle, key);
@@ -751,6 +759,7 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_GetInternals_Success)
     {
         // Arrange
+		CONSTMAP_RESULT result;
         const char*const* keys;
         const char*const* values;
         size_t count;
@@ -764,7 +773,7 @@ BEGIN_TEST_SUITE(constmap_unittests)
             .IgnoreArgument(1);
 
         ///Act
-        CONSTMAP_RESULT result = ConstMap_GetInternals(aHandle, &keys, &values, &count);
+        result = ConstMap_GetInternals(aHandle, &keys, &values, &count);
 
         ///Assert
         ASSERT_ARE_EQUAL(CONSTMAP_RESULT, CONSTMAP_OK, result);
@@ -802,6 +811,22 @@ BEGIN_TEST_SUITE(constmap_unittests)
     TEST_FUNCTION(ConstMap_GetInternals_Failures)
     {
         // Arrange
+        MAP_RESULT mapErrorList[] = {
+            MAP_ERROR,
+            MAP_INVALIDARG,
+            MAP_KEYEXISTS,
+            MAP_KEYNOTFOUND,
+            MAP_FILTER_REJECT
+        };
+        size_t errors = sizeof(mapErrorList) / sizeof(MAP_RESULT);
+        CONSTMAP_RESULT constErrorList[] = {
+            CONSTMAP_ERROR,
+            CONSTMAP_INVALIDARG,
+            CONSTMAP_ERROR,
+            CONSTMAP_KEYNOTFOUND,
+            CONSTMAP_ERROR
+        };
+		size_t e;
         const char*const* keys;
         const char*const* values;
         size_t count;
@@ -824,31 +849,15 @@ BEGIN_TEST_SUITE(constmap_unittests)
             .IgnoreArgument(1);
 
         ///Act
-        MAP_RESULT mapErrorList[] = {
-            MAP_ERROR,
-            MAP_INVALIDARG,
-            MAP_KEYEXISTS,
-            MAP_KEYNOTFOUND,
-            MAP_FILTER_REJECT
-        };
-        size_t errors = sizeof(mapErrorList) / sizeof(MAP_RESULT);
-        CONSTMAP_RESULT constErrorList[] = {
-            CONSTMAP_ERROR,
-            CONSTMAP_INVALIDARG,
-            CONSTMAP_ERROR,
-            CONSTMAP_KEYNOTFOUND,
-            CONSTMAP_ERROR
-        };
-
-        for (size_t e = 0; e < errors; e++)
+        for (e = 0; e < errors; e++)
         {
+			CONSTMAP_RESULT result;
             currentMapResult = mapErrorList[e];
-            CONSTMAP_RESULT result = ConstMap_GetInternals(aHandle, &keys, &values, &count);
+            result = ConstMap_GetInternals(aHandle, &keys, &values, &count);
             ASSERT_ARE_EQUAL(CONSTMAP_RESULT, constErrorList[e], result);
         }
 
         ///Assert
-
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         //Ablution    

--- a/tests/doublylinkedlist_ut/doublylinkedlist_ut.c
+++ b/tests/doublylinkedlist_ut/doublylinkedlist_ut.c
@@ -381,9 +381,8 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
     {
         ///arrange
         DLIST_ENTRY listHead;
-        DList_InitializeListHead(&listHead);
-
         DLIST_ENTRY toBeInserted;
+        DList_InitializeListHead(&listHead);
 
         ///act
         DList_InsertHeadList(&listHead, &toBeInserted);
@@ -400,9 +399,9 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
     {
         ///arrange
         DLIST_ENTRY listHead;
-        DList_InitializeListHead(&listHead);
         DLIST_ENTRY existingInList;
         DLIST_ENTRY toBeInserted;
+        DList_InitializeListHead(&listHead);
         DList_InsertTailList(&listHead, &existingInList); /*would be same as insertHead when it is the first item... */
 
         ///act

--- a/tests/gballoc_ut/gballoc_ut.c
+++ b/tests/gballoc_ut/gballoc_ut.c
@@ -121,8 +121,9 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
 TEST_FUNCTION(gballoc_init_resets_memory_used)
 {
     //arrange
+	void* allocation;
     gballoc_init();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     EXPECTED_CALL(mock_malloc(0))
         .SetReturn(allocation);
@@ -146,10 +147,11 @@ TEST_FUNCTION(gballoc_init_resets_memory_used)
 TEST_FUNCTION(when_gballoc_init_calls_lock_init_and_it_succeeds_then_gballoc_init_succeeds)
 {
     // arrange
+	int result;
     STRICT_EXPECTED_CALL(Lock_Init());
 
     // act
-    int result = gballoc_init();
+    result = gballoc_init();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -160,11 +162,12 @@ TEST_FUNCTION(when_gballoc_init_calls_lock_init_and_it_succeeds_then_gballoc_ini
 TEST_FUNCTION(when_lock_init_fails_gballoc_init_fails)
 {
     // arrange
+	int result;
     STRICT_EXPECTED_CALL(Lock_Init())
         .SetReturn((LOCK_HANDLE)NULL);
 
     // act
-    int result = gballoc_init();
+    result = gballoc_init();
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -175,11 +178,12 @@ TEST_FUNCTION(when_lock_init_fails_gballoc_init_fails)
 TEST_FUNCTION(gballoc_init_after_gballoc_init_fails)
 {
     // arrange
+	int result;
     STRICT_EXPECTED_CALL(Lock_Init());
     gballoc_init();
 
     //act
-    int result = gballoc_init();
+    result = gballoc_init();
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -222,6 +226,7 @@ TEST_FUNCTION(gballoc_deinit_after_gballoc_deinit_doesnot_free_lock)
 TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_malloc_fails)
 {
     // arrange
+	void* result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -229,7 +234,7 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_malloc_fails)
         .SetReturn(LOCK_ERROR);
 
     // act
-    void* result = gballoc_malloc(1);
+    result = gballoc_malloc(1);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -242,9 +247,11 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_malloc_fails)
 TEST_FUNCTION(gballoc_malloc_with_0_Size_Calls_Underlying_malloc)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -255,7 +262,7 @@ TEST_FUNCTION(gballoc_malloc_with_0_Size_Calls_Underlying_malloc)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_malloc(0);
+    result = gballoc_malloc(0);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -273,9 +280,11 @@ TEST_FUNCTION(gballoc_malloc_with_0_Size_Calls_Underlying_malloc)
 TEST_FUNCTION(gballoc_malloc_with_1_Size_Calls_Underlying_malloc_And_Increases_Max_Used)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -286,7 +295,7 @@ TEST_FUNCTION(gballoc_malloc_with_1_Size_Calls_Underlying_malloc_And_Increases_M
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_malloc(1);
+    result = gballoc_malloc(1);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -302,9 +311,11 @@ TEST_FUNCTION(gballoc_malloc_with_1_Size_Calls_Underlying_malloc_And_Increases_M
 TEST_FUNCTION(When_malloc_Fails_Then_gballoc_malloc_fails_too)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -317,7 +328,7 @@ TEST_FUNCTION(When_malloc_Fails_Then_gballoc_malloc_fails_too)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_malloc(1);
+    result = gballoc_malloc(1);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -332,6 +343,7 @@ TEST_FUNCTION(When_malloc_Fails_Then_gballoc_malloc_fails_too)
 TEST_FUNCTION(When_allocating_memory_for_tracking_information_fails_Then_gballoc_malloc_fails_too)
 {
     // arrange
+	void* result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -342,7 +354,7 @@ TEST_FUNCTION(When_allocating_memory_for_tracking_information_fails_Then_gballoc
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_malloc(1);
+    result = gballoc_malloc(1);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -354,10 +366,11 @@ TEST_FUNCTION(When_allocating_memory_for_tracking_information_fails_Then_gballoc
 TEST_FUNCTION(gballoc_malloc_after_deinit_calls_crt_malloc)
 {
     // arrange
+	void* result;
     STRICT_EXPECTED_CALL(mock_malloc(1));
 
     //act
-    void* result = gballoc_malloc(1);
+    result = gballoc_malloc(1);
 
     //assert
     ASSERT_IS_NOT_NULL(result);
@@ -370,6 +383,7 @@ TEST_FUNCTION(gballoc_malloc_after_deinit_calls_crt_malloc)
 TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_calloc_fails)
 {
     // arrange
+	void* result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -377,7 +391,7 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_calloc_fails)
     .SetReturn(LOCK_ERROR);
 
     // act
-    void* result = gballoc_calloc(1,1);
+    result = gballoc_calloc(1,1);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -390,9 +404,11 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_calloc_fails)
 TEST_FUNCTION(gballoc_calloc_with_0_Size_And_ItemCount_Calls_Underlying_calloc)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -403,7 +419,7 @@ TEST_FUNCTION(gballoc_calloc_with_0_Size_And_ItemCount_Calls_Underlying_calloc)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_calloc(0, 0);
+    result = gballoc_calloc(0, 0);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -420,9 +436,11 @@ TEST_FUNCTION(gballoc_calloc_with_0_Size_And_ItemCount_Calls_Underlying_calloc)
 TEST_FUNCTION(gballoc_calloc_with_1_Item_Of_1_Size_Calls_Underlying_malloc_And_Increases_Max_Used)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -433,7 +451,7 @@ TEST_FUNCTION(gballoc_calloc_with_1_Item_Of_1_Size_Calls_Underlying_malloc_And_I
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_calloc(1, 1);
+    result = gballoc_calloc(1, 1);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -450,9 +468,11 @@ TEST_FUNCTION(gballoc_calloc_with_1_Item_Of_1_Size_Calls_Underlying_malloc_And_I
 TEST_FUNCTION(gballoc_calloc_with_1_Item_Of_0_Size_Calls_Underlying_malloc_And_Does_Not_Increase_Max_Used)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -463,7 +483,7 @@ TEST_FUNCTION(gballoc_calloc_with_1_Item_Of_0_Size_Calls_Underlying_malloc_And_D
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_calloc(1, 0);
+    result = gballoc_calloc(1, 0);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -480,9 +500,11 @@ TEST_FUNCTION(gballoc_calloc_with_1_Item_Of_0_Size_Calls_Underlying_malloc_And_D
 TEST_FUNCTION(gballoc_calloc_with_0_Items_Of_1_Size_Calls_Underlying_malloc_And_Does_Not_Increase_Max_Used)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -493,7 +515,7 @@ TEST_FUNCTION(gballoc_calloc_with_0_Items_Of_1_Size_Calls_Underlying_malloc_And_
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_calloc(0, 1);
+    result = gballoc_calloc(0, 1);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -510,9 +532,11 @@ TEST_FUNCTION(gballoc_calloc_with_0_Items_Of_1_Size_Calls_Underlying_malloc_And_
 TEST_FUNCTION(gballoc_calloc_with_42_Items_Of_2_Size_Calls_Underlying_malloc_And_Increases_Max_Size)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -523,7 +547,7 @@ TEST_FUNCTION(gballoc_calloc_with_42_Items_Of_2_Size_Calls_Underlying_malloc_And
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_calloc(42, 2);
+    result = gballoc_calloc(42, 2);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -539,9 +563,11 @@ TEST_FUNCTION(gballoc_calloc_with_42_Items_Of_2_Size_Calls_Underlying_malloc_And
 TEST_FUNCTION(When_calloc_Fails_Then_gballoc_calloc_fails_too)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -554,7 +580,7 @@ TEST_FUNCTION(When_calloc_Fails_Then_gballoc_calloc_fails_too)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_calloc(1, 1);
+    result = gballoc_calloc(1, 1);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -569,6 +595,7 @@ TEST_FUNCTION(When_calloc_Fails_Then_gballoc_calloc_fails_too)
 TEST_FUNCTION(When_allocating_memory_for_tracking_information_fails_Then_gballoc_calloc_fails_too)
 {
     // arrange
+	void* result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -579,7 +606,7 @@ TEST_FUNCTION(When_allocating_memory_for_tracking_information_fails_Then_gballoc
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_calloc(1, 1);
+    result = gballoc_calloc(1, 1);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -591,10 +618,11 @@ TEST_FUNCTION(When_allocating_memory_for_tracking_information_fails_Then_gballoc
 TEST_FUNCTION(gballoc_calloc_after_deinit_calls_crt_calloc)
 {
     // arrange
+	void* result;
     STRICT_EXPECTED_CALL(mock_calloc(1, 1));
 
     // act
-    void* result = gballoc_calloc(1, 1);
+    result = gballoc_calloc(1, 1);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -608,6 +636,7 @@ TEST_FUNCTION(gballoc_calloc_after_deinit_calls_crt_calloc)
 TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_realloc_fails)
 {
     // arrange
+	void* result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -615,7 +644,7 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_realloc_fails)
         .SetReturn(LOCK_ERROR);
 
     // act
-    void* result = gballoc_realloc(NULL, 1);
+    result = gballoc_realloc(NULL, 1);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -626,10 +655,11 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_realloc_fails)
 TEST_FUNCTION(gballoc_realloc_after_deinit_fails)
 {
     // arrange
+	void* result;
     STRICT_EXPECTED_CALL(mock_realloc(NULL, 1));
 
     // act
-    void* result = gballoc_realloc(NULL, 1);
+    result = gballoc_realloc(NULL, 1);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -642,9 +672,11 @@ TEST_FUNCTION(gballoc_realloc_after_deinit_fails)
 TEST_FUNCTION(gballoc_realloc_with_NULL_Arg_And_0_Size_Calls_Underlying_realloc)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -655,7 +687,7 @@ TEST_FUNCTION(gballoc_realloc_with_NULL_Arg_And_0_Size_Calls_Underlying_realloc)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_realloc(NULL, 0);
+    result = gballoc_realloc(NULL, 0);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -672,9 +704,11 @@ TEST_FUNCTION(gballoc_realloc_with_NULL_Arg_And_0_Size_Calls_Underlying_realloc)
 TEST_FUNCTION(gballoc_realloc_with_NULL_Arg_And_1_Size_Calls_Underlying_realloc)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -685,7 +719,7 @@ TEST_FUNCTION(gballoc_realloc_with_NULL_Arg_And_1_Size_Calls_Underlying_realloc)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_realloc(NULL, 1);
+    result = gballoc_realloc(NULL, 1);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, TEST_ALLOC_PTR1, result);
@@ -702,9 +736,11 @@ TEST_FUNCTION(gballoc_realloc_with_NULL_Arg_And_1_Size_Calls_Underlying_realloc)
 TEST_FUNCTION(gballoc_realloc_with_Previous_1_Byte_Block_Ptr_And_2_Size_Calls_Underlying_realloc_And_Increases_Max_Used_Memory)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -718,7 +754,7 @@ TEST_FUNCTION(gballoc_realloc_with_Previous_1_Byte_Block_Ptr_And_2_Size_Calls_Un
         .SetReturn(TEST_ALLOC_PTR2);
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void* result = gballoc_realloc(NULL, 1);
+    result = gballoc_realloc(NULL, 1);
 
     // act
     result = gballoc_realloc(result, 2);
@@ -737,9 +773,11 @@ TEST_FUNCTION(gballoc_realloc_with_Previous_1_Byte_Block_Ptr_And_2_Size_Calls_Un
 TEST_FUNCTION(When_realloc_fails_then_gballoc_realloc_Fails_Too_And_No_Change_Is_Made_To_Memory_Counters)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -753,7 +791,7 @@ TEST_FUNCTION(When_realloc_fails_then_gballoc_realloc_Fails_Too_And_No_Change_Is
         .SetReturn((void*)NULL);
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void* result = gballoc_realloc(NULL, 1);
+    result = gballoc_realloc(NULL, 1);
 
     // act
     result = gballoc_realloc(result, 2);
@@ -772,6 +810,7 @@ TEST_FUNCTION(When_realloc_fails_then_gballoc_realloc_Fails_Too_And_No_Change_Is
 TEST_FUNCTION(When_Allocating_Memory_For_tracking_fails_gballoc_realloc_fails)
 {
     // arrange
+	void* result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -782,7 +821,7 @@ TEST_FUNCTION(When_Allocating_Memory_For_tracking_fails_gballoc_realloc_fails)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_realloc(NULL, 1);
+    result = gballoc_realloc(NULL, 1);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -794,9 +833,12 @@ TEST_FUNCTION(When_Allocating_Memory_For_tracking_fails_gballoc_realloc_fails)
 TEST_FUNCTION(When_The_Pointer_Is_Not_Tracked_gballoc_realloc_Returns_NULL)
 {
     // arrange
+	void* result1;
+	void* result2;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -808,10 +850,10 @@ TEST_FUNCTION(When_The_Pointer_Is_Not_Tracked_gballoc_realloc_Returns_NULL)
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void* result1 = gballoc_realloc(NULL, 1);
+    result1 = gballoc_realloc(NULL, 1);
 
     // act
-    void* result2 = gballoc_realloc(TEST_REALLOC_PTR, 2);
+    result2 = gballoc_realloc(TEST_REALLOC_PTR, 2);
 
     // assert
     ASSERT_IS_NULL(result2);
@@ -827,9 +869,11 @@ TEST_FUNCTION(When_The_Pointer_Is_Not_Tracked_gballoc_realloc_Returns_NULL)
 TEST_FUNCTION(When_ptr_is_null_and_the_underlying_realloc_fails_then_the_memory_used_for_tracking_is_freed)
 {
     // arrange
+	void* result;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -842,7 +886,7 @@ TEST_FUNCTION(When_ptr_is_null_and_the_underlying_realloc_fails_then_the_memory_
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    void* result = gballoc_realloc(NULL, 1);
+    result = gballoc_realloc(NULL, 1);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -872,16 +916,18 @@ TEST_FUNCTION(gballoc_free_after_deinit_calls_crt_free)
 TEST_FUNCTION(when_acquiring_the_lock_fails_then_gballoc_free_does_nothing)
 {
     // arrange
+	void* block;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
     EXPECTED_CALL(mock_malloc(0))
         .SetReturn(allocation);
     /* This is the call to the underlying malloc with the size we want to allocate */
     STRICT_EXPECTED_CALL(mock_realloc(NULL, 1));
-    void* block = gballoc_realloc(NULL, 1);
+    block = gballoc_realloc(NULL, 1);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE))
@@ -906,16 +952,18 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_then_gballoc_free_does_nothing)
 TEST_FUNCTION(gballoc_free_calls_the_underlying_free)
 {
     // arrange
+	void* block;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
     EXPECTED_CALL(mock_malloc(0))
         .SetReturn(allocation);
     /* This is the call to the underlying malloc with the size we want to allocate */
     STRICT_EXPECTED_CALL(mock_realloc(NULL, 1));
-    void* block = gballoc_realloc(NULL, 1);
+    block = gballoc_realloc(NULL, 1);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
@@ -942,15 +990,17 @@ TEST_FUNCTION(gballoc_free_calls_the_underlying_free)
 TEST_FUNCTION(gballoc_malloc_free_2_times_with_1_byte_yields_1_byte_as_max)
 {
     // arrange
+	void* block;
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
     EXPECTED_CALL(mock_malloc(0))
         .SetReturn(allocation);
     STRICT_EXPECTED_CALL(mock_realloc(NULL, 1));
-    void* block = gballoc_realloc(NULL, 1);
+    block = gballoc_realloc(NULL, 1);
     gballoc_free(block);
 
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
@@ -980,9 +1030,10 @@ TEST_FUNCTION(gballoc_malloc_free_2_times_with_1_byte_yields_1_byte_as_max)
 TEST_FUNCTION(gballoc_free_with_an_untracked_pointer_does_not_alter_total_memory_used)
 {
     // arrange
+	void* allocation;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     /* don't quite like this, but I'm unsure I want to invest more in this memory counting */
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
@@ -1031,6 +1082,7 @@ TEST_FUNCTION(when_gballoc_getMaximumMemoryUsed_called_It_Shall_Lock_And_Unlock)
 TEST_FUNCTION(when_acquiring_the_lock_fails_then_gballoc_getMaximumMemoryUsed_fails)
 {
     // arrange
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -1038,7 +1090,7 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_then_gballoc_getMaximumMemoryUsed_fa
         .SetReturn(LOCK_ERROR);
 
     // act
-    size_t result = gballoc_getMaximumMemoryUsed();
+    result = gballoc_getMaximumMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1064,22 +1116,25 @@ TEST_FUNCTION(gballoc_getMaximumMemoryUsed_after_deinit_fails)
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_returns_1)
 {
     // arrange
+	void* allocation;
+	void* toBeFreed;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
 
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
         .SetReturn(allocation);
     STRICT_EXPECTED_CALL(mock_malloc(1));
-    void *toBeFreed = gballoc_malloc(1);
+    toBeFreed = gballoc_malloc(1);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 1, result);
@@ -1095,20 +1150,23 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_returns_1)
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_2x3_byte_calloc_returns_6)
 {
     // arrange
+	void* allocation;
+	void* toBeFreed;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
         .SetReturn(allocation);
-    void *toBeFreed = gballoc_calloc(2, 3);
+    toBeFreed = gballoc_calloc(2, 3);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 6, result);
@@ -1124,9 +1182,12 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_2x3_byte_calloc_returns_6)
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_3_bytes_realloc_returns_3)
 {
     // arrange
+	void* allocation;
+	void* toBeFreed;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
@@ -1134,14 +1195,14 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_3_bytes_reall
     STRICT_EXPECTED_CALL(mock_malloc(1));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed = gballoc_malloc(1);
+    toBeFreed = gballoc_malloc(1);
     toBeFreed = gballoc_realloc(toBeFreed, 3);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 3, result);
@@ -1157,9 +1218,12 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_3_bytes_reall
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_free_returns_0)
 {
     // arrange
+	void* allocation;
+	void* toBeFreed;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
@@ -1167,14 +1231,14 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_free_returns_
     STRICT_EXPECTED_CALL(mock_malloc(1));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed = gballoc_malloc(1);
+    toBeFreed = gballoc_malloc(1);
     gballoc_free(toBeFreed);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 0, result);
@@ -1189,23 +1253,26 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_free_returns_
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_2x3_byte_calloc_and_free_returns_0)
 {
     // arrange
+	void* allocation;
+	void* toBeFreed;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
         .SetReturn(allocation);
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed = gballoc_calloc(2, 3);
+    toBeFreed = gballoc_calloc(2, 3);
     gballoc_free(toBeFreed);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 0, result);
@@ -1220,9 +1287,12 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_2x3_byte_calloc_and_free_return
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_realloc_and_free_returns_0)
 {
     // arrange
+	void* allocation;
+	void* toBeFreed;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation = malloc(OVERHEAD_SIZE);
+    allocation = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
@@ -1230,7 +1300,7 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_realloc_and_free_returns_0)
     STRICT_EXPECTED_CALL(mock_malloc(1));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed = gballoc_malloc(1);
+    toBeFreed = gballoc_malloc(1);
     toBeFreed = gballoc_realloc(toBeFreed, 3);
     gballoc_free(toBeFreed);
     umock_c_reset_all_calls();
@@ -1238,7 +1308,7 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_realloc_and_free_returns_0)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 0, result);
@@ -1253,11 +1323,16 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_realloc_and_free_returns_0)
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc_returns_2)
 {
     // arrange
+	void* allocation1;
+	void* allocation2;
+	void* toBeFreed1;
+	void* toBeFreed2;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
 
-    void* allocation1 = malloc(OVERHEAD_SIZE);
-    void* allocation2 = malloc(OVERHEAD_SIZE);
+    allocation1 = malloc(OVERHEAD_SIZE);
+    allocation2 = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
@@ -1270,14 +1345,14 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc
     STRICT_EXPECTED_CALL(mock_malloc(1));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed1 = gballoc_malloc(1);
-    void *toBeFreed2 = gballoc_malloc(1);
+    toBeFreed1 = gballoc_malloc(1);
+    toBeFreed2 = gballoc_malloc(1);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 2, result);
@@ -1295,11 +1370,16 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc_and_3_realloc_returns_4)
 {
     // arrange
+	void* allocation1;
+	void* allocation2;
+	void* toBeFreed1;
+	void* toBeFreed2;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
 
-    void* allocation1 = malloc(OVERHEAD_SIZE);
-    void* allocation2 = malloc(OVERHEAD_SIZE);
+    allocation1 = malloc(OVERHEAD_SIZE);
+    allocation2 = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
@@ -1312,15 +1392,15 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc
     STRICT_EXPECTED_CALL(mock_malloc(1));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed1 = gballoc_malloc(1);
-    void *toBeFreed2 = gballoc_malloc(1);
+    toBeFreed1 = gballoc_malloc(1);
+    toBeFreed2 = gballoc_malloc(1);
     toBeFreed2 = gballoc_realloc(toBeFreed2, 3);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 4, result);
@@ -1338,11 +1418,16 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_6_byte_calloc_returns_7)
 {
     // arrange
+	void* allocation1;
+	void* allocation2;
+	void* toBeFreed1;
+	void* toBeFreed2;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
 
-    void* allocation1 = malloc(OVERHEAD_SIZE);
-    void* allocation2 = malloc(OVERHEAD_SIZE);
+    allocation1 = malloc(OVERHEAD_SIZE);
+    allocation2 = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
@@ -1355,14 +1440,14 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_6_byte_calloc
     STRICT_EXPECTED_CALL(mock_calloc(2, 3));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed1 = gballoc_malloc(1);
-    void *toBeFreed2 = gballoc_calloc(2, 3);
+    toBeFreed1 = gballoc_malloc(1);
+    toBeFreed2 = gballoc_calloc(2, 3);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 7, result);
@@ -1380,10 +1465,15 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_6_byte_calloc
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_6_byte_calloc_and_free_returns_6)
 {
     // arrange
+	void* allocation1;
+	void* allocation2;
+	void* toBeFreed1;
+	void* toBeFreed2;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation1 = malloc(OVERHEAD_SIZE);
-    void* allocation2 = malloc(OVERHEAD_SIZE);
+    allocation1 = malloc(OVERHEAD_SIZE);
+    allocation2 = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
@@ -1398,15 +1488,15 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_6_byte_calloc
         .SetReturn((char*)allocation2 + OVERHEAD_SIZE / 2);
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed1 = gballoc_malloc(1);
-    void *toBeFreed2 = gballoc_calloc(2, 3);
+    toBeFreed1 = gballoc_malloc(1);
+    toBeFreed2 = gballoc_calloc(2, 3);
     gballoc_free(toBeFreed1);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 6, result);
@@ -1423,10 +1513,15 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_6_byte_calloc
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc_and_3_realloc_and_free_returns_3)
 {
     // arrange
+	void* allocation1;
+	void* allocation2;
+	void* toBeFreed1;
+	void* toBeFreed2;
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
-    void* allocation1 = malloc(OVERHEAD_SIZE);
-    void* allocation2 = malloc(OVERHEAD_SIZE);
+    allocation1 = malloc(OVERHEAD_SIZE);
+    allocation2 = malloc(OVERHEAD_SIZE);
 
     STRICT_EXPECTED_CALL(Lock(TEST_LOCK_HANDLE));
     EXPECTED_CALL(mock_malloc(0))
@@ -1442,8 +1537,8 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc
         .SetReturn((char*)allocation2 + OVERHEAD_SIZE / 2); /*somewhere in the middle of allocation*/
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
-    void *toBeFreed1 = gballoc_malloc(1);
-    void *toBeFreed2 = gballoc_malloc(1);
+    toBeFreed1 = gballoc_malloc(1);
+    toBeFreed2 = gballoc_malloc(1);
     toBeFreed2 = gballoc_realloc(toBeFreed2, 3);
     gballoc_free(toBeFreed1);
     umock_c_reset_all_calls();
@@ -1451,7 +1546,7 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 3, result);
@@ -1468,6 +1563,7 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_1_byte_malloc_and_1_byte_malloc
 TEST_FUNCTION(gballoc_getCurrentMemoryUsed_locks_and_unlocks)
 {
     // assert
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -1475,7 +1571,7 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_locks_and_unlocks)
     STRICT_EXPECTED_CALL(Unlock(TEST_LOCK_HANDLE));
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, 0, result);
@@ -1499,6 +1595,7 @@ TEST_FUNCTION(gballoc_getCurrentMemoryUsed_after_deinit_fails)
 TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_getCurrentMemoryUsed_fails)
 {
     // arrange
+	size_t result;
     gballoc_init();
     umock_c_reset_all_calls();
 
@@ -1506,7 +1603,7 @@ TEST_FUNCTION(when_acquiring_the_lock_fails_gballoc_getCurrentMemoryUsed_fails)
         .SetReturn(LOCK_ERROR);
 
     // act
-    size_t result = gballoc_getCurrentMemoryUsed();
+    result = gballoc_getCurrentMemoryUsed();
 
     // assert
     ASSERT_ARE_EQUAL(size_t, SIZE_MAX, result);

--- a/tests/gballoc_without_init_ut/gballoc_without_init_ut.c
+++ b/tests/gballoc_without_init_ut/gballoc_without_init_ut.c
@@ -127,11 +127,11 @@ TEST_FUNCTION(when_gballoc_is_not_initialized_gballoc_deinit_doesnot_free_lock)
 TEST_FUNCTION(when_gballoc_is_not_initialized_gballoc_malloc_calls_crt_malloc)
 {
     // arrange
-    
+    void* result;
     STRICT_EXPECTED_CALL(mock_malloc(1));
 
     //act
-    void* result = gballoc_malloc(1);
+    result = gballoc_malloc(1);
 
     //assert
     ASSERT_IS_NOT_NULL(result);
@@ -144,10 +144,11 @@ TEST_FUNCTION(when_gballoc_is_not_initialized_gballoc_malloc_calls_crt_malloc)
 TEST_FUNCTION(when_gballoc_is_not_initialized_then_gballoc_calloc_calls_crt_calloc)
 {
     // arrange
+	void* result;
     STRICT_EXPECTED_CALL(mock_calloc(1, 1));
 
     // act
-    void* result = gballoc_calloc(1, 1);
+    result = gballoc_calloc(1, 1);
 
     // assert
     ASSERT_IS_NOT_NULL(result);
@@ -160,10 +161,11 @@ TEST_FUNCTION(when_gballoc_is_not_initialized_then_gballoc_calloc_calls_crt_call
 TEST_FUNCTION(when_gballoc_is_not_initialized_then_gballoc_realloc_calls_crt_realloc)
 {
     // arrange
+	void* result;
     STRICT_EXPECTED_CALL(mock_realloc(NULL, 1));
 
     // act
-    void* result = gballoc_realloc(NULL, 1);
+    result = gballoc_realloc(NULL, 1);
 
     // assert
     ASSERT_IS_NOT_NULL(result);

--- a/tests/http_proxy_io_ut/http_proxy_io_ut.c
+++ b/tests/http_proxy_io_ut/http_proxy_io_ut.c
@@ -560,6 +560,7 @@ TEST_FUNCTION(http_proxy_io_create_with_NULL_proxy_hostname_fails)
 TEST_FUNCTION(when_a_call_made_by_http_proxy_io_create_fails_then_http_proxy_io_create_fails)
 {
     // arrange
+	size_t i;
     int negativeTestsInitResult = umock_c_negative_tests_init();
     ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
@@ -585,7 +586,7 @@ TEST_FUNCTION(when_a_call_made_by_http_proxy_io_create_fails_then_http_proxy_io_
 
     umock_c_negative_tests_snapshot();
 
-    for (size_t i = 0; i < umock_c_negative_tests_call_count() - 1; i++)
+    for (i = 0; i < umock_c_negative_tests_call_count() - 1; i++)
     {
         char temp_str[128];
         CONCRETE_IO_HANDLE http_io;

--- a/tests/httpheaders_ut/httpheaders_ut.c
+++ b/tests/httpheaders_ut/httpheaders_ut.c
@@ -201,13 +201,14 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_Alloc_happy_path_succeeds)
         {
             ///arrange
+			HTTP_HEADERS_HANDLE handle;
             STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
                 .IgnoreArgument(1);
 
             STRICT_EXPECTED_CALL(Map_Create(IGNORED_PTR_ARG));
 
             ///act
-            HTTP_HEADERS_HANDLE handle = HTTPHeaders_Alloc();
+            handle = HTTPHeaders_Alloc();
 
             ///assert
             ASSERT_IS_NOT_NULL(handle);
@@ -222,12 +223,13 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_Alloc_fails_when_malloc_fails)
         {
             ///arrange
+			HTTP_HEADERS_HANDLE httpHandle;
             whenShallmalloc_fail = currentmalloc_call + 1;
             STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
+            httpHandle = HTTPHeaders_Alloc();
 
             ///assert
             ASSERT_IS_NULL(httpHandle);
@@ -271,6 +273,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_Alloc_fails_when_Map_Create_fails)
         {
             ///arrange
+			HTTP_HEADERS_HANDLE httpHandle;
             STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
                 .IgnoreArgument(1);
             STRICT_EXPECTED_CALL(Map_Create(IGNORED_PTR_ARG))
@@ -280,7 +283,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
+            httpHandle = HTTPHeaders_Alloc();
 
             ///assert
             ASSERT_IS_NULL(httpHandle);
@@ -291,6 +294,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_Alloc_succeeds_and_GetHeaderCount_returns_0)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             size_t nHeaders;
             size_t zero = 0;
@@ -301,7 +305,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .CopyOutArgumentBuffer(4, &zero, sizeof(zero));
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_GetHeaderCount(httpHandle, &nHeaders);
+            res = HTTPHeaders_GetHeaderCount(httpHandle, &nHeaders);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -317,6 +321,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_happy_path_succeeds)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
@@ -328,7 +333,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -344,6 +349,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_fails_when_Map_AddOrUpdate_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
@@ -357,7 +363,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .SetReturn(MAP_ERROR);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_ALLOC_FAILED, res);
@@ -373,6 +379,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_succeeds)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
@@ -384,7 +391,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -415,11 +422,12 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_with_NULL_name_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NULL, VALUE1);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NULL, VALUE1);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res);
@@ -433,11 +441,12 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_with_NULL_value_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, NULL);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, NULL);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res);
@@ -451,6 +460,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_with_same_Name_appends_to_existing_value_succeeds)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -472,7 +482,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -486,6 +496,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_with_same_Name_appends_fails_when_Map_AddOrUpdate_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -508,7 +519,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_ERROR, res);
@@ -522,6 +533,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_with_same_Name_fails_when_gballoc_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -538,7 +550,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_ALLOC_FAILED, res);
@@ -552,6 +564,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_add_two_headers_produces_two_headers)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -567,7 +580,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME2, VALUE2);
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME2, VALUE2);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -581,6 +594,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_When_Second_Added_Header_Is_A_Substring_Of_An_Existing_Header_2_Headers_Are_Added)
         {
             ///arrange
+			HTTP_HEADERS_RESULT result;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "ab"))
                 .IgnoreArgument(1)
@@ -596,7 +610,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT result = HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", VALUE1);
+            result = HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", VALUE1);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, result);
@@ -623,11 +637,12 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_FindHeaderValue_with_NULL_name_returns_NULL)
         {
             ///arrange
+			const char* res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
             ///act
-            const char* res = HTTPHeaders_FindHeaderValue(httpHandle, NULL);
+            res = HTTPHeaders_FindHeaderValue(httpHandle, NULL);
 
             ///assert
             ASSERT_IS_NULL(res);
@@ -642,6 +657,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_FindHeaderValue_retrieves_previously_stored_value_succeeds)
         {
             ///arrange
+			const char* res1;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -653,7 +669,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            const char* res1 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1);
+            res1 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1);
 
             ///assert
             ASSERT_ARE_EQUAL(char_ptr, VALUE1, res1);
@@ -668,6 +684,8 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_FindHeaderValue_retrieves_previously_stored_value_for_two_headers_succeeds)
         {
             ///arrange
+			const char* res1;
+			const char* res2;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -687,8 +705,8 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .SetReturn(VALUE2);
 
             ///act
-            const char* res1 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1);
-            const char* res2 = HTTPHeaders_FindHeaderValue(httpHandle, NAME2);
+            res1 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1);
+            res2 = HTTPHeaders_FindHeaderValue(httpHandle, NAME2);
 
             ///assert
             ASSERT_ARE_EQUAL(char_ptr, VALUE1, res1);
@@ -703,6 +721,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         /*Tests_SRS_HTTP_HEADERS_99_021:[ In this case the return value shall point to a string that shall strcmp equal to the original stored string.]*/
         TEST_FUNCTION(HTTPHeaders_FindHeaderValue_retrieves_concatenation_of_previously_stored_values_for_header_name_succeeds)
         {
+			const char* res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -719,7 +738,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .SetReturn(VALUE1 ", " VALUE2);
 
             ///act
-            const char* res = HTTPHeaders_FindHeaderValue(httpHandle, NAME1);
+            res = HTTPHeaders_FindHeaderValue(httpHandle, NAME1);
 
             ///assert
             ASSERT_ARE_EQUAL(char_ptr,VALUE1 ", " VALUE2, res);
@@ -734,6 +753,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_FindHeaderValue_returns_NULL_for_nonexistent_value)
         {
             ///arrange
+			const char* res2;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -746,7 +766,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .SetReturn((const char*)NULL);
 
             ///act
-            const char* res2 = HTTPHeaders_FindHeaderValue(httpHandle, NAME2);
+            res2 = HTTPHeaders_FindHeaderValue(httpHandle, NAME2);
 
             ///assert
             ASSERT_IS_NULL(res2);
@@ -761,6 +781,9 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_FindHeaderValue_with_nonexistent_header_succeeds)
         {
             ///arrange
+			const char* res1;
+			const char* res2;
+			const char* res3;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -779,9 +802,9 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .SetReturn((const char*)NULL);
 
             ///act
-            const char* res1 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1_TRICK1);
-            const char* res2 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1_TRICK2);
-            const char* res3 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1_TRICK3);
+            res1 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1_TRICK1);
+            res2 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1_TRICK2);
+            res3 = HTTPHeaders_FindHeaderValue(httpHandle, NAME1_TRICK3);
 
             ///assert
             ASSERT_IS_NULL(res1);
@@ -797,6 +820,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_ReplaceHeaderNameValuePair_succeeds)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -812,7 +836,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_ReplaceHeaderNameValuePair(httpHandle, NAME1, VALUE2);
+            res = HTTPHeaders_ReplaceHeaderNameValuePair(httpHandle, NAME1, VALUE2);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -826,6 +850,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_ReplaceHeaderNameValuePair_for_none_existing_header_succeeds)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
@@ -837,7 +862,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_ReplaceHeaderNameValuePair(httpHandle, NAME1, VALUE2);
+            res = HTTPHeaders_ReplaceHeaderNameValuePair(httpHandle, NAME1, VALUE2);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -851,10 +876,11 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_GetHeaderCount_with_NULL_handle_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res1;
             size_t nHeaders;
 
             ///act
-            HTTP_HEADERS_RESULT res1 = HTTPHeaders_GetHeaderCount(NULL, &nHeaders);
+            res1 = HTTPHeaders_GetHeaderCount(NULL, &nHeaders);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res1);
@@ -865,11 +891,12 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_GetHeaderCount_with_NULL_headersCount_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res1;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
             ///act
-            HTTP_HEADERS_RESULT res1 = HTTPHeaders_GetHeaderCount(httpHandle, NULL);
+            res1 = HTTPHeaders_GetHeaderCount(httpHandle, NULL);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res1);
@@ -886,16 +913,17 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         {
             ///arrange
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
-            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
-                .IgnoreArgument(1)
-                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
-            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
             size_t nHeaders;
             const char* keys[] = { "NAME1" }; 
             const char* values[] = { "VALUE1" }; 
             const char* const ** pKeys = (const char* const **)&keys; 
             const char* const ** pValues = (const char* const **)&values;
             const size_t one = 1;
+			HTTP_HEADERS_RESULT res;
+            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
+                .IgnoreArgument(1)
+                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
+            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
             umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(Map_GetInternals(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
@@ -906,7 +934,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
 
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_GetHeaderCount(httpHandle, &nHeaders);
+            res = HTTPHeaders_GetHeaderCount(httpHandle, &nHeaders);
             
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -921,6 +949,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_GetHeaderCount_fails_when_Map_GetInternals_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             size_t nHeaders;
             umock_c_reset_all_calls();
@@ -930,7 +959,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .SetReturn(MAP_ERROR);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_GetHeaderCount(httpHandle, &nHeaders);
+            res = HTTPHeaders_GetHeaderCount(httpHandle, &nHeaders);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_ERROR, res);
@@ -946,7 +975,15 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_GetHeaderCount_with_2_header_produces_2)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
+            size_t nHeaders;
+            const char* keys[2] = { "NAME1", "NAME2" };
+            const char* values[2] = { "VALUE1", "VALUE2" };
+            const char* const ** pKeys = (const char* const **)&keys;
+            const char* const ** pValues = (const char* const **)&values;
+
+            const size_t two = 2;
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
                 .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
@@ -955,13 +992,6 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1)
                 .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
             (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME2, VALUE2);
-            size_t nHeaders;
-            const char* keys[2] = { "NAME1", "NAME2" };
-            const char* values[2] = { "VALUE1", "VALUE2" };
-            const char* const ** pKeys = (const char* const **)&keys;
-            const char* const ** pValues = (const char* const **)&values;
-
-            const size_t two = 2;
             umock_c_reset_all_calls();
 
 
@@ -972,7 +1002,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .CopyOutArgumentBuffer(4, &two, sizeof(two));
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_GetHeaderCount(httpHandle, &nHeaders);
+            res = HTTPHeaders_GetHeaderCount(httpHandle, &nHeaders);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -1001,6 +1031,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_GetHeader_with_NULL_buffer_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
                 .IgnoreArgument(1)
@@ -1009,7 +1040,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
             umock_c_reset_all_calls();
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_GetHeader(httpHandle, 0, NULL);
+            res = HTTPHeaders_GetHeader(httpHandle, 0, NULL);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res);
@@ -1024,6 +1055,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_GetHeader_with_index_too_big_fails_1)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res1;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             char* headerValue;
             const char* thisIsNULL = NULL;
@@ -1037,7 +1069,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .CopyOutArgumentBuffer(4, &zero, sizeof(zero));
 
             ///act
-            HTTP_HEADERS_RESULT res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
+            res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res1);
@@ -1052,18 +1084,19 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_GetHeader_with_index_too_big_fails_2)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res1;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
-            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
-                .IgnoreArgument(1)
-                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
-            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
             const char* keys[1] = { "NAME1" };
             const char* values[1] = { "VALUE1" };
             const char* const ** pKeys = (const char* const **)&keys;
             const char* const ** pValues = (const char* const **)&values;
             const size_t one = 1;
-            umock_c_reset_all_calls();
             char* headerValue;
+            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, NAME1))
+                .IgnoreArgument(1)
+                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
+            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, VALUE1);
+            umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(Map_GetInternals(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
                 .IgnoreArgument(1)
@@ -1072,7 +1105,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .CopyOutArgumentBuffer(4, &one, sizeof(one));
 
             ///act
-            HTTP_HEADERS_RESULT res1 = HTTPHeaders_GetHeader(httpHandle, 1, &headerValue);
+            res1 = HTTPHeaders_GetHeader(httpHandle, 1, &headerValue);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res1);
@@ -1087,18 +1120,19 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_GetHeader_succeeds_1)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res1;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
-            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "a"))
-                .IgnoreArgument(1)
-                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
-            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", "b");
-            umock_c_reset_all_calls();
             char* headerValue;
             const char* keys[1] = { "a" };
             const char** pKeys = &keys[0];
             const char* values[1] = { "b" };
             const char** pValues = &values[0];
             const size_t one = 1;
+            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "a"))
+                .IgnoreArgument(1)
+                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
+            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", "b");
+            umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(Map_GetInternals(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
                 .IgnoreArgument(1)
@@ -1110,7 +1144,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
+            res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res1);
@@ -1127,17 +1161,18 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         {
             ///arrange
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
-            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "a"))
-                .IgnoreArgument(1)
-                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
-            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", "b");
-            umock_c_reset_all_calls();
             char* headerValue;
             const char* keys[1] = { "a" };
             const char** pKeys = &keys[0];
             const char* values[1] = { "b" };
             const char** pValues = &values[0];
             const size_t one = 1;
+			HTTP_HEADERS_RESULT res1;
+            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "a"))
+                .IgnoreArgument(1)
+                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
+            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", "b");
+            umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(Map_GetInternals(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
                 .IgnoreArgument(1)
@@ -1147,7 +1182,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .SetReturn(MAP_ERROR);
 
             ///act
-            HTTP_HEADERS_RESULT res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
+            res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_ERROR, res1);
@@ -1162,17 +1197,18 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         {
             ///arrange
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
-            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "a"))
-                .IgnoreArgument(1)
-                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
-            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", "b");
-            umock_c_reset_all_calls();
             char* headerValue;
             const char* keys[1] = { "a" };
             const char** pKeys = &keys[0];
             const char* values[1] = { "b" };
             const char** pValues = &values[0];
             const size_t one = 1;
+			HTTP_HEADERS_RESULT res1;
+            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "a"))
+                .IgnoreArgument(1)
+                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
+            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", "b");
+            umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(Map_GetInternals(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
                 .IgnoreArgument(1)
@@ -1185,7 +1221,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
+            res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_ERROR, res1);
@@ -1200,11 +1236,12 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_with_colon_in_name_fails)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a:", "b");
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a:", "b");
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res);
@@ -1218,17 +1255,18 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_with_colon_in_value_succeeds_1)
         {
             ///arrange
-            HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
-            char* headerValue;
-            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "a"))
-                .IgnoreArgument(1)
-                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
-            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", ":");
             const char* keys[1] = { "a" };
             const char** pKeys = &keys[0];
             const char* values[1] = { ":" };
             const char** pValues = &values[0];
             const size_t one = 1;
+            HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
+            char* headerValue;
+			HTTP_HEADERS_RESULT res1;
+            STRICT_EXPECTED_CALL(Map_GetValueFromKey(IGNORED_PTR_ARG, "a"))
+                .IgnoreArgument(1)
+                .SetReturn((const char*)NULL); /*this key does not exist, the line below is adding it*/
+            (void)HTTPHeaders_AddHeaderNameValuePair(httpHandle, "a", ":");
             umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(Map_GetInternals(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
@@ -1241,7 +1279,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
+            res1 = HTTPHeaders_GetHeader(httpHandle, 0, &headerValue);
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res1);
@@ -1260,18 +1298,21 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
             ///arrange
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             char unacceptableString[2]={'\0', '\0'};
+			int c;
             
-            for(int c=SCHAR_MIN;c <=SCHAR_MAX; c++)
+            for(c=SCHAR_MIN;c <=SCHAR_MAX; c++)
             {
                 if(c=='\0') continue;
 
                 if((c<33) ||( 126<c)|| (c==':'))
                 {
+					HTTP_HEADERS_RESULT res;
+
                     /*so it is an unacceptable character*/
                     unacceptableString[0]=(char)c;
 
                     ///act
-                    HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, unacceptableString, VALUE1);
+                    res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, unacceptableString, VALUE1);
 
                     ///assert
                     ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_INVALID_ARG, res);
@@ -1286,6 +1327,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHeaders_AddHeaderNameValuePair_with_LWS_value_stores_without_LWS_characters_succeeds)
         {
             ///arrange
+			HTTP_HEADERS_RESULT res;
             HTTP_HEADERS_HANDLE httpHandle = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
@@ -1297,7 +1339,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_RESULT res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, " \r\t\n" VALUE1); /*notice how there are some LWS characters in the value*/
+            res = HTTPHeaders_AddHeaderNameValuePair(httpHandle, NAME1, " \r\t\n" VALUE1); /*notice how there are some LWS characters in the value*/
 
             ///assert
             ASSERT_ARE_EQUAL(HTTP_HEADERS_RESULT, HTTP_HEADERS_OK, res);
@@ -1326,6 +1368,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHEADERS_Clone_happy_path)
         {
             ///arrange
+			HTTP_HEADERS_HANDLE result;
             HTTP_HEADERS_HANDLE source = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
@@ -1335,7 +1378,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_HANDLE result = HTTPHeaders_Clone(source);
+            result = HTTPHeaders_Clone(source);
 
             ///assert
             ASSERT_IS_NOT_NULL(result);
@@ -1350,6 +1393,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHEADERS_Clone_fails_when_map_clone_fails)
         {
             ///arrange
+			HTTP_HEADERS_HANDLE result;
             HTTP_HEADERS_HANDLE source = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
@@ -1362,7 +1406,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1);
 
             ///act
-            HTTP_HEADERS_HANDLE result = HTTPHeaders_Clone(source);
+            result = HTTPHeaders_Clone(source);
 
             ///assert
             ASSERT_IS_NULL(result);
@@ -1377,6 +1421,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
         TEST_FUNCTION(HTTPHEADERS_Clone_fails_when_gballoc_fails)
         {
             ///arrange
+			HTTP_HEADERS_HANDLE result;
             HTTP_HEADERS_HANDLE source = HTTPHeaders_Alloc();
             umock_c_reset_all_calls();
 
@@ -1384,7 +1429,7 @@ BEGIN_TEST_SUITE(HTTPHeaders_UnitTests)
                 .IgnoreArgument(1).SetReturn(NULL);
 
             ///act
-            HTTP_HEADERS_HANDLE result = HTTPHeaders_Clone(source);
+            result = HTTPHeaders_Clone(source);
 
             ///assert
             ASSERT_IS_NULL(result);

--- a/tests/lock_ut/lock_ut.c
+++ b/tests/lock_ut/lock_ut.c
@@ -63,11 +63,12 @@ TEST_FUNCTION(LOCK_Init_Lock_succeeds)
 TEST_FUNCTION(LOCK_Init_Lock_Unlock_succeeds)
 {
     //arrange
+	LOCK_RESULT result;
     LOCK_HANDLE handle = Lock_Init();
     (void)Lock(handle);
 
     //act
-    LOCK_RESULT result = Unlock(handle);
+    result = Unlock(handle);
 
     //assert
     ASSERT_ARE_EQUAL(LOCK_RESULT, LOCK_OK, result);
@@ -143,12 +144,13 @@ TEST_FUNCTION(LOCK_Init_Unlock_fails)
 TEST_FUNCTION(LOCK_Init_Lock_Unlock_Unlock_fails)
 {
     //arrange
+	LOCK_RESULT result;
     LOCK_HANDLE handle = Lock_Init();
     (void)Lock(handle);
     (void)Unlock(handle);
 
     //act
-    LOCK_RESULT result = Unlock(handle);
+    result = Unlock(handle);
 
     //assert
     ASSERT_ARE_EQUAL(LOCK_RESULT, LOCK_ERROR, result);

--- a/tests/map_ut/map_ut.c
+++ b/tests/map_ut/map_ut.c
@@ -216,6 +216,8 @@ BEGIN_TEST_SUITE(map_unittests)
     /*Tests_SRS_MAP_02_004: [Map_Destroy shall release all resources associated with the map.] */
     TEST_FUNCTION(Map_Create_Destroy_succeeds)
     {
+		MAP_HANDLE handle;
+
         ///arrange
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
@@ -228,7 +230,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE handle = Map_Create(NULL);
+        handle = Map_Create(NULL);
         Map_Destroy(handle);
 
         ///assert
@@ -307,13 +309,15 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
-        umock_c_reset_all_calls();
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result;
+
+        umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result = Map_GetInternals(handle, &keys, &values, &count);
+        result = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result);
@@ -330,12 +334,13 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Create_fails_when_malloc_fails)
     {
         ///arrange
+		MAP_HANDLE handle;
         whenShallmalloc_fail = 1;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE handle = Map_Create(NULL);
+        handle = Map_Create(NULL);
 
         ///assert
         ASSERT_IS_NULL(handle);
@@ -363,10 +368,12 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result;
+
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result = Map_Add(NULL, TEST_REDKEY, TEST_REDVALUE);
+        result = Map_Add(NULL, TEST_REDKEY, TEST_REDVALUE);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result);
@@ -381,10 +388,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result = Map_Add(handle, NULL, TEST_REDVALUE);
+        result = Map_Add(handle, NULL, TEST_REDVALUE);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result);
@@ -399,10 +407,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result = Map_Add(handle, TEST_REDKEY, NULL);
+        result = Map_Add(handle, TEST_REDKEY, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result);
@@ -420,6 +429,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
@@ -432,8 +443,8 @@ BEGIN_TEST_SUITE(map_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_REDVALUE) + 1)); /*copy of red value*/
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -457,6 +468,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -480,9 +494,9 @@ BEGIN_TEST_SUITE(map_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_BLUEVALUE) + 1)); /*copy of blue value*/
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -507,6 +521,9 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
@@ -539,9 +556,9 @@ BEGIN_TEST_SUITE(map_unittests)
 
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -563,6 +580,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -592,9 +612,9 @@ BEGIN_TEST_SUITE(map_unittests)
 
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -616,6 +636,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -640,9 +663,9 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -664,6 +687,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -683,9 +709,9 @@ BEGIN_TEST_SUITE(map_unittests)
         /*below are undo actions*/
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -707,6 +733,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -729,8 +757,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -749,6 +777,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -767,8 +797,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -787,6 +817,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -801,8 +833,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -822,6 +854,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
@@ -831,8 +865,8 @@ BEGIN_TEST_SUITE(map_unittests)
         /*below are undo actions*/ /*none*/
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -851,6 +885,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
@@ -859,8 +895,8 @@ BEGIN_TEST_SUITE(map_unittests)
         /*below are undo actions*/ /*none*/
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_KEYEXISTS, result1);
@@ -882,6 +918,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_Add(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -890,8 +928,8 @@ BEGIN_TEST_SUITE(map_unittests)
         /*below are undo actions*/ /*none*/
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_BLUEKEY, TEST_YELLOWVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Add(handle, TEST_BLUEKEY, TEST_YELLOWVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_KEYEXISTS, result1);
@@ -927,11 +965,12 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_AddOrUpdate_with_NULL_key_handle_fails)
     {
         ///arrange
+		MAP_RESULT result1;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, NULL, TEST_YELLOWVALUE);
+        result1 = Map_AddOrUpdate(handle, NULL, TEST_YELLOWVALUE);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -945,11 +984,12 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_AddOrUpdate_with_NULL_value_handle_fails)
     {
         ///arrange
+		MAP_RESULT result1;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, NULL);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -966,6 +1006,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -976,8 +1018,8 @@ BEGIN_TEST_SUITE(map_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_REDVALUE) + 1)); /*copy of red value*/
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -997,6 +1039,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -1014,9 +1059,9 @@ BEGIN_TEST_SUITE(map_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_BLUEVALUE) + 1)); /*copy of red value*/
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1040,6 +1085,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -1067,9 +1115,9 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1090,6 +1138,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -1113,9 +1164,9 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1136,6 +1187,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -1156,9 +1210,9 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1179,6 +1233,9 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -1195,9 +1252,9 @@ BEGIN_TEST_SUITE(map_unittests)
         /*below are undo actions*/ /*none*/
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1218,6 +1275,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
@@ -1237,8 +1296,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -1257,6 +1316,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
@@ -1273,8 +1334,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -1293,6 +1354,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
@@ -1305,8 +1368,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -1325,6 +1388,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
@@ -1334,8 +1399,8 @@ BEGIN_TEST_SUITE(map_unittests)
         /*below are undo actions*/
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -1353,6 +1418,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
@@ -1363,8 +1430,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .ValidateArgumentBuffer(1, TEST_REDVALUE, strlen(TEST_REDVALUE) + 1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_YELLOWVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_YELLOWVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1388,6 +1455,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
@@ -1399,8 +1468,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .ValidateArgumentBuffer(1, TEST_REDVALUE, strlen(TEST_REDVALUE) + 1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_YELLOWVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_YELLOWVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -1424,6 +1493,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -1433,8 +1504,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .ValidateArgumentBuffer(1, TEST_BLUEVALUE, strlen(TEST_BLUEVALUE) + 1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_YELLOWVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_YELLOWVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1457,6 +1528,8 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         size_t count;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
@@ -1468,8 +1541,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .ValidateArgumentBuffer(1, TEST_BLUEVALUE, strlen(TEST_BLUEVALUE) + 1);
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_YELLOWVALUE);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_YELLOWVALUE);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_ERROR, result1);
@@ -1506,10 +1579,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result1;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_Delete(handle, NULL);
+        result1 = Map_Delete(handle, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -1524,10 +1598,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result1;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_Delete(handle, TEST_REDKEY);
+        result1 = Map_Delete(handle, TEST_REDKEY);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_KEYNOTFOUND, result1);
@@ -1542,11 +1617,12 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result1;
         (void)Map_AddOrUpdate(handle, TEST_YELLOWKEY, TEST_YELLOWVALUE);
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_Delete(handle, TEST_REDKEY);
+        result1 = Map_Delete(handle, TEST_REDKEY);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_KEYNOTFOUND, result1);
@@ -1564,6 +1640,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         (void)Map_AddOrUpdate(handle, TEST_YELLOWKEY, TEST_YELLOWVALUE);
         umock_c_reset_all_calls();
 
@@ -1580,8 +1658,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_Delete(handle, TEST_YELLOWKEY);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Delete(handle, TEST_YELLOWKEY);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1601,6 +1679,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_YELLOWKEY, TEST_YELLOWVALUE);
         
@@ -1619,8 +1699,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_Delete(handle, TEST_YELLOWKEY);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Delete(handle, TEST_YELLOWKEY);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1642,6 +1722,8 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_RESULT result1;
+		MAP_RESULT result3;
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_YELLOWKEY, TEST_YELLOWVALUE);
 
@@ -1660,8 +1742,8 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_RESULT result1 = Map_Delete(handle, TEST_REDKEY);
-        MAP_RESULT result3 = Map_GetInternals(handle, &keys, &values, &count);
+        result1 = Map_Delete(handle, TEST_REDKEY);
+        result3 = Map_GetInternals(handle, &keys, &values, &count);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1680,10 +1762,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         bool exists;
+		MAP_RESULT result1;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_ContainsKey(NULL,TEST_REDKEY, &exists);
+        result1 = Map_ContainsKey(NULL,TEST_REDKEY, &exists);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -1698,10 +1781,11 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         bool exists;
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result1;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_ContainsKey(handle, NULL, &exists);
+        result1 = Map_ContainsKey(handle, NULL, &exists);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -1716,10 +1800,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result1;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_ContainsKey(handle, TEST_REDKEY, NULL);
+        result1 = Map_ContainsKey(handle, TEST_REDKEY, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -1736,12 +1821,14 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
         bool e1, e2;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_ContainsKey(handle, TEST_REDKEY, &e1);
-        MAP_RESULT result2 = Map_ContainsKey(handle, TEST_BLUEKEY, &e2);
+        result1 = Map_ContainsKey(handle, TEST_REDKEY, &e1);
+        result2 = Map_ContainsKey(handle, TEST_BLUEKEY, &e2);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1760,10 +1847,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         bool e1;
+		MAP_RESULT result1;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_ContainsValue(NULL, TEST_REDKEY, &e1);
+        result1 = Map_ContainsValue(NULL, TEST_REDKEY, &e1);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -1778,10 +1866,11 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
         bool e1;
+		MAP_RESULT result1;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_ContainsValue(handle, NULL, &e1);
+        result1 = Map_ContainsValue(handle, NULL, &e1);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -1796,10 +1885,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		MAP_RESULT result1;
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_ContainsValue(handle, TEST_REDKEY, NULL);
+        result1 = Map_ContainsValue(handle, TEST_REDKEY, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result1);
@@ -1816,12 +1906,14 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
         bool e1, e2;
+		MAP_RESULT result1;
+		MAP_RESULT result2;
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result1 = Map_ContainsValue(handle, TEST_REDVALUE, &e1);
-        MAP_RESULT result2 = Map_ContainsValue(handle, TEST_BLUEVALUE, &e2);
+        result1 = Map_ContainsValue(handle, TEST_REDVALUE, &e1);
+        result2 = Map_ContainsValue(handle, TEST_BLUEVALUE, &e2);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_OK, result1);
@@ -1854,10 +1946,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		const char* result;
         umock_c_reset_all_calls();
 
         ///act
-        const char* result = Map_GetValueFromKey(handle, NULL);
+        result = Map_GetValueFromKey(handle, NULL);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -1872,10 +1965,11 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		const char* result;
         umock_c_reset_all_calls();
 
         ///act
-        const char* result = Map_GetValueFromKey(handle, TEST_REDKEY);
+        result = Map_GetValueFromKey(handle, TEST_REDKEY);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -1890,11 +1984,12 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		const char* result;
         Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         umock_c_reset_all_calls();
 
         ///act
-        const char* result = Map_GetValueFromKey(handle, TEST_REDKEY);
+        result = Map_GetValueFromKey(handle, TEST_REDKEY);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, TEST_REDVALUE, result);
@@ -1926,11 +2021,12 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* values;
         size_t size;
+		MAP_RESULT result;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result = Map_GetInternals(handle, NULL, &values, &size);
+        result = Map_GetInternals(handle, NULL, &values, &size);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result);
@@ -1946,11 +2042,12 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         size_t size;
+		MAP_RESULT result;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result = Map_GetInternals(handle, &keys, NULL, &size);
+        result = Map_GetInternals(handle, &keys, NULL, &size);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result);
@@ -1966,11 +2063,12 @@ BEGIN_TEST_SUITE(map_unittests)
         ///arrange
         const char*const* keys;
         const char*const* values;
+		MAP_RESULT result;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
         ///act
-        MAP_RESULT result = Map_GetInternals(handle, &keys, &values, NULL);
+        result = Map_GetInternals(handle, &keys, &values, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_INVALIDARG, result);
@@ -2007,6 +2105,7 @@ BEGIN_TEST_SUITE(map_unittests)
         const char*const* keys;
         const char*const* values;
         size_t count;
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
@@ -2014,7 +2113,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(result);
@@ -2033,6 +2132,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_empty_fails_when_malloc_fails)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         umock_c_reset_all_calls();
 
@@ -2041,7 +2141,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2055,6 +2155,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_1_element_succeeds)
     {
         ///arrange
+		MAP_HANDLE result;
         const char*const* keys;
         const char*const* values;
         size_t count;
@@ -2074,7 +2175,7 @@ BEGIN_TEST_SUITE(map_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_REDVALUE) + 1)); /*this is creating a clone of RED value*/
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(result);
@@ -2095,6 +2196,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_1_element_fails_when_gbaloc_fails_1)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         umock_c_reset_all_calls();
@@ -2121,7 +2223,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2136,6 +2238,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_1_element_fails_when_gbaloc_fails_2)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         umock_c_reset_all_calls();
@@ -2158,7 +2261,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2173,6 +2276,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_1_element_fails_when_gbaloc_fails_3)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         umock_c_reset_all_calls();
@@ -2191,7 +2295,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2206,6 +2310,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_1_element_fails_when_gbaloc_fails_4)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         umock_c_reset_all_calls();
@@ -2218,7 +2323,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2233,6 +2338,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_1_element_fails_when_gbaloc_fails_5)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         umock_c_reset_all_calls();
@@ -2242,7 +2348,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2257,6 +2363,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_2_element_succeeds)
     {
         ///arrange
+		MAP_HANDLE result;
         const char*const* keys;
         const char*const* values;
         size_t count;
@@ -2279,7 +2386,7 @@ BEGIN_TEST_SUITE(map_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_BLUEVALUE) + 1)); /*this is creating a clone of RED value*/
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(result);
@@ -2302,6 +2409,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_2_element_fails_when_gballoc_fails_1)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -2337,7 +2445,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2352,6 +2460,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_2_element_fails_when_gballoc_fails_2)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -2383,7 +2492,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2398,6 +2507,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_2_element_fails_when_gballoc_fails_3)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -2425,7 +2535,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2440,6 +2550,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_2_element_fails_when_gballoc_fails_4)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -2463,7 +2574,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2478,6 +2589,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_2_element_fails_when_gballoc_fails_5)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -2497,7 +2609,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2512,6 +2624,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_2_element_fails_when_gballoc_fails_6)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -2526,7 +2639,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2541,6 +2654,7 @@ BEGIN_TEST_SUITE(map_unittests)
     TEST_FUNCTION(Map_Clone_with_map_with_2_element_fails_when_gballoc_fails_7)
     {
         ///arrange
+		MAP_HANDLE result;
         MAP_HANDLE handle = Map_Create(NULL);
         (void)Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
         (void)Map_AddOrUpdate(handle, TEST_BLUEKEY, TEST_BLUEVALUE);
@@ -2551,7 +2665,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        MAP_HANDLE result = Map_Clone(handle);
+        result = Map_Clone(handle);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -2567,6 +2681,9 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(DontAllowCapitalsFilters);
+		MAP_RESULT result1;
+		MAP_RESULT result2;
+		MAP_RESULT result3;
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_realloc(NULL, sizeof(const char*)));
@@ -2575,9 +2692,9 @@ BEGIN_TEST_SUITE(map_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_GREENVALUE) + 1));
 
         ///act
-        MAP_RESULT result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_Add(handle, TEST_YELLOWKEY, TEST_YELLOWVALUE);
-        MAP_RESULT result3 = Map_Add(handle, TEST_GREENKEY, TEST_GREENVALUE);
+        result1 = Map_Add(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_Add(handle, TEST_YELLOWKEY, TEST_YELLOWVALUE);
+        result3 = Map_Add(handle, TEST_GREENKEY, TEST_GREENVALUE);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_FILTER_REJECT, result1);
@@ -2594,6 +2711,8 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(DontAllowCapitalsFilters);
+		MAP_RESULT result1;
+		MAP_RESULT result2;
         umock_c_reset_all_calls();
 
         EXPECTED_CALL(gballoc_realloc(NULL, sizeof(const char*)));
@@ -2602,8 +2721,8 @@ BEGIN_TEST_SUITE(map_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_GREENVALUE) + 1));
 
         ///act
-        MAP_RESULT result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
-        MAP_RESULT result2 = Map_AddOrUpdate(handle, TEST_GREENKEY, TEST_GREENVALUE);
+        result1 = Map_AddOrUpdate(handle, TEST_REDKEY, TEST_REDVALUE);
+        result2 = Map_AddOrUpdate(handle, TEST_GREENKEY, TEST_GREENVALUE);
 
         ///assert
         ASSERT_ARE_EQUAL(MAP_RESULT, MAP_FILTER_REJECT, result1);
@@ -2635,6 +2754,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(STRING_construct("{"))
@@ -2644,7 +2764,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2659,6 +2779,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(STRING_construct("{"))
@@ -2671,7 +2792,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2686,13 +2807,14 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(STRING_construct("{"))
             .IgnoreArgument(1).SetReturn(NULL);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2707,6 +2829,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         umock_c_reset_all_calls();
 
@@ -2733,7 +2856,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(toJSON);
@@ -2749,6 +2872,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         umock_c_reset_all_calls();
 
@@ -2778,7 +2902,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2793,6 +2917,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         umock_c_reset_all_calls();
 
@@ -2821,7 +2946,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2836,6 +2961,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         umock_c_reset_all_calls();
 
@@ -2860,7 +2986,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2875,6 +3001,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         umock_c_reset_all_calls();
 
@@ -2897,7 +3024,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2912,6 +3039,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         umock_c_reset_all_calls();
 
@@ -2929,7 +3057,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2944,6 +3072,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         umock_c_reset_all_calls();
 
@@ -2956,7 +3085,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2971,6 +3100,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         umock_c_reset_all_calls();
 
@@ -2979,7 +3109,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .SetReturn(NULL);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -2994,6 +3124,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3043,7 +3174,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(toJSON);
@@ -3059,6 +3190,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3112,7 +3244,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3127,6 +3259,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3177,7 +3310,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3192,6 +3325,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3239,7 +3373,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3254,6 +3388,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3300,7 +3435,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3315,6 +3450,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3356,7 +3492,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3371,6 +3507,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3406,7 +3543,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3421,6 +3558,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3453,7 +3591,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3468,6 +3606,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3497,7 +3636,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3512,6 +3651,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3540,7 +3680,7 @@ BEGIN_TEST_SUITE(map_unittests)
         }
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3555,6 +3695,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3580,7 +3721,7 @@ BEGIN_TEST_SUITE(map_unittests)
         }
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3595,6 +3736,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3618,7 +3760,7 @@ BEGIN_TEST_SUITE(map_unittests)
         }
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3633,6 +3775,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3648,7 +3791,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3663,6 +3806,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3674,7 +3818,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);
@@ -3689,6 +3833,7 @@ BEGIN_TEST_SUITE(map_unittests)
     {
         ///arrange
         MAP_HANDLE handle = Map_Create(NULL);
+		STRING_HANDLE toJSON;
         (void)Map_AddOrUpdate(handle, "redkey", "reddoor");
         (void)Map_AddOrUpdate(handle, "yellowkey", "yellowdoor");
         umock_c_reset_all_calls();
@@ -3698,7 +3843,7 @@ BEGIN_TEST_SUITE(map_unittests)
             .SetReturn(NULL);
 
         ///act
-        STRING_HANDLE toJSON = Map_ToJSON(handle);
+        toJSON = Map_ToJSON(handle);
 
         ///assert
         ASSERT_IS_NULL(toJSON);

--- a/tests/optionhandler_ut/optionhandler_ut.c
+++ b/tests/optionhandler_ut/optionhandler_ut.c
@@ -223,11 +223,11 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     TEST_FUNCTION(OptionHandler_Create_happy_path)
     {
         ///arrange
-
+		OPTIONHANDLER_HANDLE h;
         OptionHandler_Create_inert_path(); /*in this case, it is happy*/
 
         ///act
-        OPTIONHANDLER_HANDLE h = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
+        h = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
 
         ///assert
         
@@ -242,6 +242,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     TEST_FUNCTION(OptionHandler_Create_unhappy_paths)
     {
         ///arrange
+		size_t i;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
@@ -249,18 +250,19 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
 
         umock_c_negative_tests_snapshot();
 
-        for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+        for (i = 0; i < umock_c_negative_tests_call_count(); i++)
         {
+            char temp_str[128];
+			OPTIONHANDLER_HANDLE h;
            
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(i);
             
             ///act
-            char temp_str[128];
             (void)sprintf(temp_str, "On failed call %zu", i);
             
             ///act
-            OPTIONHANDLER_HANDLE h = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
+            h = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
 
             ///assert
             ASSERT_IS_NULL_WITH_MSG(h, temp_str);
@@ -848,13 +850,14 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     TEST_FUNCTION(OptionHandler_AddOption_happy_path)
     {
         ///arrange
+		OPTIONHANDLER_RESULT result;
         OPTIONHANDLER_HANDLE handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
 
         void* value = "value";
         OptionHandler_AddOption_inert_path(value);
 
         ///act
-        OPTIONHANDLER_RESULT result = OptionHandler_AddOption(handle, "name", value);
+        result = OptionHandler_AddOption(handle, "name", value);
 
         ///assert
         ASSERT_ARE_EQUAL(OPTIONHANDLER_RESULT, OPTIONHANDLER_OK, result);
@@ -868,28 +871,32 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     TEST_FUNCTION(OptionHandler_AddOption_unhappy_path)
     {
         ///arrange
+        void* value = "value";
+		size_t i;
+		OPTIONHANDLER_HANDLE handle;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
         
-        OPTIONHANDLER_HANDLE handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
+        handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
         umock_c_reset_all_calls();
 
-        void* value = "value";
         OptionHandler_AddOption_inert_path(value);
 
         umock_c_negative_tests_snapshot();
 
-        for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+        for (i = 0; i < umock_c_negative_tests_call_count(); i++)
         {
-            umock_c_negative_tests_reset();
+            char temp_str[128];
+			OPTIONHANDLER_RESULT result;
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            char temp_str[128];
             (void)sprintf(temp_str, "On failed call %zu", i);
 
             ///act
-            OPTIONHANDLER_RESULT result = OptionHandler_AddOption(handle, "name", value);
+            result = OptionHandler_AddOption(handle, "name", value);
 
             ///assert
             ASSERT_ARE_EQUAL_WITH_MSG(OPTIONHANDLER_RESULT, OPTIONHANDLER_ERROR, result, temp_str);
@@ -938,6 +945,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     TEST_FUNCTION(OptionHandler_FeedOptions_with_0_saved_options_feeds_0_succeeds)
     {
         ///arrange
+		OPTIONHANDLER_RESULT result;
         OPTIONHANDLER_HANDLE handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
         umock_c_reset_all_calls();
 
@@ -945,7 +953,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
             .IgnoreArgument_handle();
 
         ///act
-        OPTIONHANDLER_RESULT result = OptionHandler_FeedOptions(handle, (void*)42);
+        result = OptionHandler_FeedOptions(handle, (void*)42);
 
         ///assert
         ASSERT_ARE_EQUAL(OPTIONHANDLER_RESULT, OPTIONHANDLER_OK, result);
@@ -971,6 +979,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     TEST_FUNCTION(OptionHandler_FeedOptions_with_1_saved_options_feeds_1_happypath)
     {
         ///arrange
+		OPTIONHANDLER_RESULT result;
         OPTIONHANDLER_HANDLE handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
         (void)OptionHandler_AddOption(handle, "a", "b");
         umock_c_reset_all_calls();
@@ -978,7 +987,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
         OptionHandler_FeedOptions_with_1_saved_options_feeds_1_inert_path();
 
         ///act
-        OPTIONHANDLER_RESULT result = OptionHandler_FeedOptions(handle, (void*)42);
+        result = OptionHandler_FeedOptions(handle, (void*)42);
 
         ///assert
         ASSERT_ARE_EQUAL(OPTIONHANDLER_RESULT, OPTIONHANDLER_OK, result);
@@ -991,12 +1000,19 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     /*Tests_SRS_OPTIONHANDLER_02_014: [ Otherwise, OptionHandler_FeedOptions shall fail and return OPTIONHANDLER_ERROR. ]*/
     TEST_FUNCTION(OptionHandler_FeedOptions_with_1_saved_options_feeds_1_unhappypaths)
     {
-
         ///arrange
+		size_t i;
+        size_t calls_that_cannot_fail[] =
+        {
+            0, 
+            1,
+        };
+		OPTIONHANDLER_HANDLE handle;
+
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-        OPTIONHANDLER_HANDLE handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
+        handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
         (void)OptionHandler_AddOption(handle, "a", "b");
         umock_c_reset_all_calls();
 
@@ -1004,15 +1020,12 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
 
         umock_c_negative_tests_snapshot();
 
-        size_t calls_that_cannot_fail[] =
+        for (i = 0; i < umock_c_negative_tests_call_count(); i++)
         {
-            0, 
-            1,
-        };
+            char temp_str[128];
+			size_t j;
+			OPTIONHANDLER_RESULT result;
 
-        for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
-        {
-            size_t j;
             for (j = 0;j < sizeof(calls_that_cannot_fail) / sizeof(calls_that_cannot_fail[0]);j++)
             {
                 if (calls_that_cannot_fail[j] == i)
@@ -1030,11 +1043,10 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            char temp_str[128];
             (void)sprintf(temp_str, "On failed call %zu", i);
 
             ///act
-            OPTIONHANDLER_RESULT result = OptionHandler_FeedOptions(handle, (void*)42);
+            result = OptionHandler_FeedOptions(handle, (void*)42);
 
             ///assert
             ASSERT_ARE_EQUAL_WITH_MSG(OPTIONHANDLER_RESULT, OPTIONHANDLER_ERROR, result, temp_str);
@@ -1068,6 +1080,8 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     {
         ///arrange
         OPTIONHANDLER_HANDLE handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
+		OPTIONHANDLER_RESULT result;
+
         (void)OptionHandler_AddOption(handle, "a", "b");
         (void)OptionHandler_AddOption(handle, "c", "b2");
         umock_c_reset_all_calls();
@@ -1075,7 +1089,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
         OptionHandler_FeedOptions_with_2_saved_options_feeds_2_inert_path();
 
         ///act
-        OPTIONHANDLER_RESULT result = OptionHandler_FeedOptions(handle, (void*)42);
+        result = OptionHandler_FeedOptions(handle, (void*)42);
 
         ///assert
         ASSERT_ARE_EQUAL(OPTIONHANDLER_RESULT, OPTIONHANDLER_OK, result);
@@ -1088,12 +1102,19 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
     /*Tests_SRS_OPTIONHANDLER_02_014: [ Otherwise, OptionHandler_FeedOptions shall fail and return OPTIONHANDLER_ERROR. ]*/
     TEST_FUNCTION(OptionHandler_FeedOptions_with_2_saved_options_feeds_2_unhappypaths)
     {
-
         ///arrange
+		OPTIONHANDLER_HANDLE handle;
+        size_t calls_that_cannot_fail[] =
+        {
+            0,
+            1,
+            3,
+        };
+		size_t i;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-        OPTIONHANDLER_HANDLE handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
+        handle = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
         (void)OptionHandler_AddOption(handle, "a", "b");
         (void)OptionHandler_AddOption(handle, "c", "b2");
         umock_c_reset_all_calls();
@@ -1102,16 +1123,12 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
 
         umock_c_negative_tests_snapshot();
 
-        size_t calls_that_cannot_fail[] =
+        for (i = 0; i < umock_c_negative_tests_call_count(); i++)
         {
-            0,
-            1,
-            3,
-        };
+            char temp_str[128];
+			size_t j;
+			OPTIONHANDLER_RESULT result;
 
-        for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
-        {
-            size_t j;
             for (j = 0;j < sizeof(calls_that_cannot_fail) / sizeof(calls_that_cannot_fail[0]);j++)
             {
                 if (calls_that_cannot_fail[j] == i)
@@ -1129,11 +1146,10 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            char temp_str[128];
             (void)sprintf(temp_str, "On failed call %zu", i);
 
             ///act
-            OPTIONHANDLER_RESULT result = OptionHandler_FeedOptions(handle, (void*)42);
+            result = OptionHandler_FeedOptions(handle, (void*)42);
 
             ///assert
             ASSERT_ARE_EQUAL_WITH_MSG(OPTIONHANDLER_RESULT, OPTIONHANDLER_ERROR, result, temp_str);

--- a/tests/platformarduino_ut/platformarduino_ut.c
+++ b/tests/platformarduino_ut/platformarduino_ut.c
@@ -56,13 +56,15 @@ BEGIN_TEST_SUITE(platformarduino_ut)
 
     TEST_SUITE_INITIALIZE(a)
     {
+		int result;
+
         TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
         (void)umock_c_init(on_umock_c_error);
 
-        int result = umocktypes_charptr_register_types();
+        result = umocktypes_charptr_register_types();
 		ASSERT_ARE_EQUAL(int, 0, result);
 
 		REGISTER_UMOCK_ALIAS_TYPE(IO_INTERFACE_DESCRIPTION, void*);
@@ -128,8 +130,8 @@ BEGIN_TEST_SUITE(platformarduino_ut)
 	TEST_FUNCTION(platform_get_default_tlsio__valid_ptr_succeed)
 	{
 		///arrange
-		my_tlsio_arduino_get_interface_description_return = (IO_INTERFACE_DESCRIPTION*)malloc(sizeof(IO_INTERFACE_DESCRIPTION));
 		const IO_INTERFACE_DESCRIPTION* result;
+		my_tlsio_arduino_get_interface_description_return = (IO_INTERFACE_DESCRIPTION*)malloc(sizeof(IO_INTERFACE_DESCRIPTION));
 
         umock_c_reset_all_calls();
 
@@ -154,8 +156,8 @@ BEGIN_TEST_SUITE(platformarduino_ut)
 	TEST_FUNCTION(platform_get_default_tlsio__NULL_failed)
 	{
 		///arrange
-		my_tlsio_arduino_get_interface_description_return = NULL;
 		const IO_INTERFACE_DESCRIPTION* result;
+		my_tlsio_arduino_get_interface_description_return = NULL;
 
 		STRICT_EXPECTED_CALL(tlsio_arduino_get_interface_description());
 

--- a/tests/singlylinkedlist_ut/singlylinkedlist_ut.c
+++ b/tests/singlylinkedlist_ut/singlylinkedlist_ut.c
@@ -123,10 +123,11 @@ TEST_FUNCTION_CLEANUP(method_cleanup)
 TEST_FUNCTION(when_underlying_calls_succeed_singlylinkedlist_create_succeeds)
 {
     // arrange
+	SINGLYLINKEDLIST_HANDLE result;
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
     // act
-    SINGLYLINKEDLIST_HANDLE result = singlylinkedlist_create();
+    result = singlylinkedlist_create();
 
     // assert
     ASSERT_IS_NOT_NULL(result);
@@ -140,11 +141,12 @@ TEST_FUNCTION(when_underlying_calls_succeed_singlylinkedlist_create_succeeds)
 TEST_FUNCTION(when_underlying_malloc_fails_singlylinkedlist_create_fails)
 {
     // arrange
+	SINGLYLINKEDLIST_HANDLE result;
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
         .SetReturn((void*)NULL);
 
     // act
-    SINGLYLINKEDLIST_HANDLE result = singlylinkedlist_create();
+    result = singlylinkedlist_create();
 
     // assert
     ASSERT_IS_NULL(result);
@@ -201,11 +203,12 @@ TEST_FUNCTION(singlylinkedlist_add_with_NULL_handle_fails)
 TEST_FUNCTION(singlylinkedlist_add_with_NULL_item_fails)
 {
     // arrange
+	LIST_ITEM_HANDLE result;
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     umock_c_reset_all_calls();
 
     // act
-	LIST_ITEM_HANDLE result = singlylinkedlist_add(list, NULL);
+	result = singlylinkedlist_add(list, NULL);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -221,18 +224,20 @@ TEST_FUNCTION(singlylinkedlist_add_adds_the_item_and_returns_a_non_NULL_handle)
 {
     // arrange
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
-    umock_c_reset_all_calls();
     int x = 42;
+	LIST_ITEM_HANDLE result;
+	LIST_ITEM_HANDLE head;
+    umock_c_reset_all_calls();
 
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_add(list, &x);
+    result = singlylinkedlist_add(list, &x);
 
     // assert
     ASSERT_IS_NOT_NULL(result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    LIST_ITEM_HANDLE head = singlylinkedlist_get_head_item(list);
+    head = singlylinkedlist_get_head_item(list);
     ASSERT_IS_NOT_NULL(head);
     ASSERT_ARE_EQUAL(int, x, *(const int*)singlylinkedlist_item_get_value(head));
 	ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -249,6 +254,8 @@ TEST_FUNCTION(singlylinkedlist_add_when_an_item_is_in_the_singlylinkedlist_adds_
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x1 = 42;
     int x2 = 43;
+	LIST_ITEM_HANDLE result;
+	LIST_ITEM_HANDLE list_item;
 
     (void)singlylinkedlist_add(list, &x1);
     umock_c_reset_all_calls();
@@ -256,12 +263,12 @@ TEST_FUNCTION(singlylinkedlist_add_when_an_item_is_in_the_singlylinkedlist_adds_
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_add(list, &x2);
+    result = singlylinkedlist_add(list, &x2);
 
     // assert
     ASSERT_IS_NOT_NULL(result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    LIST_ITEM_HANDLE list_item = singlylinkedlist_get_head_item(list);
+    list_item = singlylinkedlist_get_head_item(list);
     ASSERT_IS_NOT_NULL(list_item);
     ASSERT_ARE_EQUAL(int, x1, *(const int*)singlylinkedlist_item_get_value(list_item));
     list_item = singlylinkedlist_get_next_item(list_item);
@@ -279,13 +286,14 @@ TEST_FUNCTION(when_the_underlying_malloc_fails_singlylinkedlist_add_fails)
     // arrange
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x = 42;
+	LIST_ITEM_HANDLE result;
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
         .SetReturn((void*)NULL);
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_add(list, &x);
+    result = singlylinkedlist_add(list, &x);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -302,10 +310,11 @@ TEST_FUNCTION(when_the_list_is_empty_singlylinkedlist_get_head_item_yields_NULL)
 {
     // arrange
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
+	LIST_ITEM_HANDLE result;
     umock_c_reset_all_calls();
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_get_head_item(list);
+    result = singlylinkedlist_get_head_item(list);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -334,11 +343,12 @@ TEST_FUNCTION(singlylinkedlist_get_head_item_removes_the_item)
     // arrange
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x = 42;
+	LIST_ITEM_HANDLE head;
     (void)singlylinkedlist_add(list, &x);
     umock_c_reset_all_calls();
 
     // act
-    LIST_ITEM_HANDLE head = singlylinkedlist_get_head_item(list);
+    head = singlylinkedlist_get_head_item(list);
 
     // assert
     ASSERT_IS_NOT_NULL(head);
@@ -358,10 +368,11 @@ TEST_FUNCTION(singlylinkedlist_get_next_item_gets_the_next_item)
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x1 = 42;
     int x2 = 43;
+	LIST_ITEM_HANDLE item;
     (void)singlylinkedlist_add(list, &x1);
     (void)singlylinkedlist_add(list, &x2);
     umock_c_reset_all_calls();
-    LIST_ITEM_HANDLE item = singlylinkedlist_get_head_item(list);
+    item = singlylinkedlist_get_head_item(list);
 
     // act
     item = singlylinkedlist_get_next_item(item);
@@ -395,10 +406,11 @@ TEST_FUNCTION(singlylinkedlist_get_next_item_when_no_more_items_in_list_returns_
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x1 = 42;
     int x2 = 43;
+	LIST_ITEM_HANDLE item;
     (void)singlylinkedlist_add(list, &x1);
     (void)singlylinkedlist_add(list, &x2);
     umock_c_reset_all_calls();
-    LIST_ITEM_HANDLE item = singlylinkedlist_get_head_item(list);
+    item = singlylinkedlist_get_head_item(list);
     item = singlylinkedlist_get_next_item(item);
 
     // act
@@ -420,12 +432,14 @@ TEST_FUNCTION(singlylinkedlist_item_get_value_returns_the_item_value)
     // arrange
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x = 42;
+	LIST_ITEM_HANDLE item;
+	int result;
     (void)singlylinkedlist_add(list, &x);
     umock_c_reset_all_calls();
-    LIST_ITEM_HANDLE item = singlylinkedlist_get_head_item(list);
+    item = singlylinkedlist_get_head_item(list);
 
     // act
-    int result = *(const int*)singlylinkedlist_item_get_value(item);
+    result = *(const int*)singlylinkedlist_item_get_value(item);
 
     // assert
     ASSERT_ARE_EQUAL(int, x, result);
@@ -469,11 +483,12 @@ TEST_FUNCTION(singlylinkedlist_find_with_NULL_match_function_fails_with_NULL)
     // arrange
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x = 42;
+	LIST_ITEM_HANDLE result;
     (void)singlylinkedlist_add(list, &x);
     umock_c_reset_all_calls();
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_find(list, NULL, TEST_CONTEXT);
+    result = singlylinkedlist_find(list, NULL, TEST_CONTEXT);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -492,6 +507,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_1_matching_item_yields_that_i
     // arrange
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x = 42;
+	LIST_ITEM_HANDLE result;
     (void)singlylinkedlist_add(list, &x);
     umock_c_reset_all_calls();
 
@@ -499,7 +515,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_1_matching_item_yields_that_i
         .IgnoreArgument(1);
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
+    result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
 
     // assert
     ASSERT_IS_NOT_NULL(result);
@@ -516,6 +532,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_1_items_that_does_not_match_r
     // arrange
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x = 42;
+	LIST_ITEM_HANDLE result;
     (void)singlylinkedlist_add(list, &x);
     umock_c_reset_all_calls();
 
@@ -523,7 +540,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_1_items_that_does_not_match_r
         .IgnoreArgument(1).SetReturn(false);
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
+    result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -543,6 +560,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_2_items_where_the_first_match
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x1 = 42;
     int x2 = 43;
+	LIST_ITEM_HANDLE result;
     (void)singlylinkedlist_add(list, &x1);
     (void)singlylinkedlist_add(list, &x2);
     umock_c_reset_all_calls();
@@ -551,7 +569,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_2_items_where_the_first_match
         .IgnoreArgument(1);
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
+    result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
 
     // assert
     ASSERT_IS_NOT_NULL(result);
@@ -573,6 +591,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_2_items_where_the_second_matc
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x1 = 42;
     int x2 = 43;
+	LIST_ITEM_HANDLE result;
     (void)singlylinkedlist_add(list, &x1);
     (void)singlylinkedlist_add(list, &x2);
     umock_c_reset_all_calls();
@@ -583,7 +602,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_2_items_where_the_second_matc
         .IgnoreArgument(1);
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
+    result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
 
     // assert
     ASSERT_IS_NOT_NULL(result);
@@ -601,6 +620,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_2_items_both_matching_yields_
 	SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
 	int x1 = 42;
 	int x2 = 42;
+	LIST_ITEM_HANDLE result;
 	(void)singlylinkedlist_add(list, &x1);
 	(void)singlylinkedlist_add(list, &x2);
 	umock_c_reset_all_calls();
@@ -609,7 +629,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_2_items_both_matching_yields_
 		.IgnoreArgument(1);
 
 	// act
-	LIST_ITEM_HANDLE result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
+	result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
 
 	// assert
 	ASSERT_IS_NOT_NULL(result);
@@ -627,6 +647,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_2_items_where_none_matches_re
     SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
     int x1 = 42;
     int x2 = 43;
+	LIST_ITEM_HANDLE result;
     (void)singlylinkedlist_add(list, &x1);
     (void)singlylinkedlist_add(list, &x2);
     umock_c_reset_all_calls();
@@ -637,7 +658,7 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_2_items_where_none_matches_re
         .IgnoreArgument(1).SetReturn(false);
 
     // act
-    LIST_ITEM_HANDLE result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
+    result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -652,10 +673,11 @@ TEST_FUNCTION(singlylinkedlist_find_on_a_list_with_no_items_yields_NULL)
 {
     // arrange
 	SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
+	LIST_ITEM_HANDLE result;
     umock_c_reset_all_calls();
 
     // act
-	LIST_ITEM_HANDLE result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
+	result = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -673,14 +695,16 @@ TEST_FUNCTION(singlylinkedlist_remove_when_one_item_is_in_the_list_succeeds)
 	// arrange
 	int x1 = 0x42;
 	SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
+	LIST_ITEM_HANDLE item;
+	int result;
 	singlylinkedlist_add(list, &x1);
-	LIST_ITEM_HANDLE item = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
+	item = singlylinkedlist_find(list, test_match_function, TEST_CONTEXT);
 	umock_c_reset_all_calls();
 
 	EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
 	// act
-	int result = singlylinkedlist_remove(list, item);
+	result = singlylinkedlist_remove(list, item);
 
 	// assert
 	ASSERT_ARE_EQUAL(int, 0, result);
@@ -695,12 +719,13 @@ TEST_FUNCTION(singlylinkedlist_remove_with_NULL_list_fails)
 {
 	// arrange
 	int x1 = 0x42;
+	int result;
 	SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
 	LIST_ITEM_HANDLE item = singlylinkedlist_add(list, &x1);
 	umock_c_reset_all_calls();
 
 	// act
-	int result = singlylinkedlist_remove(NULL, item);
+	result = singlylinkedlist_remove(NULL, item);
 
 	// assert
 	ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -714,11 +739,12 @@ TEST_FUNCTION(singlylinkedlist_remove_with_NULL_list_fails)
 TEST_FUNCTION(singlylinkedlist_remove_with_NULL_item_fails)
 {
 	// arrange
+	int result;
 	SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
 	umock_c_reset_all_calls();
 
 	// act
-	int result = singlylinkedlist_remove(list, NULL);
+	result = singlylinkedlist_remove(list, NULL);
 
 	// assert
 	ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -733,13 +759,14 @@ TEST_FUNCTION(singlylinkedlist_remove_with_an_item_that_has_already_been_removed
 {
 	// arrange
 	int x1 = 0x42;
+	int result;
 	SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
 	LIST_ITEM_HANDLE item = singlylinkedlist_add(list, &x1);
 	singlylinkedlist_remove(list, item);
 	umock_c_reset_all_calls();
 
 	// act
-	int result = singlylinkedlist_remove(list, item);
+	result = singlylinkedlist_remove(list, item);
 
 	// assert
 	ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -754,6 +781,7 @@ TEST_FUNCTION(singlylinkedlist_remove_first_of_2_items_succeeds)
 {
 	// arrange
 	int x1 = 0x42;
+	int result;
 	SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
 	LIST_ITEM_HANDLE item1 = singlylinkedlist_add(list, &x1);
 	umock_c_reset_all_calls();
@@ -761,7 +789,7 @@ TEST_FUNCTION(singlylinkedlist_remove_first_of_2_items_succeeds)
 	EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
 	// act
-	int result = singlylinkedlist_remove(list, item1);
+	result = singlylinkedlist_remove(list, item1);
 
 	// assert
 	ASSERT_ARE_EQUAL(int, 0, result);
@@ -776,6 +804,7 @@ TEST_FUNCTION(singlylinkedlist_remove_second_of_2_items_succeeds)
 {
 	// arrange
 	int x2 = 0x43;
+	int result;
 	SINGLYLINKEDLIST_HANDLE list = singlylinkedlist_create();
 	LIST_ITEM_HANDLE item2 = singlylinkedlist_add(list, &x2);
 	umock_c_reset_all_calls();
@@ -783,7 +812,7 @@ TEST_FUNCTION(singlylinkedlist_remove_second_of_2_items_succeeds)
 	EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
 	// act
-	int result = singlylinkedlist_remove(list, item2);
+	result = singlylinkedlist_remove(list, item2);
 
 	// assert
 	ASSERT_ARE_EQUAL(int, 0, result);

--- a/tests/socket_async_ut/keep_alive.h
+++ b/tests/socket_async_ut/keep_alive.h
@@ -19,10 +19,11 @@ static int keep_count;     // number of times to try before declaring failure (i
 
 static int my_setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen)
 {
+	int value;
     (void)optlen;
     // All options are integers
     ASSERT_ARE_EQUAL(int, sockfd, test_socket);
-    int value = *((int*)optval);
+    value = *((int*)optval);
     if (level == IPPROTO_TCP)
     {
         switch (optname)

--- a/tests/socket_async_ut/socket_async_ut.c
+++ b/tests/socket_async_ut/socket_async_ut.c
@@ -137,6 +137,9 @@ BEGIN_TEST_SUITE(socket_async_ut)
 TEST_SUITE_INITIALIZE(a)
 {
     int result;
+	size_t type_size;
+	ssize_t sr_error;
+
     TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
     g_testByTest = TEST_MUTEX_CREATE();
     ASSERT_IS_NOT_NULL(g_testByTest);
@@ -151,7 +154,7 @@ TEST_SUITE_INITIALIZE(a)
     ASSERT_ARE_EQUAL(int, 0, result);
 
     // Unnatural type_size variable exists to avoid "conditional expression is constant" warning
-    size_t type_size = sizeof(ssize_t);
+    type_size = sizeof(ssize_t);
     if (type_size == sizeof(int32_t))
     {
         REGISTER_UMOCK_ALIAS_TYPE(ssize_t, int32_t);
@@ -179,7 +182,7 @@ TEST_SUITE_INITIALIZE(a)
         ASSERT_FAIL("bad socklen_t");
     }
 
-    ssize_t sr_error = (ssize_t)(-1);
+    sr_error = (ssize_t)(-1);
     REGISTER_GLOBAL_MOCK_RETURNS(socket, test_socket, -1);
     REGISTER_GLOBAL_MOCK_RETURNS(bind, 0, -1);
     REGISTER_GLOBAL_MOCK_RETURNS(connect, 0, -1);
@@ -254,7 +257,7 @@ TEST_SUITE_INITIALIZE(a)
     {
         ///arrange
         // no calls expected
-
+		int i;
         size_t received_count_receptor = BAD_BUFFER_COUNT;
         send_receive_parameters_t parameters[3];
 
@@ -264,7 +267,7 @@ TEST_SUITE_INITIALIZE(a)
         populate_s_r_parameters(parameters + 2, test_msg,   0,                  &received_count_receptor,   "Unexpected receive_result success when size parameter is 0");
 
         // Cycle through each failing combo of parameters
-        for (int i = 0; i < sizeof(parameters) / sizeof(send_receive_parameters_t); i++)
+        for (i = 0; i < sizeof(parameters) / sizeof(send_receive_parameters_t); i++)
         {
             ///act
             int receive_result = socket_async_receive(test_socket, parameters[i].buffer, parameters[i].size, parameters[i].returned_count);
@@ -284,6 +287,7 @@ TEST_SUITE_INITIALIZE(a)
     {
         ///arrange
         char *buffer = test_msg;
+		int receive_result;
         size_t size = sizeof(test_msg);
         size_t received_count_receptor = BAD_BUFFER_COUNT;
         size_t *received_count = &received_count_receptor;
@@ -296,7 +300,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        int receive_result = socket_async_receive(test_socket, buffer, size, received_count);
+        receive_result = socket_async_receive(test_socket, buffer, size, received_count);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(size_t, received_count_receptor, BAD_BUFFER_COUNT, "Unexpected received_count_receptor");
@@ -312,6 +316,7 @@ TEST_SUITE_INITIALIZE(a)
     {
         ///arrange
         char *buffer = test_msg;
+		int receive_result;
         size_t size = sizeof(test_msg);
         size_t received_count_receptor = BAD_BUFFER_COUNT;
         size_t *received_count = &received_count_receptor;
@@ -324,7 +329,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        int receive_result = socket_async_receive(test_socket, buffer, size, received_count);
+        receive_result = socket_async_receive(test_socket, buffer, size, received_count);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(size_t, received_count_receptor, 0, "Unexpected received_count_receptor");
@@ -340,6 +345,7 @@ TEST_SUITE_INITIALIZE(a)
     {
         ///arrange
         char *buffer = test_msg;
+		int receive_result;
         size_t size = sizeof(test_msg);
         size_t received_count_receptor;
         size_t *received_count = &received_count_receptor;
@@ -347,7 +353,7 @@ TEST_SUITE_INITIALIZE(a)
         STRICT_EXPECTED_CALL(recv(test_socket, buffer, size, RECV_ZERO_FLAGS));
 
         ///act
-        int receive_result = socket_async_receive(test_socket, buffer, size, received_count);
+        receive_result = socket_async_receive(test_socket, buffer, size, received_count);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(size_t, received_count_receptor, sizeof(test_msg), "Unexpected received_count_receptor");
@@ -364,7 +370,7 @@ TEST_SUITE_INITIALIZE(a)
     {
         ///arrange
         // no calls expected
-
+		int i;
         size_t sent_count_receptor = BAD_BUFFER_COUNT;
         send_receive_parameters_t parameters[2];
         //                                     buffer       size            received_count              fail_msg
@@ -372,7 +378,7 @@ TEST_SUITE_INITIALIZE(a)
         populate_s_r_parameters(parameters + 1, test_msg, sizeof(test_msg), NULL,                 "Unexpected receive_result success when received_count is NULL");
 
         // Cycle through each failing combo of parameters
-        for (int i = 0; i < sizeof(parameters) / sizeof(send_receive_parameters_t); i++)
+        for (i = 0; i < sizeof(parameters) / sizeof(send_receive_parameters_t); i++)
         {
             ///act
             int send_result = socket_async_send(test_socket, parameters[i].buffer, parameters[i].size, parameters[i].returned_count);
@@ -389,7 +395,7 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_send__send_fail__fails)
     {
         ///arrange
-
+		int send_result;
         char *buffer = test_msg;
         size_t size = sizeof(test_msg);
         size_t sent_count_receptor = BAD_BUFFER_COUNT;
@@ -403,7 +409,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        int send_result = socket_async_send(test_socket, buffer, size, sent_count);
+        send_result = socket_async_send(test_socket, buffer, size, sent_count);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, send_result, 0, "Unexpected send_result success");
@@ -417,6 +423,7 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_send__send_waiting__succeeds)
     {
         ///arrange
+		int send_result;
         char *buffer = test_msg;
         size_t size = sizeof(test_msg);
         size_t sent_count_receptor = BAD_BUFFER_COUNT;
@@ -430,7 +437,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        int send_result = socket_async_send(test_socket, buffer, size, sent_count);
+        send_result = socket_async_send(test_socket, buffer, size, sent_count);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(size_t, sent_count_receptor, 0, "Unexpected sent_count_receptor");
@@ -467,6 +474,7 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_send__succeeds)
     {
         ///arrange
+		int send_result;
         char *buffer = test_msg;
         size_t size = sizeof(test_msg);
         size_t sent_count_receptor = BAD_BUFFER_COUNT;
@@ -475,7 +483,7 @@ TEST_SUITE_INITIALIZE(a)
         STRICT_EXPECTED_CALL(send(test_socket, buffer, size, SEND_ZERO_FLAGS));
 
         ///act
-        int send_result = socket_async_send(test_socket, buffer, size, sent_count);
+        send_result = socket_async_send(test_socket, buffer, size, sent_count);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(size_t, sent_count_receptor, sizeof(test_msg), "Unexpected sent_count_receptor");
@@ -506,6 +514,7 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_is_create_complete__select_fail__fails)
     {
         ///arrange
+		int create_complete_result;
         bool is_complete;
         bool* is_complete_param = &is_complete;
         // getsockopt is used to get the extended error information after a socket failure
@@ -517,7 +526,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        int create_complete_result = socket_async_is_create_complete(test_socket, is_complete_param);
+        create_complete_result = socket_async_is_create_complete(test_socket, is_complete_param);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, create_complete_result, 0, "Unexpected create_complete_result success");
@@ -528,13 +537,15 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_is_create_complete__errset_set__fails)
     {
         ///arrange
+		int getsockopt_extended_error_return_value;
+		int create_complete_result;
         bool is_complete;
         bool* is_complete_param = &is_complete;
         // Define how the FD_ISSET etc. macros behave
         // Cause the FD_ISSET macro to detect a failure even though select() succeeded
         select_behavior = SELECT_TCP_IS_COMPLETE_ERRSET_FAIL;
         // getsockopt is used to get the extended error information after a socket failure
-        int getsockopt_extended_error_return_value = EXTENDED_ERROR_FAIL;
+        getsockopt_extended_error_return_value = EXTENDED_ERROR_FAIL;
 
         STRICT_EXPECTED_CALL(select(test_socket + 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
         // getsockopt is used to get the extended error information after a socket failure
@@ -542,7 +553,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        int create_complete_result = socket_async_is_create_complete(test_socket, is_complete_param);
+        create_complete_result = socket_async_is_create_complete(test_socket, is_complete_param);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, create_complete_result, 0, "Unexpected create_complete_result success");
@@ -553,6 +564,7 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_is_create_complete__waiting__succeeds)
     {
         ///arrange
+		int create_complete_result;
         bool is_complete = true; // unexpected so change can be detected
         bool* is_complete_param = &is_complete;
         // Define how the FD_ISET etc. macros behave
@@ -561,7 +573,7 @@ TEST_SUITE_INITIALIZE(a)
         STRICT_EXPECTED_CALL(select(test_socket + 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 
         ///act
-        int create_complete_result = socket_async_is_create_complete(test_socket, is_complete_param);
+        create_complete_result = socket_async_is_create_complete(test_socket, is_complete_param);
 
         ///assert
         ASSERT_IS_FALSE_WITH_MSG(is_complete, "Unexpected is_complete failure");
@@ -573,6 +585,7 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_is_create_complete__succeeds)
     {
         ///arrange
+		int create_complete_result;
         bool is_complete = false; // unexpected so change can be detected
         bool* is_complete_param = &is_complete;
         // Define how the FD_ISET etc. macros behave
@@ -581,7 +594,7 @@ TEST_SUITE_INITIALIZE(a)
         STRICT_EXPECTED_CALL(select(test_socket + 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 
         ///act
-        int create_complete_result = socket_async_is_create_complete(test_socket, is_complete_param);
+        create_complete_result = socket_async_is_create_complete(test_socket, is_complete_param);
 
         ///assert
         ASSERT_IS_TRUE_WITH_MSG(is_complete, "Unexpected is_complete failure");
@@ -593,13 +606,14 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_create__create_fail__fails)
     {
         ///arrange
+		SOCKET_ASYNC_HANDLE create_result;
         SOCKET_ASYNC_OPTIONS* options = NULL;
         bool is_udp = false;
 
         STRICT_EXPECTED_CALL(socket(AF_INET, SOCK_STREAM /* the TCP value, doesn't matter */, 0)).SetReturn(SOCKET_FAIL_RETURN);
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(int, create_result, SOCKET_ASYNC_INVALID_SOCKET, "Unexpected create_result success");
@@ -610,6 +624,7 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_create__opt_default_fail__fails)
     {
         ///arrange
+		SOCKET_ASYNC_HANDLE create_result;
         SOCKET_ASYNC_OPTIONS* options = NULL;
         bool is_udp = false;
 
@@ -618,7 +633,7 @@ TEST_SUITE_INITIALIZE(a)
         STRICT_EXPECTED_CALL(setsockopt(test_socket, IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG)).SetReturn(SETSOCKOPT_FAIL_RETURN);
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(int, create_result, SOCKET_ASYNC_INVALID_SOCKET, "Unexpected create_result success");
@@ -629,12 +644,13 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_create__set_all_options_fail__fails)
     {
         ///arrange
-        int negativeTestsInitResult = umock_c_negative_tests_init();
-        ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
-
         SOCKET_ASYNC_OPTIONS options_value = { test_keep_alive , test_keep_idle , test_keep_interval, test_keep_count };
         SOCKET_ASYNC_OPTIONS* options = &options_value;
         bool is_udp = false;
+        int negativeTestsInitResult = umock_c_negative_tests_init();
+		size_t i;
+
+        ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
         STRICT_EXPECTED_CALL(socket(AF_INET, SOCK_STREAM, 0));
         STRICT_EXPECTED_CALL(setsockopt(test_socket, IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
@@ -643,13 +659,15 @@ TEST_SUITE_INITIALIZE(a)
         STRICT_EXPECTED_CALL(setsockopt(test_socket, IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
         umock_c_negative_tests_snapshot();
 
-        for (unsigned int i = 1; i < umock_c_negative_tests_call_count(); i++)
+        for (i = 1; i < umock_c_negative_tests_call_count(); i++)
         {
-            umock_c_negative_tests_reset();
+			SOCKET_ASYNC_HANDLE create_result;
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+            create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
             ///assert
             ASSERT_ARE_EQUAL_WITH_MSG(int, create_result, SOCKET_ASYNC_INVALID_SOCKET, "Unexpected create_result success");
@@ -668,7 +686,7 @@ TEST_SUITE_INITIALIZE(a)
         bool is_udp = false;
         // getsockopt is used to get the extended error information after a socket failure
         int getsockopt_extended_error_return_value = EXTENDED_ERROR_FAIL;
-
+		SOCKET_ASYNC_HANDLE create_result;
 
         STRICT_EXPECTED_CALL(socket(AF_INET, SOCK_STREAM, 0));
         STRICT_EXPECTED_CALL(setsockopt(test_socket, IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
@@ -680,7 +698,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(int, create_result, SOCKET_ASYNC_INVALID_SOCKET, "Unexpected create_result success");
@@ -694,6 +712,7 @@ TEST_SUITE_INITIALIZE(a)
         SOCKET_ASYNC_OPTIONS options_value = { test_keep_alive , test_keep_idle , test_keep_interval, test_keep_count };
         SOCKET_ASYNC_OPTIONS* options = &options_value;
         bool is_udp = false;
+		SOCKET_ASYNC_HANDLE create_result;
         // getsockopt is used to get the extended error information after a socket failure
         int getsockopt_extended_error_return_value = EXTENDED_ERROR_FAIL;
 
@@ -709,7 +728,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_ARE_EQUAL_WITH_MSG(int, create_result, SOCKET_ASYNC_INVALID_SOCKET, "Unexpected create_result success");
@@ -722,13 +741,13 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_create__tcp_connect_waiting__succeeds)
     {
         ///arrange
-        init_keep_alive_values();
         SOCKET_ASYNC_OPTIONS options_value = { test_keep_alive , test_keep_idle , test_keep_interval, test_keep_count };
         SOCKET_ASYNC_OPTIONS* options = &options_value;
         bool is_udp = false;
+		SOCKET_ASYNC_HANDLE create_result;
         // getsockopt is used to get the extended error information after a socket failure
-        int getsockopt_extended_error_return_value = EXTENDED_ERROR_CONNECt_WAITING;
-
+        int getsockopt_extended_error_return_value = EXTENDED_ERROR_CONNECT_WAITING;
+        init_keep_alive_values();
 
         STRICT_EXPECTED_CALL(socket(AF_INET, SOCK_STREAM, 0));
         STRICT_EXPECTED_CALL(setsockopt(test_socket, IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
@@ -741,7 +760,7 @@ TEST_SUITE_INITIALIZE(a)
             .CopyOutArgumentBuffer_optval(&getsockopt_extended_error_return_value, sizeof_int);
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_KEEP_ALIVE_SET();
@@ -755,11 +774,11 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_create__tcp_succeeds)
     {
         ///arrange
-        init_keep_alive_values();
         SOCKET_ASYNC_OPTIONS options_value = { test_keep_alive , test_keep_idle , test_keep_interval, test_keep_count };
         SOCKET_ASYNC_OPTIONS* options = &options_value;
         bool is_udp = false;
-
+		SOCKET_ASYNC_HANDLE create_result;
+        init_keep_alive_values();
 
         STRICT_EXPECTED_CALL(socket(AF_INET, SOCK_STREAM /* the TCP value */, 0));
         STRICT_EXPECTED_CALL(setsockopt(test_socket, IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
@@ -770,7 +789,7 @@ TEST_SUITE_INITIALIZE(a)
         STRICT_EXPECTED_CALL(connect(test_socket, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_KEEP_ALIVE_SET();
@@ -784,18 +803,18 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_create__tcp_default_sys_keep_alive__succeeds)
     {
         ///arrange
-        init_keep_alive_values();
         SOCKET_ASYNC_OPTIONS options_value = { test_keep_alive_sys_default , test_keep_idle , test_keep_interval, test_keep_count };
         SOCKET_ASYNC_OPTIONS* options = &options_value;
         bool is_udp = false;
-
+		SOCKET_ASYNC_HANDLE create_result;
+        init_keep_alive_values();
 
         STRICT_EXPECTED_CALL(socket(AF_INET, SOCK_STREAM /* the TCP value */, 0));
         STRICT_EXPECTED_CALL(bind(test_socket, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(connect(test_socket, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_KEEP_ALIVE_UNTOUCHED();
@@ -809,10 +828,10 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_create__tcp_keep_alive_off_by_default__succeeds)
     {
         ///arrange
-        init_keep_alive_values();
         SOCKET_ASYNC_OPTIONS* options = NULL;
         bool is_udp = false;
-
+		SOCKET_ASYNC_HANDLE create_result;
+        init_keep_alive_values();
 
         STRICT_EXPECTED_CALL(socket(AF_INET, SOCK_STREAM /* the TCP value */, 0));
         STRICT_EXPECTED_CALL(setsockopt(test_socket, IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
@@ -820,7 +839,7 @@ TEST_SUITE_INITIALIZE(a)
         STRICT_EXPECTED_CALL(connect(test_socket, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_KEEP_ALIVE_FALSE();
@@ -834,18 +853,18 @@ TEST_SUITE_INITIALIZE(a)
     TEST_FUNCTION(socket_async_create__udp__succeeds)
     {
         ///arrange
-        init_keep_alive_values();
         SOCKET_ASYNC_OPTIONS options_value = { test_keep_alive_sys_default , test_keep_idle , test_keep_interval, test_keep_count };
         SOCKET_ASYNC_OPTIONS* options = &options_value;
         bool is_udp = true;
-
+		SOCKET_ASYNC_HANDLE create_result;
+        init_keep_alive_values();
 
         STRICT_EXPECTED_CALL(socket(AF_INET, SOCK_DGRAM /* the UDP value */, 0));
         STRICT_EXPECTED_CALL(bind(test_socket, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(connect(test_socket, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
 
         ///act
-        SOCKET_ASYNC_HANDLE create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
+        create_result = socket_async_create(test_ipv4, test_port, is_udp, options);
 
         ///assert
         ASSERT_KEEP_ALIVE_UNTOUCHED();

--- a/tests/socket_async_ut/test_defines.h
+++ b/tests/socket_async_ut/test_defines.h
@@ -23,7 +23,7 @@ char test_msg[] = "Send this";
 #define BIND_FAIL_RETURN -1
 #define EXTENDED_ERROR_FAIL EACCES
 #define EXTENDED_ERROR_WAITING EAGAIN
-#define EXTENDED_ERROR_CONNECt_WAITING EINPROGRESS
+#define EXTENDED_ERROR_CONNECT_WAITING EINPROGRESS
 static size_t sizeof_int = sizeof(test_socket);
 
 typedef struct

--- a/tests/socket_async_ut/win32_fake_linux/socket_async_os.h
+++ b/tests/socket_async_ut/win32_fake_linux/socket_async_os.h
@@ -7,10 +7,26 @@
 
 #ifdef __cplusplus
 extern "C" {
+#include <cstdbool>
+#include <cstddef>
+#include <cstdint>
 #endif
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+
+#ifndef EINPROGRESS
+#define  EINPROGRESS    112
+#endif
+
+#ifndef EAGAIN
+#define  EAGAIN			11
+#endif
+
+#ifndef EWOULDBLOCK
+#define  EWOULDBLOCK	140
+#endif
 
 #define	SOL_SOCKET	0xffff
 #define	SO_ERROR	0x1007

--- a/tests/socketio_win32_ut/socketio_win32_ut.c
+++ b/tests/socketio_win32_ut/socketio_win32_ut.c
@@ -170,8 +170,8 @@ const void* my_singlylinkedlist_item_get_value(LIST_ITEM_HANDLE item_handle)
 LIST_ITEM_HANDLE my_singlylinkedlist_find(SINGLYLINKEDLIST_HANDLE handle, LIST_MATCH_FUNCTION match_function, const void* match_context)
 {
     size_t i;
-    (void)handle;
     const void* found_item = NULL;
+    (void)handle;
     for (i = 0; i < list_item_count; i++)
     {
         if (match_function((LIST_ITEM_HANDLE)list_items[i], match_context))
@@ -439,14 +439,15 @@ TEST_FUNCTION(socketio_create_io_create_parameters_NULL_fails)
 TEST_FUNCTION(socketio_create_singlylinkedlist_create_fails)
 {
     // arrange
-    EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
+	CONCRETE_IO_HANDLE ioHandle;
+
+	EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     EXPECTED_CALL(singlylinkedlist_create()).SetReturn((SINGLYLINKEDLIST_HANDLE)NULL);
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-
     // act
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
+    ioHandle = socketio_create(&socketConfig);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -456,14 +457,15 @@ TEST_FUNCTION(socketio_create_singlylinkedlist_create_fails)
 TEST_FUNCTION(socketio_create_succeeds)
 {
     // arrange
-    EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
+	CONCRETE_IO_HANDLE ioHandle;
+
+	EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     EXPECTED_CALL(singlylinkedlist_create());
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-
     // act
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
+    ioHandle = socketio_create(&socketConfig);
 
     // assert
     ASSERT_IS_NOT_NULL(ioHandle);
@@ -534,6 +536,7 @@ TEST_FUNCTION(socketio_open_socket_io_NULL_fails)
 TEST_FUNCTION(socketio_open_socket_fails)
 {
     // arrange
+	int result;
     SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
     CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
 
@@ -547,7 +550,7 @@ TEST_FUNCTION(socketio_open_socket_fails)
 #endif
 
     // act
-    int result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -560,6 +563,7 @@ TEST_FUNCTION(socketio_open_socket_fails)
 TEST_FUNCTION(socketio_open_getaddrinfo_fails)
 {
     // arrange
+	int result;
     SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
     CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
 
@@ -576,7 +580,7 @@ TEST_FUNCTION(socketio_open_getaddrinfo_fails)
     EXPECTED_CALL(closesocket(IGNORED_NUM_ARG));
 
     // act
-    int result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -589,6 +593,7 @@ TEST_FUNCTION(socketio_open_getaddrinfo_fails)
 TEST_FUNCTION(socketio_open_connect_fails)
 {
     // arrange
+	int result;
     SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
     CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
 
@@ -607,7 +612,7 @@ TEST_FUNCTION(socketio_open_connect_fails)
     EXPECTED_CALL(freeaddrinfo(&TEST_ADDR_INFO));
 
     // act
-    int result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -620,6 +625,7 @@ TEST_FUNCTION(socketio_open_connect_fails)
 TEST_FUNCTION(socketio_open_ioctlsocket_fails)
 {
     // arrange
+	int result;
     SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
     CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
     static ADDRINFO addrInfo = { AI_PASSIVE, AF_INET, SOCK_STREAM, IPPROTO_TCP, 128, NULL, (struct sockaddr*)0x11, NULL };
@@ -640,7 +646,7 @@ TEST_FUNCTION(socketio_open_ioctlsocket_fails)
     EXPECTED_CALL(freeaddrinfo(&TEST_ADDR_INFO));
 
     // act
-    int result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -653,6 +659,7 @@ TEST_FUNCTION(socketio_open_ioctlsocket_fails)
 TEST_FUNCTION(socketio_open_succeeds)
 {
     // arrange
+	int result;
     SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
     CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
 
@@ -665,7 +672,7 @@ TEST_FUNCTION(socketio_open_succeeds)
     EXPECTED_CALL(freeaddrinfo(&TEST_ADDR_INFO));
 
     // act
-    int result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -934,13 +941,14 @@ TEST_FUNCTION(socketio_setoption_fails_when_option_name_is_null)
 {
     // arrange
     int irrelevant = 1;
+	int result;
 
     CONCRETE_IO_HANDLE ioHandle = setup_socket();
 
     umock_c_reset_all_calls();
 
     // act
-    int result = socketio_setoption(ioHandle, NULL, &irrelevant);
+    result = socketio_setoption(ioHandle, NULL, &irrelevant);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -951,12 +959,13 @@ TEST_FUNCTION(socketio_setoption_fails_when_option_name_is_null)
 TEST_FUNCTION(socketio_setoption_fails_when_value_is_null)
 {
     // arrange
+	int result;
     CONCRETE_IO_HANDLE ioHandle = setup_socket();
 
     umock_c_reset_all_calls();
 
     // act
-    int result = socketio_setoption(ioHandle, "tcp_keepalive", NULL);
+    result = socketio_setoption(ioHandle, "tcp_keepalive", NULL);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -968,13 +977,14 @@ TEST_FUNCTION(socketio_setoption_fails_when_it_receives_an_unsupported_option)
 {
     // arrange
     int irrelevant = 1;
+	int result;
 
     CONCRETE_IO_HANDLE ioHandle = setup_socket();
 
     umock_c_reset_all_calls();
 
     // act
-    int result = socketio_setoption(ioHandle, "unsupported_option_name", &irrelevant);
+    result = socketio_setoption(ioHandle, "unsupported_option_name", &irrelevant);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -1091,6 +1101,7 @@ TEST_FUNCTION(socketio_setoption_does_not_persist_keepalive_values_if_WSAIoctl_f
 {
     // arrange
     int irrelevant = 1;
+	int result;
 
     CONCRETE_IO_HANDLE ioHandle = setup_socket();
 
@@ -1110,7 +1121,7 @@ TEST_FUNCTION(socketio_setoption_does_not_persist_keepalive_values_if_WSAIoctl_f
     memset(&persisted_tcp_keepalive, 0, sizeof(struct tcp_keepalive));
 
     // act
-    int result = socketio_setoption(ioHandle, "tcp_keepalive", &irrelevant);
+    result = socketio_setoption(ioHandle, "tcp_keepalive", &irrelevant);
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
 
     result = socketio_setoption(ioHandle, "tcp_keepalive_time", &irrelevant); // use different option for 2nd call so we don't overwrite the value from the 1st

--- a/tests/string_tokenizer_ut/string_tokenizer_ut.c
+++ b/tests/string_tokenizer_ut/string_tokenizer_ut.c
@@ -136,12 +136,12 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_create_succeed)
     {
         ///arrange
+		STRING_TOKENIZER_HANDLE t;
         const char* inputString = "Pirlimpimpim";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
 
         umock_c_reset_all_calls();
-        ///act
 
         STRICT_EXPECTED_CALL(gballoc_malloc(0))  //Token Allocation.
             .IgnoreArgument(1);
@@ -149,8 +149,8 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(0))  //Token Content Allocation.
             .IgnoreArgument(1);
 
-
-        STRING_TOKENIZER_HANDLE t = STRING_TOKENIZER_create(input_string_handle);
+        ///act
+        t = STRING_TOKENIZER_create(input_string_handle);
 
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
         ///assert
@@ -181,9 +181,9 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     {
         ///arrange
         const char* inputString = "Pirlimpimpim";
+		STRING_TOKENIZER_HANDLE t;
 
         umock_c_reset_all_calls();
-        ///act
 
         STRICT_EXPECTED_CALL(gballoc_malloc(0))  //Token Allocation.
             .IgnoreArgument(1);
@@ -191,8 +191,8 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(0))  //Token Content Allocation.
             .IgnoreArgument(1);
 
-
-        STRING_TOKENIZER_HANDLE t = STRING_TOKENIZER_create_from_char(inputString);
+        ///act
+        t = STRING_TOKENIZER_create_from_char(inputString);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -207,18 +207,19 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     {
         ///arrange
         const char* inputString = "Pirlimpimpim";
+		STRING_TOKENIZER_HANDLE t;
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
 
         umock_c_reset_all_calls();
-        ///act
 
         
         EXPECTED_CALL(gballoc_malloc(0));  //Token Allocation.
 
 
         whenShallmalloc_fail = currentmalloc_call + 1;
-        STRING_TOKENIZER_HANDLE t = STRING_TOKENIZER_create(input_string_handle);
+        ///act
+        t = STRING_TOKENIZER_create(input_string_handle);
 
         ///assert
         ASSERT_IS_NULL(t);
@@ -233,12 +234,13 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_handle_NULL_Fail)
     {
         ///arrange
+		int r;
         STRING_HANDLE output_string_handle = STRING_new();
 
         umock_c_reset_all_calls();
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(NULL, output_string_handle, "m");
+        r = STRING_TOKENIZER_get_next_token(NULL, output_string_handle, "m");
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, r, 0);
@@ -251,12 +253,13 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_Delimiter_empty_Fail)
     {
         ///arrange
+		int r;
         STRING_HANDLE output_string_handle = STRING_new();
 
         umock_c_reset_all_calls();
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(NULL, output_string_handle, "");
+        r = STRING_TOKENIZER_get_next_token(NULL, output_string_handle, "");
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, r, 0);
@@ -270,6 +273,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_output_NULL_Fail)
     {
         ///arrange
+		int r;
         const char* inputString = "Pirlimpimpim";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -279,7 +283,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
         umock_c_reset_all_calls();
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(t, NULL, "m");
+        r = STRING_TOKENIZER_get_next_token(t, NULL, "m");
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, r, 0);
@@ -293,6 +297,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_delimiters_NULL_Fail)
     {
         ///arrange
+		int r;
         const char* inputString = "Pirlimpimpim";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -303,7 +308,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
         umock_c_reset_all_calls();
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, NULL);
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, NULL);
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, r, 0);
@@ -317,6 +322,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_PIRLI_Succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "Pirlimpimpim";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -331,7 +337,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(2);
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "m");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "m");
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, "Pirli", STRING_c_str(output_string_handle));
@@ -347,6 +353,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_Start_With_Delimiter_Succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "Pirlimpimpim";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -361,7 +368,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(2);
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, "irlimpimpim", STRING_c_str(output_string_handle));
@@ -378,6 +385,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_Start_And_End_With_Delimiter_Succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "PirlimP";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -392,7 +400,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(2);
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, "irlim", STRING_c_str(output_string_handle));
@@ -408,6 +416,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_with_All_token_String_Fail)
     {
         ///arrange
+		int r;
         const char* inputString = "PPPPPP";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -418,7 +427,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
         umock_c_reset_all_calls();
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, r, 0);
@@ -433,6 +442,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_2Times_With_Just_1Token_SecondCall_Fail)
     {
         ///arrange
+		int r;
         const char* inputString = "TestP";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -447,7 +457,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(2);
 
         ///act1
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
 
         ///Assert1
         ASSERT_ARE_EQUAL(char_ptr, "Test", STRING_c_str(output_string_handle));
@@ -470,6 +480,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_2charactersToken_at_begin_of_input_call_1_Time_Succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "??This is a Test";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -483,8 +494,8 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(1)
             .IgnoreArgument(2);
 
-        ///act1
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "?");
+        ///act
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "?");
 
         ///Assert1
         ASSERT_ARE_EQUAL(char_ptr, "This is a Test", STRING_c_str(output_string_handle));
@@ -501,6 +512,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_stringWith3Tokens_Call3Times_Succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "Test1PTest2PTest3";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -520,8 +532,8 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(1)
             .IgnoreArgument(2);
 
-        ///act1
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
+        ///act
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
         
         ///Assert1
         ASSERT_ARE_EQUAL(char_ptr, "Test1", STRING_c_str(output_string_handle));
@@ -551,6 +563,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_inputEmptyString_Fail)
     {
         ///arrange
+		int r;
         const char* inputString = "";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -561,7 +574,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
         umock_c_reset_all_calls();
 
         ///act
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "P");
 
         ///Assert
         ASSERT_ARE_NOT_EQUAL(int, r, 0);
@@ -577,6 +590,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_multipleCalls_DifferentToken_Succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "?a???b,,,#c";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -592,7 +606,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(2);
 
 
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "?");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "?");
 
         ///Assert1
         ASSERT_ARE_EQUAL(char_ptr,"a", STRING_c_str(output_string_handle));
@@ -638,6 +652,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_inputString_with_SingleCharacter_call2Times_succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "c";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -653,7 +668,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(2);
 
 
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "?");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "?");
 
         ///Assert1
         ASSERT_ARE_EQUAL(char_ptr,"c", STRING_c_str(output_string_handle));
@@ -676,6 +691,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_inputString_with_NULL_in_the_Middle_succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "This is a Test \0 1234";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -691,7 +707,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(2);
 
 
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "1");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "1");
 
         ///Assert1
         ASSERT_ARE_EQUAL(char_ptr,"This is a Test ", STRING_c_str(output_string_handle));
@@ -709,6 +725,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
     TEST_FUNCTION(STRING_TOKENIZER_get_next_token_inputString_with_specialCharacters_succeed)
     {
         ///arrange
+		int r;
         const char* inputString = "This is a Test \r\n 1234 \r\n\t 12345";
 
         STRING_HANDLE input_string_handle = STRING_construct(inputString);
@@ -724,7 +741,7 @@ BEGIN_TEST_SUITE(string_tokenizer_unittests)
             .IgnoreArgument(2);
 
 
-        int r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "\r\n");
+        r = STRING_TOKENIZER_get_next_token(t, output_string_handle, "\r\n");
 
         ///Assert1
         ASSERT_ARE_EQUAL(char_ptr,"This is a Test ", STRING_c_str(output_string_handle));

--- a/tests/strings_ut/strings_ut.c
+++ b/tests/strings_ut/strings_ut.c
@@ -153,10 +153,11 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_new_fail)
     {
         //arrange
+        STRING_HANDLE str_handle;
+		size_t count;
+		size_t index;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
-
-        STRING_HANDLE str_handle;
 
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
@@ -165,15 +166,16 @@ BEGIN_TEST_SUITE(strings_unittests)
         umock_c_negative_tests_snapshot();
 
         //act
-        size_t count = umock_c_negative_tests_call_count();
-        for (size_t index = 0; index < count; index++)
+        count = umock_c_negative_tests_call_count();
+        for (index = 0; index < count; index++)
         {
-            umock_c_negative_tests_reset();
+            char tmp_msg[64];
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
             str_handle = STRING_new();
 
-            char tmp_msg[64];
             sprintf(tmp_msg, "STRING_new failure in test %zu/%zu", index+1, count);
 
             //assert
@@ -247,10 +249,11 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_construct_Fail)
     {
         //arrange
+        STRING_HANDLE str_handle;
+		size_t count;
+		size_t index;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
-
-        STRING_HANDLE str_handle;
 
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
@@ -259,15 +262,16 @@ BEGIN_TEST_SUITE(strings_unittests)
         umock_c_negative_tests_snapshot();
 
         //act
-        size_t count = umock_c_negative_tests_call_count();
-        for (size_t index = 0; index < count; index++)
+        count = umock_c_negative_tests_call_count();
+        for (index = 0; index < count; index++)
         {
-            umock_c_negative_tests_reset();
+            char tmp_msg[64];
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
             str_handle = STRING_construct(TEST_STRING_VALUE);
 
-            char tmp_msg[64];
             sprintf(tmp_msg, "STRING_construct failure in test %zu/%zu", index+1, count);
 
             //assert
@@ -390,10 +394,11 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_construct_sprintf_fail)
     {
         //arrange
+        STRING_HANDLE str_handle;
+		size_t count;
+		size_t index;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
-
-        STRING_HANDLE str_handle;
 
         EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
@@ -401,15 +406,16 @@ BEGIN_TEST_SUITE(strings_unittests)
         umock_c_negative_tests_snapshot();
 
         //act
-        size_t count = umock_c_negative_tests_call_count();
-        for (size_t index = 0; index < count; index++)
+        count = umock_c_negative_tests_call_count();
+        for (index = 0; index < count; index++)
         {
-            umock_c_negative_tests_reset();
+            char tmp_msg[64];
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
             str_handle = STRING_construct_sprintf(FORMAT_STRING, TEST_STRING_VALUE);
 
-            char tmp_msg[64];
             sprintf(tmp_msg, "STRING_construct_sprintf failure in test %zu/%zu", index+1, count);
 
             //assert
@@ -424,6 +430,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Concat_Succeed)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE g_hString;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
@@ -432,7 +439,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = STRING_concat(g_hString, TEST_STRING_VALUE);
+        nResult = STRING_concat(g_hString, TEST_STRING_VALUE);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, COMBINED_STRING_VALUE, STRING_c_str(g_hString) );
@@ -447,12 +454,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Concat_HANDLE_NULL_Fail)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE g_hString;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = STRING_concat(NULL, TEST_STRING_VALUE);
+        nResult = STRING_concat(NULL, TEST_STRING_VALUE);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -467,12 +475,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Concat_CharPtr_NULL_Fail)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE g_hString;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = STRING_concat(g_hString, NULL);
+        nResult = STRING_concat(g_hString, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -524,8 +533,8 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Concat_With_STRING_SUCCEED)
     {
         ///arrange
-        STRING_HANDLE g_hString;
-        g_hString = STRING_construct(INITIAL_STRING_VALUE);
+		int nResult;
+        STRING_HANDLE g_hString = STRING_construct(INITIAL_STRING_VALUE);
         STRING_HANDLE hAppend = STRING_construct(TEST_STRING_VALUE);
         umock_c_reset_all_calls();
 
@@ -533,7 +542,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = STRING_concat_with_STRING(g_hString, hAppend);
+        nResult = STRING_concat_with_STRING(g_hString, hAppend);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, COMBINED_STRING_VALUE, STRING_c_str(g_hString) );
@@ -549,11 +558,12 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Concat_With_STRING_HANDLE_NULL_Fail)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE hAppend = STRING_construct(TEST_STRING_VALUE);
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = STRING_concat_with_STRING(NULL, hAppend);
+        nResult = STRING_concat_with_STRING(NULL, hAppend);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -568,11 +578,12 @@ BEGIN_TEST_SUITE(strings_unittests)
     {
         ///arrange
         STRING_HANDLE g_hString;
+		int nResult;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = STRING_concat_with_STRING(g_hString, NULL);
+        nResult = STRING_concat_with_STRING(g_hString, NULL);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -600,6 +611,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     {
         ///arrange
         STRING_HANDLE g_hString;
+		int nResult;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
 
@@ -607,7 +619,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = STRING_copy(g_hString, TEST_STRING_VALUE);
+        nResult = STRING_copy(g_hString, TEST_STRING_VALUE);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, TEST_STRING_VALUE, STRING_c_str(g_hString) );
@@ -622,12 +634,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Copy_NULL_Fail)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE g_hString;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = STRING_copy(g_hString, NULL);
+        nResult = STRING_copy(g_hString, NULL);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -641,6 +654,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Copy_n_Succeed)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE g_hString;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
@@ -649,7 +663,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = STRING_copy_n(g_hString, COMBINED_STRING_VALUE, NUMBER_OF_CHAR_TOCOPY);
+        nResult = STRING_copy_n(g_hString, COMBINED_STRING_VALUE, NUMBER_OF_CHAR_TOCOPY);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, INITIAL_STRING_VALUE, STRING_c_str(g_hString) );
@@ -677,12 +691,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Copy_n_With_CONST_CHAR_NULL_Fail)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE g_hString;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
 
         ///act
-        int nResult = STRING_copy_n(g_hString, NULL, NUMBER_OF_CHAR_TOCOPY);
+        nResult = STRING_copy_n(g_hString, NULL, NUMBER_OF_CHAR_TOCOPY);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, nResult, 0);
@@ -696,6 +711,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_Copy_n_With_Size_0_Succeed)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE g_hString;
         g_hString = STRING_construct(INITIAL_STRING_VALUE);
         umock_c_reset_all_calls();
@@ -704,7 +720,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = STRING_copy_n(g_hString, COMBINED_STRING_VALUE, 0);
+        nResult = STRING_copy_n(g_hString, COMBINED_STRING_VALUE, 0);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, EMPTY_STRING, STRING_c_str(g_hString) );
@@ -719,6 +735,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_quote_Succeed)
     {
         ///arrange
+		int nResult;
         STRING_HANDLE g_hString;
         g_hString = STRING_construct(TEST_STRING_VALUE);
         umock_c_reset_all_calls();
@@ -727,7 +744,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = STRING_quote(g_hString);
+        nResult = STRING_quote(g_hString);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, QUOTED_TEST_STRING_VALUE, STRING_c_str(g_hString) );
@@ -741,10 +758,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_quote_fail)
     {
         ///arrange
+		STRING_HANDLE str_handle;
+		size_t count;
+		size_t index;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-        STRING_HANDLE str_handle = STRING_construct(TEST_STRING_VALUE);
+        str_handle = STRING_construct(TEST_STRING_VALUE);
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, 2 + strlen(TEST_STRING_VALUE) + 1))
@@ -753,15 +773,17 @@ BEGIN_TEST_SUITE(strings_unittests)
         umock_c_negative_tests_snapshot();
 
         ///act
-        size_t count = umock_c_negative_tests_call_count();
-        for (size_t index = 0; index < count; index++)
+        count = umock_c_negative_tests_call_count();
+        for (index = 0; index < count; index++)
         {
-            umock_c_negative_tests_reset();
+            char tmp_msg[64];
+			int nResult;
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            int nResult = STRING_quote(str_handle);
+            nResult = STRING_quote(str_handle);
 
-            char tmp_msg[64];
             sprintf(tmp_msg, "STRING_quote failure in test %zu/%zu", index+1, count);
 
             //assert
@@ -803,6 +825,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_c_str_Success)
     {
         ///arrange
+		const char* s;
         STRING_HANDLE g_hString;
 
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
@@ -811,7 +834,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
         ///act
         g_hString = STRING_construct(TEST_STRING_VALUE);
-        const char* s = STRING_c_str(g_hString);
+        s = STRING_c_str(g_hString);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, s, TEST_STRING_VALUE);
@@ -826,6 +849,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     {
         ///arrange
         STRING_HANDLE g_hString;
+		int nResult;
         g_hString = STRING_construct(TEST_STRING_VALUE);
         umock_c_reset_all_calls();
 
@@ -833,7 +857,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             .IgnoreArgument(1);
 
         ///act
-        int nResult = STRING_empty(g_hString);
+        nResult = STRING_empty(g_hString);
 
         ///assert
         ASSERT_ARE_EQUAL(int, nResult, 0);
@@ -893,11 +917,12 @@ BEGIN_TEST_SUITE(strings_unittests)
     {
         ///arrange
         STRING_HANDLE g_hString;
+		size_t nResult;
         g_hString = STRING_construct(TEST_STRING_VALUE);
         umock_c_reset_all_calls();
 
         ///act
-        size_t nResult = STRING_length(g_hString);
+        nResult = STRING_length(g_hString);
 
         ///assert
         ASSERT_ARE_EQUAL(size_t, nResult, strlen(TEST_STRING_VALUE) );
@@ -936,6 +961,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_clone_succeeds)
     {
         ///arrange
+		STRING_HANDLE result;
         STRING_HANDLE hSource = STRING_construct("aa");
         umock_c_reset_all_calls();
 
@@ -944,7 +970,7 @@ BEGIN_TEST_SUITE(strings_unittests)
         STRICT_EXPECTED_CALL(gballoc_malloc(sizeof("aa")));
 
         ///act
-        STRING_HANDLE result = STRING_clone(hSource);
+        result = STRING_clone(hSource);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, result);
@@ -961,10 +987,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_clone_fail)
     {
         //arrange
+		STRING_HANDLE str_handle;
+		size_t count;
+		size_t index;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-        STRING_HANDLE str_handle = STRING_construct("aa");
+        str_handle = STRING_construct("aa");
         umock_c_reset_all_calls();
 
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
@@ -974,15 +1003,17 @@ BEGIN_TEST_SUITE(strings_unittests)
         umock_c_negative_tests_snapshot();
 
         //act
-        size_t count = umock_c_negative_tests_call_count();
-        for (size_t index = 0; index < count; index++)
+        count = umock_c_negative_tests_call_count();
+        for (index = 0; index < count; index++)
         {
-            umock_c_negative_tests_reset();
+			STRING_HANDLE str_result;
+            char tmp_msg[64];
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            STRING_HANDLE str_result = STRING_clone(str_handle);
+            str_result = STRING_clone(str_handle);
 
-            char tmp_msg[64];
             sprintf(tmp_msg, "STRING_clone failure in test %zu/%zu", index+1, count);
 
             //assert
@@ -1024,13 +1055,15 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_construct_n_succeeds_with_2_char)
     {
         ///arrange
+		STRING_HANDLE result;
+
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
         STRICT_EXPECTED_CALL(gballoc_malloc(3))
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE result = STRING_construct_n("qq", 2);
+        result = STRING_construct_n("qq", 2);
 
         ///assert
         ASSERT_IS_NOT_NULL(result);
@@ -1045,13 +1078,14 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_construct_n_succeeds_with_3_char_out_of_five)
     {
         ///arrange
+		STRING_HANDLE result;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument(1);
         STRICT_EXPECTED_CALL(gballoc_malloc(4))
             .IgnoreArgument(1);
 
         ///act
-        STRING_HANDLE result = STRING_construct_n("12345", 3);
+        result = STRING_construct_n("12345", 3);
 
         ///assert
         ASSERT_IS_NOT_NULL(result);
@@ -1065,6 +1099,8 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_construct_n_fail)
     {
         //arrange
+		size_t count;
+		size_t index;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
@@ -1076,15 +1112,17 @@ BEGIN_TEST_SUITE(strings_unittests)
         umock_c_negative_tests_snapshot();
 
         //act
-        size_t count = umock_c_negative_tests_call_count();
-        for (size_t index = 0; index < count; index++)
+        count = umock_c_negative_tests_call_count();
+        for (index = 0; index < count; index++)
         {
+			STRING_HANDLE result;
+            char tmp_msg[64];
+
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            STRING_HANDLE result = STRING_construct_n("qq", 2);
+            result = STRING_construct_n("qq", 2);
 
-            char tmp_msg[64];
             sprintf(tmp_msg, "STRING_construct_n failure in test %zu/%zu", index+1, count);
 
             //assert
@@ -1099,11 +1137,12 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_compare_s1_NULL)
     {
         ///arrange
+		int result;
         STRING_HANDLE h2 = STRING_construct("bb");
         umock_c_reset_all_calls();
 
         ///act
-        int result = STRING_compare(NULL, h2);
+        result = STRING_compare(NULL, h2);
 
         ///assert
         ASSERT_ARE_EQUAL(int, 1, result);
@@ -1117,11 +1156,12 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_compare_s2_NULL)
     {
         ///arrange
+		int result;
         STRING_HANDLE h1 = STRING_construct("aa");
         umock_c_reset_all_calls();
 
         ///act
-        int result = STRING_compare(h1, NULL);
+        result = STRING_compare(h1, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(int, -1, result);
@@ -1150,12 +1190,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_compare_s1_first_SUCCEED)
     {
         ///arrange
+		int result;
         STRING_HANDLE h1 = STRING_construct("aa");
         STRING_HANDLE h2 = STRING_construct("bb");
         umock_c_reset_all_calls();
 
         ///act
-        int result = STRING_compare(h1, h2);
+        result = STRING_compare(h1, h2);
 
         ///assert
         ASSERT_ARE_EQUAL(int, -1, result);
@@ -1170,12 +1211,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_compare_s2_first_SUCCEED)
     {
         ///arrange
+		int result;
         STRING_HANDLE h1 = STRING_construct("aa");
         STRING_HANDLE h2 = STRING_construct("bb");
         umock_c_reset_all_calls();
 
         ///act
-        int result = STRING_compare(h2, h1);
+        result = STRING_compare(h2, h1);
 
         ///assert
         ASSERT_ARE_EQUAL(int, 1, result);
@@ -1191,12 +1233,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_compare_Equal_SUCCEED)
     {
         ///arrange
+		int result;
         STRING_HANDLE h1 = STRING_construct("a1234");
         STRING_HANDLE h2 = STRING_construct("a1234");
         umock_c_reset_all_calls();
 
         ///act
-        int result = STRING_compare(h1, h2);
+        result = STRING_compare(h1, h2);
 
         ///assert
         ASSERT_ARE_EQUAL(int, 0, result);
@@ -1232,9 +1275,11 @@ BEGIN_TEST_SUITE(strings_unittests)
     /*Tests_SRS_STRING_02_020: [The string shall end with " (quote).] */
     TEST_FUNCTION(STRING_new_JSON_succeeds)
     {
-        for (size_t i = 0; i < sizeof(JSONtests) / sizeof(JSONtests[0]); i++)
+		size_t i;
+        for (i = 0; i < sizeof(JSONtests) / sizeof(JSONtests[0]); i++)
         {
             ///arrange
+			STRING_HANDLE result;
             umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
@@ -1242,7 +1287,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             STRICT_EXPECTED_CALL(gballoc_malloc(strlen(JSONtests[i].expectedJSON) + 1));
 
             ///act
-            STRING_HANDLE result = STRING_new_JSON(JSONtests[i].source);
+            result = STRING_new_JSON(JSONtests[i].source);
 
             ///assert
             ASSERT_ARE_EQUAL(char_ptr, JSONtests[i].expectedJSON, STRING_c_str(result));
@@ -1257,6 +1302,8 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_new_JSON_fails)
     {
         //arrange
+		size_t count;
+		size_t index;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
@@ -1266,15 +1313,17 @@ BEGIN_TEST_SUITE(strings_unittests)
         umock_c_negative_tests_snapshot();
 
         //act
-        size_t count = umock_c_negative_tests_call_count();
-        for (size_t index = 0; index < count; index++)
+        count = umock_c_negative_tests_call_count();
+        for (index = 0; index < count; index++)
         {
-            umock_c_negative_tests_reset();
+            char tmp_msg[64];
+			STRING_HANDLE result;
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            STRING_HANDLE result = STRING_new_JSON("ab");
+            result = STRING_new_JSON("ab");
 
-            char tmp_msg[64];
             sprintf(tmp_msg, "STRING_new_JSON failure in test %zu/%zu", index+1, count);
 
             //assert
@@ -1319,14 +1368,14 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_from_byte_array_succeeds)
     {
         ///arrange
-
+		STRING_HANDLE result;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument_size();
 
         STRICT_EXPECTED_CALL(gballoc_malloc(1 + 1));
 
         ///act
-        STRING_HANDLE result = STRING_from_byte_array((const unsigned char*)"a", 1);
+        result = STRING_from_byte_array((const unsigned char*)"a", 1);
 
         ///assert
         ASSERT_IS_NOT_NULL(result);
@@ -1341,14 +1390,14 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_from_byte_array_succeeds_2)
     {
         ///arrange
-
+		STRING_HANDLE result;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument_size();
 
         STRICT_EXPECTED_CALL(gballoc_malloc(1 + 0));
 
         ///act
-        STRING_HANDLE result = STRING_from_byte_array(NULL, 0);
+        result = STRING_from_byte_array(NULL, 0);
 
         ///assert
         ASSERT_IS_NOT_NULL(result);
@@ -1363,7 +1412,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_from_byte_array_fails_1)
     {
         ///arrange
-
+		STRING_HANDLE result;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument_size();
         
@@ -1374,7 +1423,7 @@ BEGIN_TEST_SUITE(strings_unittests)
             .IgnoreArgument_ptr();
 
         ///act
-        STRING_HANDLE result = STRING_from_byte_array((const unsigned char*)"a", 1);
+        result = STRING_from_byte_array((const unsigned char*)"a", 1);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -1387,13 +1436,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_from_byte_array_fails_2)
     {
         ///arrange
-
+		STRING_HANDLE result;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument_size()
             .SetReturn(NULL);
 
         ///act
-        STRING_HANDLE result = STRING_from_byte_array((const unsigned char*)"a", 1);
+        result = STRING_from_byte_array((const unsigned char*)"a", 1);
 
         ///assert
         ASSERT_IS_NULL(result);
@@ -1420,13 +1469,14 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_sprintf_format_NULL_fail)
     {
         ///arrange
+		int str_result;
         STRING_HANDLE str_handle = STRING_new();
         ASSERT_IS_NOT_NULL(str_handle);
 
         umock_c_reset_all_calls();
 
         ///act
-        int str_result = STRING_sprintf(str_handle, NULL, TEST_STRING_VALUE);
+        str_result = STRING_sprintf(str_handle, NULL, TEST_STRING_VALUE);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, str_result, 0);
@@ -1439,6 +1489,7 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_sprintf_format_succeed)
     {
         ///arrange
+		int str_result;
         STRING_HANDLE str_handle = STRING_construct(INITIAL_STRING_VALUE);
         ASSERT_IS_NOT_NULL(str_handle);
 
@@ -1447,7 +1498,7 @@ BEGIN_TEST_SUITE(strings_unittests)
         EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
 
         ///act
-        int str_result = STRING_sprintf(str_handle, FORMAT_STRING, TEST_STRING_VALUE);
+        str_result = STRING_sprintf(str_handle, FORMAT_STRING, TEST_STRING_VALUE);
 
         ///assert
         ASSERT_ARE_EQUAL(int, str_result, 0);
@@ -1462,13 +1513,14 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_sprintf_format_Empty_String_succeed)
     {
         ///arrange
+		int str_result;
         STRING_HANDLE str_handle = STRING_construct(INITIAL_STRING_VALUE);
         ASSERT_IS_NOT_NULL(str_handle);
 
         umock_c_reset_all_calls();
 
         ///act
-        int str_result = STRING_sprintf(str_handle, EMPTY_STRING);
+        str_result = STRING_sprintf(str_handle, EMPTY_STRING);
 
         ///assert
         ASSERT_ARE_EQUAL(int, str_result, 0);
@@ -1483,10 +1535,13 @@ BEGIN_TEST_SUITE(strings_unittests)
     TEST_FUNCTION(STRING_sprintf_format_fail)
     {
         ///arrange
+		size_t count;
+		size_t index;
         int negativeTestsInitResult = umock_c_negative_tests_init();
+		STRING_HANDLE str_handle;
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-        STRING_HANDLE str_handle = STRING_construct(INITIAL_STRING_VALUE);
+        str_handle = STRING_construct(INITIAL_STRING_VALUE);
         ASSERT_IS_NOT_NULL(str_handle);
 
         umock_c_reset_all_calls();
@@ -1496,15 +1551,17 @@ BEGIN_TEST_SUITE(strings_unittests)
         umock_c_negative_tests_snapshot();
 
         //act
-        size_t count = umock_c_negative_tests_call_count();
-        for (size_t index = 0; index < count; index++)
+        count = umock_c_negative_tests_call_count();
+        for (index = 0; index < count; index++)
         {
-            umock_c_negative_tests_reset();
+            char tmp_msg[64];
+			int str_result;
+
+			umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            int str_result = STRING_sprintf(str_handle, FORMAT_STRING, TEST_STRING_VALUE);
+            str_result = STRING_sprintf(str_handle, FORMAT_STRING, TEST_STRING_VALUE);
 
-            char tmp_msg[64];
             sprintf(tmp_msg, "STRING_sprintf failure in test %zu/%zu", index+1, count);
 
             ///assert

--- a/tests/template_ut/template_ut.c
+++ b/tests/template_ut/template_ut.c
@@ -322,6 +322,7 @@ BEGIN_TEST_SUITE(template_ut)
     {
         ///arrange
         TARGET_RESULT result;
+		size_t i;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
@@ -350,13 +351,13 @@ BEGIN_TEST_SUITE(template_ut)
 
         umock_c_negative_tests_snapshot();
 
-        for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+        for (i = 0; i < umock_c_negative_tests_call_count(); i++)
         {
+            char temp_str[128];
 
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(i);
 
-            char temp_str[128];
             (void)sprintf(temp_str, "On failed call %zu", i);
 
             ///act
@@ -378,6 +379,9 @@ BEGIN_TEST_SUITE(template_ut)
         ///arrange
         TARGET_RESULT result;
         int negativeTestsInitResult = umock_c_negative_tests_init();
+        bool runTest[] = { true, false, true };
+		size_t i;
+
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
         /**
@@ -393,18 +397,17 @@ BEGIN_TEST_SUITE(template_ut)
         STRICT_EXPECTED_CALL(gballoc_malloc(SIZEOF_FOO_MEMORY));
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
-        bool runTest[] = { true, false, true };
-
         umock_c_negative_tests_snapshot();
 
-        for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+        for (i = 0; i < umock_c_negative_tests_call_count(); i++)
         {
             if (runTest[i])
             {
+                char temp_str[128];
+
                 umock_c_negative_tests_reset();
                 umock_c_negative_tests_fail_call(i);
 
-                char temp_str[128];
                 (void)sprintf(temp_str, "On failed call %zu", i);
 
                 ///act
@@ -426,6 +429,7 @@ BEGIN_TEST_SUITE(template_ut)
     {
         ///arrange
         TARGET_RESULT result;
+		size_t i;
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
@@ -446,13 +450,13 @@ BEGIN_TEST_SUITE(template_ut)
         * Here we are demonstrating how to automatically test an unhappy path from a function that 
         *    we do not implement any mock to replace it.
         */
-        for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+        for (i = 0; i < umock_c_negative_tests_call_count(); i++)
         {
+            char temp_str[128];
 
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(i);
 
-            char temp_str[128];
             (void)sprintf(temp_str, "On failed call %zu", i);
 
             ///act

--- a/tests/tickcounter_freertos_ut/tickcounter_freertos_ut.c
+++ b/tests/tickcounter_freertos_ut/tickcounter_freertos_ut.c
@@ -98,12 +98,13 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
 TEST_FUNCTION(tickcounter_freertos_create_fails)
 {
     ///arrange
+	TICK_COUNTER_HANDLE tickHandle;
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
         .IgnoreArgument(1)
         .SetReturn((void*)NULL);
 
     ///act
-    TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
+    tickHandle = tickcounter_create();
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -116,13 +117,14 @@ TEST_FUNCTION(tickcounter_freertos_create_fails)
 TEST_FUNCTION(tickcounter_freertos_create_succeed)
 {
     ///arrange
+	TICK_COUNTER_HANDLE tickHandle;
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
         .IgnoreArgument(1);
 	STRICT_EXPECTED_CALL(xTaskGetTickCount())
 		.SetReturn(FAKE_TICK_NO_OVERFLOW);
 
     ///act
-    TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
+    tickHandle = tickcounter_create();
 
     ///assert
     ASSERT_IS_NOT_NULL(tickHandle);
@@ -180,11 +182,12 @@ TEST_FUNCTION(tickcounter_freertos_get_current_ms_tick_counter_NULL_fail)
 TEST_FUNCTION(tickcounter_freertos_get_current_ms_current_ms_NULL_fail)
 {
     ///arrange
+	int result;
     TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
     umock_c_reset_all_calls();
 
     ///act
-    int result = tickcounter_get_current_ms(tickHandle, NULL);
+    result = tickcounter_get_current_ms(tickHandle, NULL);
 
     ///assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -198,6 +201,9 @@ TEST_FUNCTION(tickcounter_freertos_get_current_ms_current_ms_NULL_fail)
 TEST_FUNCTION(tickcounter_freertos_get_current_ms_succeed)
 {
 	///arrange
+	tickcounter_ms_t current_ms = 0;
+	int result;
+	TICK_COUNTER_HANDLE tickHandle;
 	STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
 		.IgnoreArgument(1);
 	STRICT_EXPECTED_CALL(xTaskGetTickCount())
@@ -205,12 +211,9 @@ TEST_FUNCTION(tickcounter_freertos_get_current_ms_succeed)
 	STRICT_EXPECTED_CALL(xTaskGetTickCount())
 		.SetReturn((FAKE_TICK_NO_OVERFLOW + FAKE_TICK_INTERVAL));
 
-
-	tickcounter_ms_t current_ms = 0;
-
 	///act
-	TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
-	int result = tickcounter_get_current_ms(tickHandle, &current_ms);
+	tickHandle = tickcounter_create();
+	result = tickcounter_get_current_ms(tickHandle, &current_ms);
 
 	///assert
 	ASSERT_ARE_EQUAL(int, 0, result);
@@ -225,6 +228,10 @@ TEST_FUNCTION(tickcounter_freertos_get_current_ms_succeed)
 TEST_FUNCTION(tickcounter_freertos_get_current_ms_succeed_despite_overflow)
 {
 	///arrange
+	TICK_COUNTER_HANDLE tickHandle;
+	tickcounter_ms_t current_ms = 0;
+	int result;
+
 	STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
 		.IgnoreArgument(1);
 	STRICT_EXPECTED_CALL(xTaskGetTickCount())
@@ -232,12 +239,10 @@ TEST_FUNCTION(tickcounter_freertos_get_current_ms_succeed_despite_overflow)
 	STRICT_EXPECTED_CALL(xTaskGetTickCount())
 		.SetReturn((FAKE_TICK_AFTER_OVERFLOW));
 
-
-	TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
-	tickcounter_ms_t current_ms = 0;
+	tickHandle = tickcounter_create();
 
 	///act
-	int result = tickcounter_get_current_ms(tickHandle, &current_ms);
+	result = tickcounter_get_current_ms(tickHandle, &current_ms);
 
 	///assert
 	ASSERT_ARE_EQUAL(int, 0, result);

--- a/tests/tickcounter_ut/tickcounter_ut.c
+++ b/tests/tickcounter_ut/tickcounter_ut.c
@@ -84,12 +84,13 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
 TEST_FUNCTION(tickcounter_create_fails)
 {
     ///arrange
+	TICK_COUNTER_HANDLE tickHandle;
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
         .IgnoreArgument(1)
         .SetReturn((void*)NULL);
 
     ///act
-    TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
+    tickHandle = tickcounter_create();
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -99,11 +100,12 @@ TEST_FUNCTION(tickcounter_create_fails)
 TEST_FUNCTION(tickcounter_create_succeed)
 {
     ///arrange
+	TICK_COUNTER_HANDLE tickHandle;
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
         .IgnoreArgument(1);
 
     ///act
-    TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
+    tickHandle = tickcounter_create();
 
     ///assert
     ASSERT_IS_NOT_NULL(tickHandle);
@@ -156,11 +158,12 @@ TEST_FUNCTION(tickcounter_get_current_ms_tick_counter_NULL_fail)
 TEST_FUNCTION(tickcounter_get_current_ms_current_ms_NULL_fail)
 {
     ///arrange
+	int result;
     TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
     umock_c_reset_all_calls();
 
     ///act
-    int result = tickcounter_get_current_ms(tickHandle, NULL);
+    result = tickcounter_get_current_ms(tickHandle, NULL);
 
     ///assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -172,13 +175,15 @@ TEST_FUNCTION(tickcounter_get_current_ms_current_ms_NULL_fail)
 TEST_FUNCTION(tickcounter_get_current_ms_succeed)
 {
     ///arrange
+	int result;
+	tickcounter_ms_t current_ms;
     TICK_COUNTER_HANDLE tickHandle = tickcounter_create();
     umock_c_reset_all_calls();
 
-    tickcounter_ms_t current_ms = 0;
+    current_ms = 0;
 
     ///act
-    int result = tickcounter_get_current_ms(tickHandle, &current_ms);
+    result = tickcounter_get_current_ms(tickHandle, &current_ms);
 
     ///assert
     ASSERT_ARE_EQUAL(int, 0, result);

--- a/tests/tlsio_esp8266_ut/tlsio_esp8266_ut.c
+++ b/tests/tlsio_esp8266_ut/tlsio_esp8266_ut.c
@@ -517,13 +517,14 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     TEST_FUNCTION(tlsio_openssl_dowork_withdata__succeed)
     {
         ///arrange
-        g_ssl_read_returns_data = 1;
         TLS_IO_INSTANCE instance;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
+        g_ssl_read_returns_data = 1;
         memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         instance.on_bytes_received = on_bytes_received;
         instance.tlsio_state = TLSIO_STATE_OPEN;
 
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         umock_c_reset_all_calls();
@@ -542,13 +543,14 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     TEST_FUNCTION(tlsio_openssl_dowork_withoutdata__succeed)
     {
         ///arrange
-        g_ssl_read_returns_data = 0;
         TLS_IO_INSTANCE instance;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
+        g_ssl_read_returns_data = 0;
         memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         instance.on_bytes_received = on_bytes_received;
         instance.tlsio_state = TLSIO_STATE_OPEN;
 
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         umock_c_reset_all_calls();
@@ -589,12 +591,13 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         ///arrange
         int result = 0;
         TLS_IO_INSTANCE instance;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
+        unsigned char test_buffer[] = { 0x42, 0x43 };
         memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         instance.tlsio_state = TLSIO_STATE_OPEN;
         g_ssl_write_success = 1;
-        unsigned char test_buffer[] = { 0x42, 0x43 };
 
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         umock_c_reset_all_calls();
@@ -636,11 +639,12 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         ///arrange
         int result = 0;
         TLS_IO_INSTANCE instance;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
         memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         instance.tlsio_state = TLSIO_STATE_OPEN;
         g_ssl_write_success = 1;
 
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         ///act
@@ -657,12 +661,13 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         ///arrange
         int result = 0;
         TLS_IO_INSTANCE instance;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
+        unsigned char test_buffer[] = {0x42};
         memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         instance.tlsio_state = TLSIO_STATE_OPEN;
         g_ssl_write_success = 1;
-        unsigned char test_buffer[] = {0x42};
 
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         ///act
@@ -678,10 +683,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         int result;
+        TLS_IO_INSTANCE instance;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
-        TLS_IO_INSTANCE instance;
         memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ///act
@@ -699,12 +704,13 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         ///arrange
         int result = 0;
         TLS_IO_INSTANCE instance;
+        unsigned char test_buffer[] = { 0x42, 0x43 };
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
         memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         instance.tlsio_state = TLSIO_STATE_OPEN;
         g_ssl_write_success = 0;
-        unsigned char test_buffer[] = { 0x42, 0x43 };
 
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         umock_c_reset_all_calls();
@@ -736,9 +742,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         ///arrange
         int result;
         TLS_IO_INSTANCE instance;
-        memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         SSL_CTX *ctx;
         SSL *ssl;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
+        memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         g_ssl_TLSv1clientmethod_success = 0;
         ctx = SSL_CTX_new(TLSv1_client_method());
         ASSERT_IS_NULL(ctx);
@@ -753,7 +760,7 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         instance.ssl = ssl;
         instance.ssl_context = ctx;
 
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         umock_c_reset_all_calls();
@@ -787,9 +794,9 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         ///arrange
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        TLS_IO_INSTANCE instance;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
-        TLS_IO_INSTANCE instance;
         memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ///act
@@ -832,9 +839,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         ///arrange
         int result;
         TLS_IO_INSTANCE instance;
-        memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         SSL_CTX *ctx;
         SSL *ssl;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
+        memset(&instance, 0, sizeof(TLS_IO_INSTANCE));
         g_ssl_TLSv1clientmethod_success = 0;
         ctx = SSL_CTX_new(TLSv1_client_method());
         ASSERT_IS_NULL(ctx);
@@ -849,7 +857,7 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         instance.ssl_context = ctx;
         instance.on_io_error = test_on_io_error;
 
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         umock_c_reset_all_calls();
@@ -881,10 +889,11 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     TEST_FUNCTION(tlsio_openssl_destroy__succeed)
     {
         ///arrange
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
         TLS_IO_INSTANCE* instance = (TLS_IO_INSTANCE*)malloc(sizeof(TLS_IO_INSTANCE));
         memset(instance, 0, sizeof(TLS_IO_INSTANCE));
         instance->tlsio_state = TLSIO_STATE_NOT_OPEN;
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         umock_c_reset_all_calls();
         STRICT_EXPECTED_CALL(free(instance));
@@ -917,10 +926,11 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     TEST_FUNCTION(tlsio_openssl_destroy_wrong_state__failed)
     {
         ///arrange
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
         TLS_IO_INSTANCE* instance = (TLS_IO_INSTANCE*)malloc(sizeof(TLS_IO_INSTANCE));
         memset(instance, 0, sizeof(TLS_IO_INSTANCE));
         instance->tlsio_state = TLSIO_STATE_OPENING;
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         umock_c_reset_all_calls();
@@ -946,6 +956,8 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
+        int result;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
         memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
 
         tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
@@ -961,8 +973,7 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         g_ssl_set_fd_success = 1;
         g_ssl_connect_success = 1;
 
-        int result;
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         g_ssl_fd_isset = 0;
@@ -1031,8 +1042,9 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
         int result;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
         g_gethostbyname_success = 1;
         g_socket_success = 1;
         g_setsockopt_success = 1;
@@ -1043,7 +1055,7 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         g_ssl_new_success = 1;
         g_ssl_set_fd_success = 1;
         g_ssl_connect_success = 1;
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         tls_io_instance.tlsio_state = TLSIO_STATE_OPENING;
 
@@ -1064,6 +1076,7 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         int result;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
         g_gethostbyname_success = 1;
         g_socket_success = 1;
         g_setsockopt_success = 1;
@@ -1074,7 +1087,7 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         g_ssl_new_success = 1;
         g_ssl_set_fd_success = 1;
         g_ssl_connect_success = 1;
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         ///act
@@ -1100,10 +1113,12 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
+        int result;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
+        int retry = 0;
         memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
         tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
-        int result;
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 0;
         g_socket_success = 1;
@@ -1118,7 +1133,6 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
 
         umock_c_reset_all_calls();
         
-        int retry = 0;
         do{
             STRICT_EXPECTED_CALL(netconn_gethostbyname(IGNORED_PTR_ARG,IGNORED_PTR_ARG)).IgnoreArgument(1).IgnoreArgument(2);  
         }while(retry++ < MAX_RETRY);
@@ -1147,10 +1161,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 0;
@@ -1202,10 +1216,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 1;
@@ -1258,10 +1272,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 1;
@@ -1320,10 +1334,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 1;
@@ -1386,10 +1400,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 1;
@@ -1452,10 +1466,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 1;
@@ -1502,10 +1516,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 1;
@@ -1571,10 +1585,10 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 1;
@@ -1645,10 +1659,11 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     {
         ///arrange
         TLS_IO_INSTANCE tls_io_instance;
-        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
-        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        int retry = 0;
+        memset(&tls_io_instance, 0, sizeof(TLS_IO_INSTANCE));
+        tls_io_instance.tlsio_state = TLSIO_STATE_NOT_OPEN;
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
         g_gethostbyname_success = 1;
         g_socket_success = 1;
@@ -1686,7 +1701,6 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         STRICT_EXPECTED_CALL(SSL_new(IGNORED_PTR_ARG)).IgnoreArgument(1);
         
         STRICT_EXPECTED_CALL(SSL_set_fd(IGNORED_PTR_ARG, IGNORED_NUM_ARG)).IgnoreArgument(1).IgnoreArgument(2);
-        int retry = 0;
         while(retry < MAX_RETRY){
             STRICT_EXPECTED_CALL(lwip_select(IGNORED_NUM_ARG, IGNORED_PTR_ARG, 
               IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).IgnoreArgument(1).IgnoreArgument(2).IgnoreArgument(3).IgnoreArgument(4).IgnoreArgument(5);
@@ -1722,11 +1736,14 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
     TEST_FUNCTION(tlsio_openssl_create_malloc__failed)
     {
         ///arrange
+        OPTIONHANDLER_HANDLE result;
+		const IO_INTERFACE_DESCRIPTION* tlsioInterfaces;
         int negativeTestsInitResult = umock_c_negative_tests_init();
+		size_t i;
+
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-        OPTIONHANDLER_HANDLE result;
-        const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_openssl_get_interface_description();
+        tlsioInterfaces = tlsio_openssl_get_interface_description();
         ASSERT_IS_NOT_NULL(tlsioInterfaces);
 
         umock_c_reset_all_calls();
@@ -1735,8 +1752,7 @@ BEGIN_TEST_SUITE(tlsio_esp8266_ut)
         
         umock_c_negative_tests_snapshot();
 
-
-        for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+        for (i = 0; i < umock_c_negative_tests_call_count(); i++)
         {
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(i);

--- a/tests/tlsioarduino_ut/tlsioarduino_ut.c
+++ b/tests/tlsioarduino_ut/tlsioarduino_ut.c
@@ -156,7 +156,8 @@ static int my_sslClient_read_count;
 int my_sslClient_read(uint8_t *buf, size_t size)
 {
     const char* readPtr = (const char*)my_sslClient_read_buffer;
-    for (int i = 0; i < my_sslClient_read_count; i++)
+	int i;
+    for (i = 0; i < my_sslClient_read_count; i++)
     {
         readPtr += my_sslClient_read_return_list[i];
     }
@@ -1683,6 +1684,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
     TEST_FUNCTION(tlsio_arduino_close__retry_without_success_and_without_callback__failed)
     {
         ///arrange
+		size_t i;
         CONCRETE_IO_HANDLE tlsioHandle;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_arduino_get_interface_description();
@@ -1699,7 +1701,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         STRICT_EXPECTED_CALL(sslClient_connect(SSLCLIENT_IP_ADDRESS, TEST_CREATE_CONNECTION_PORT));
         STRICT_EXPECTED_CALL(sslClient_connected());
         STRICT_EXPECTED_CALL(sslClient_stop());
-        for (size_t i = 0; i < 11; i++)
+        for (i = 0; i < 11; i++)
         {
             STRICT_EXPECTED_CALL(sslClient_connected());
         }
@@ -1719,7 +1721,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         ASSERT_ARE_EQUAL(int, 0, result);
 
         ///act
-        for (size_t i = 0; i < 10; i++)
+        for (i = 0; i < 10; i++)
         {
             ASSERT_ARE_EQUAL(int, (int)TLSIO_ARDUINO_STATE_CLOSING, (int)tlsio_arduino_get_state(tlsioHandle));
             tlsioInterfaces->concrete_io_dowork(tlsioHandle);
@@ -1743,6 +1745,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
     TEST_FUNCTION(tlsio_arduino_close__retry_without_success__failed)
     {
         ///arrange
+		size_t i;
         CONCRETE_IO_HANDLE tlsioHandle;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_arduino_get_interface_description();
@@ -1759,7 +1762,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         STRICT_EXPECTED_CALL(sslClient_connect(SSLCLIENT_IP_ADDRESS, TEST_CREATE_CONNECTION_PORT));
         STRICT_EXPECTED_CALL(sslClient_connected());
         STRICT_EXPECTED_CALL(sslClient_stop());
-        for (size_t i = 0; i < 11; i++)
+        for (i = 0; i < 11; i++)
         {
             STRICT_EXPECTED_CALL(sslClient_connected());
         }
@@ -1780,7 +1783,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         CleanCallbackCounters();
 
         ///act
-        for (size_t i = 0; i < 10; i++)
+        for (i = 0; i < 10; i++)
         {
             ASSERT_ARE_EQUAL(int, (int)TLSIO_ARDUINO_STATE_CLOSING, (int)tlsio_arduino_get_state(tlsioHandle));
             tlsioInterfaces->concrete_io_dowork(tlsioHandle);
@@ -1802,6 +1805,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
     TEST_FUNCTION(tlsio_arduino_close__retry_10_times__succeed)
     {
         ///arrange
+		size_t i;
         CONCRETE_IO_HANDLE tlsioHandle;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_arduino_get_interface_description();
@@ -1818,7 +1822,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         STRICT_EXPECTED_CALL(sslClient_connect(SSLCLIENT_IP_ADDRESS, TEST_CREATE_CONNECTION_PORT));
         STRICT_EXPECTED_CALL(sslClient_connected());
         STRICT_EXPECTED_CALL(sslClient_stop());
-        for (size_t i = 0; i < 11; i++)
+        for (i = 0; i < 11; i++)
         {
             STRICT_EXPECTED_CALL(sslClient_connected());
         }
@@ -1839,7 +1843,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         CleanCallbackCounters();
 
         ///act
-        for (size_t i = 0; i < 10; i++)
+        for (i = 0; i < 10; i++)
         {
             ASSERT_ARE_EQUAL(int, (int)TLSIO_ARDUINO_STATE_CLOSING, (int)tlsio_arduino_get_state(tlsioHandle));
             tlsioInterfaces->concrete_io_dowork(tlsioHandle);
@@ -2290,6 +2294,8 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
     TEST_FUNCTION(tlsio_arduino_open__retry_without_success_without_callback__failed)
     {
         ///arrange
+		size_t i;
+		TLSIO_ARDUINO_STATE state;
         CONCRETE_IO_HANDLE tlsioHandle;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_arduino_get_interface_description();
@@ -2304,7 +2310,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         STRICT_EXPECTED_CALL(sslClient_hostByName(TEST_CREATE_CONNECTION_HOST_NAME, IGNORED_PTR_ARG)).IgnoreArgument(2);
         STRICT_EXPECTED_CALL(sslClient_connected());
         STRICT_EXPECTED_CALL(sslClient_connect(SSLCLIENT_IP_ADDRESS, TEST_CREATE_CONNECTION_PORT));
-        for (size_t i = 0; i < 11; i++)
+        for (i = 0; i < 11; i++)
         {
             STRICT_EXPECTED_CALL(sslClient_connected());
         }
@@ -2320,11 +2326,11 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         ASSERT_ARE_EQUAL(int, 0, result);
 
         ///act
-        for (size_t i = 0; i < 10; i++)
+        for (i = 0; i < 10; i++)
         {
             char temp[100];
             sprintf(temp, "on failed call %zu", i);
-            TLSIO_ARDUINO_STATE state = tlsio_arduino_get_state(tlsioHandle);
+            state = tlsio_arduino_get_state(tlsioHandle);
             ASSERT_ARE_EQUAL_WITH_MSG(TLSIO_ARDUINO_STATE, TLSIO_ARDUINO_STATE_OPENING, state, temp);
             tlsioInterfaces->concrete_io_dowork(tlsioHandle);
         }
@@ -2333,7 +2339,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
         ASSERT_ARE_EQUAL(int, 1, currentmalloc_call);
         ASSERT_CALLBACK_COUNTERS(0, 0, 0, 0, 0);
-        TLSIO_ARDUINO_STATE state = tlsio_arduino_get_state(tlsioHandle);
+        state = tlsio_arduino_get_state(tlsioHandle);
         ASSERT_ARE_EQUAL(TLSIO_ARDUINO_STATE, TLSIO_ARDUINO_STATE_ERROR, state);
 
         ///cleanup
@@ -2351,6 +2357,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
     TEST_FUNCTION(tlsio_arduino_open__retry_without_success__failed)
     {
         ///arrange
+		size_t i;
         CONCRETE_IO_HANDLE tlsioHandle;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_arduino_get_interface_description();
@@ -2365,7 +2372,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         STRICT_EXPECTED_CALL(sslClient_hostByName(TEST_CREATE_CONNECTION_HOST_NAME, IGNORED_PTR_ARG)).IgnoreArgument(2);
         STRICT_EXPECTED_CALL(sslClient_connected());
         STRICT_EXPECTED_CALL(sslClient_connect(SSLCLIENT_IP_ADDRESS, TEST_CREATE_CONNECTION_PORT));
-        for (size_t i = 0; i < 11; i++)
+        for (i = 0; i < 11; i++)
         {
             STRICT_EXPECTED_CALL(sslClient_connected());
         }
@@ -2382,7 +2389,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         CleanCallbackCounters();
 
         ///act
-        for (size_t i = 0; i < 10; i++)
+        for (i = 0; i < 10; i++)
         {
             ASSERT_ARE_EQUAL(int, (int)TLSIO_ARDUINO_STATE_OPENING, (int)tlsio_arduino_get_state(tlsioHandle));
             tlsioInterfaces->concrete_io_dowork(tlsioHandle);
@@ -2405,6 +2412,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
     TEST_FUNCTION(tlsio_arduino_open__retry_10_times__succeed)
     {
         ///arrange
+		size_t i;
         CONCRETE_IO_HANDLE tlsioHandle;
         int result;
         const IO_INTERFACE_DESCRIPTION* tlsioInterfaces = tlsio_arduino_get_interface_description();
@@ -2419,7 +2427,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         STRICT_EXPECTED_CALL(sslClient_hostByName(TEST_CREATE_CONNECTION_HOST_NAME, IGNORED_PTR_ARG)).IgnoreArgument(2);
         STRICT_EXPECTED_CALL(sslClient_connected());
         STRICT_EXPECTED_CALL(sslClient_connect(SSLCLIENT_IP_ADDRESS, TEST_CREATE_CONNECTION_PORT));
-        for (size_t i = 0; i < 11; i++)
+        for (i = 0; i < 11; i++)
         {
             STRICT_EXPECTED_CALL(sslClient_connected());
         }
@@ -2436,7 +2444,7 @@ BEGIN_TEST_SUITE(tlsioarduino_ut)
         CleanCallbackCounters();
 
         ///act
-        for (size_t i = 0; i < 10; i++)
+        for (i = 0; i < 10; i++)
         {
             ASSERT_ARE_EQUAL(int, (int)TLSIO_ARDUINO_STATE_OPENING, (int)tlsio_arduino_get_state(tlsioHandle));
             tlsioInterfaces->concrete_io_dowork(tlsioHandle);

--- a/tests/urlencode_ut/urlencode_ut.c
+++ b/tests/urlencode_ut/urlencode_ut.c
@@ -471,12 +471,13 @@ TEST_FUNCTION(URL_new_should_yield_zeroLengthString)
 TEST_FUNCTION(URL_is_hello_world)
 {
     // arrange
+	STRING_HANDLE encodedURL;
     STRING_HANDLE hello = STRING_new();
 
     ASSERT_ARE_EQUAL(int, STRING_concat(hello, "hello world"),0);
 
     // act
-    STRING_HANDLE encodedURL = URL_Encode(hello);
+    encodedURL = URL_Encode(hello);
 
 
     //assert
@@ -489,12 +490,13 @@ TEST_FUNCTION(URL_is_hello_world)
 TEST_FUNCTION(URL_unreserved_mapping)
 {
     // arrange
+	STRING_HANDLE encodedUnreservedURL;
     STRING_HANDLE unreserved = STRING_new();
 
     ASSERT_ARE_EQUAL(int, STRING_concat(unreserved, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._"), 0);
 
     // act
-    STRING_HANDLE encodedUnreservedURL = URL_Encode(unreserved);
+    encodedUnreservedURL = URL_Encode(unreserved);
 
 
     //assert
@@ -507,12 +509,13 @@ TEST_FUNCTION(URL_unreserved_mapping)
 TEST_FUNCTION(URL_path_with_device)
 {
     // arrange
+	STRING_HANDLE encodedPathWithDevice;
     STRING_HANDLE pathWithDevice = STRING_new();
 
     ASSERT_ARE_EQUAL(int, STRING_concat(pathWithDevice, "/getalarm('Le Pichet')"), 0);
 
     // act
-    STRING_HANDLE encodedPathWithDevice = URL_Encode(pathWithDevice);
+    encodedPathWithDevice = URL_Encode(pathWithDevice);
 
 
     //assert
@@ -525,12 +528,13 @@ TEST_FUNCTION(URL_path_with_device)
 TEST_FUNCTION(URL_a_few_bogus_characters)
 {
     // arrange
+	STRING_HANDLE encodedBogusCharacters;
     STRING_HANDLE bogusCharacters = STRING_new();
 
     ASSERT_ARE_EQUAL(int, STRING_concat(bogusCharacters, "{}%"), 0);
 
     // act
-    STRING_HANDLE encodedBogusCharacters = URL_Encode(bogusCharacters);
+    encodedBogusCharacters = URL_Encode(bogusCharacters);
 
 
     //assert
@@ -543,12 +547,13 @@ TEST_FUNCTION(URL_a_few_bogus_characters)
 TEST_FUNCTION(URL_full_IOT_url)
 {
     // arrange
+	STRING_HANDLE encodedFullUrl;
     STRING_HANDLE fullUrl = STRING_new();
     
     ASSERT_ARE_EQUAL(int, STRING_concat(fullUrl, "https://one.two.three.four-five.com/six/Seven('EightNine1234567890.Ten_Eleven')?twelve-thirteen=2015-11-31 HTTP/1.1"), 0);
 
     // act
-    STRING_HANDLE encodedFullUrl = URL_Encode(fullUrl);
+    encodedFullUrl = URL_Encode(fullUrl);
 
     //ASSERT
     ASSERT_IS_NOT_NULL(encodedFullUrl);
@@ -564,12 +569,12 @@ TEST_FUNCTION(URL_Exhaustive_chars)
     for (i = 0; i < numberOfTests; i++)
     {
         //arrange
-
+		STRING_HANDLE encodedOriginal;
         STRING_HANDLE original = STRING_new();
         ASSERT_ARE_EQUAL(int, STRING_concat(original, testVector[i].inputData), 0);
 
         //act
-        STRING_HANDLE encodedOriginal = URL_Encode(original);
+        encodedOriginal = URL_Encode(original);
 
         //assert
         ASSERT_IS_NOT_NULL(encodedOriginal);

--- a/tests/uws_client_ut/uws_client_ut.c
+++ b/tests/uws_client_ut/uws_client_ut.c
@@ -751,6 +751,7 @@ TEST_FUNCTION(when_allocating_memory_for_the_hostname_copy_fails_then_uws_client
 {
     // arrange
     SOCKETIO_CONFIG socketio_config;
+	UWS_CLIENT_HANDLE uws_client;
 
     socketio_config.accepted_socket = NULL;
     socketio_config.hostname = "test_host";
@@ -763,7 +764,7 @@ TEST_FUNCTION(when_allocating_memory_for_the_hostname_copy_fails_then_uws_client
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
     // act
-    UWS_CLIENT_HANDLE uws_client = uws_client_create("test_host", 80, "bbb", false, protocols, sizeof(protocols) / sizeof(protocols[0]));
+    uws_client = uws_client_create("test_host", 80, "bbb", false, protocols, sizeof(protocols) / sizeof(protocols[0]));
 
     // assert
     ASSERT_IS_NULL(uws_client);
@@ -775,6 +776,7 @@ TEST_FUNCTION(when_allocating_memory_for_the_resource_name_copy_fails_then_uws_c
 {
     // arrange
     SOCKETIO_CONFIG socketio_config;
+	UWS_CLIENT_HANDLE uws_client;
 
     socketio_config.accepted_socket = NULL;
     socketio_config.hostname = "test_host";
@@ -790,7 +792,7 @@ TEST_FUNCTION(when_allocating_memory_for_the_resource_name_copy_fails_then_uws_c
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
     // act
-    UWS_CLIENT_HANDLE uws_client = uws_client_create("test_host", 80, "test_resource/1", false, protocols, sizeof(protocols) / sizeof(protocols[0]));
+    uws_client = uws_client_create("test_host", 80, "test_resource/1", false, protocols, sizeof(protocols) / sizeof(protocols[0]));
 
     // assert
     ASSERT_IS_NULL(uws_client);
@@ -832,6 +834,7 @@ TEST_FUNCTION(when_getting_the_socket_interface_description_fails_then_uws_clien
 {
     // arrange
     SOCKETIO_CONFIG socketio_config;
+	UWS_CLIENT_HANDLE uws_client;
 
     socketio_config.accepted_socket = NULL;
     socketio_config.hostname = "test_host";
@@ -851,7 +854,7 @@ TEST_FUNCTION(when_getting_the_socket_interface_description_fails_then_uws_clien
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
     // act
-    UWS_CLIENT_HANDLE uws_client = uws_client_create("test_host", 80, "test_resource/1", false, protocols, sizeof(protocols) / sizeof(protocols[0]));
+    uws_client = uws_client_create("test_host", 80, "test_resource/1", false, protocols, sizeof(protocols) / sizeof(protocols[0]));
 
     // assert
     ASSERT_IS_NULL(uws_client);
@@ -1243,6 +1246,7 @@ TEST_FUNCTION(when_any_call_fails_uws_client_create_with_io_fails)
     // arrange
     SOCKETIO_CONFIG socketio_config;
     UWS_CLIENT_HANDLE uws_client;
+	size_t i;
     static const WS_PROTOCOL two_protocols[] = { { "test_protocol1" },{ "test_protocol2" } };
 
     int negativeTestsInitResult = umock_c_negative_tests_init();
@@ -1276,7 +1280,7 @@ TEST_FUNCTION(when_any_call_fails_uws_client_create_with_io_fails)
 
     umock_c_negative_tests_snapshot();
 
-    for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+    for (i = 0; i < umock_c_negative_tests_call_count(); i++)
     {
         char temp_str[128];
 
@@ -4054,11 +4058,11 @@ TEST_FUNCTION(when_a_65535_bytes_binary_frame_is_received_it_shall_be_indicated_
     UWS_CLIENT_HANDLE uws_client;
     const char test_upgrade_response[] = "HTTP/1.1 101 Switching Protocols\r\n\r\n";
     unsigned char* test_frame = (unsigned char*)malloc(65535 + 4);
+    size_t i;
     test_frame[0] = 0x82;
     test_frame[1] = 0x7E;
     test_frame[2] = 0xFF;
     test_frame[3] = 0xFF;
-    size_t i;
 
     for (i = 0; i < 65535; i++)
     {
@@ -4098,6 +4102,7 @@ TEST_FUNCTION(when_a_65536_bytes_binary_frame_is_received_it_shall_be_indicated_
     UWS_CLIENT_HANDLE uws_client;
     const char test_upgrade_response[] = "HTTP/1.1 101 Switching Protocols\r\n\r\n";
     unsigned char* test_frame = (unsigned char*)malloc(65536 + 10);
+    size_t i;
     test_frame[0] = 0x82;
     test_frame[1] = 0x7F;
     test_frame[2] = 0x00;
@@ -4108,7 +4113,6 @@ TEST_FUNCTION(when_a_65536_bytes_binary_frame_is_received_it_shall_be_indicated_
     test_frame[7] = 0x01;
     test_frame[8] = 0x00;
     test_frame[9] = 0x00;
-    size_t i;
 
     for (i = 0; i < 65536; i++)
     {
@@ -4148,6 +4152,7 @@ TEST_FUNCTION(when_a_65537_bytes_binary_frame_is_received_it_shall_be_indicated_
     UWS_CLIENT_HANDLE uws_client;
     const char test_upgrade_response[] = "HTTP/1.1 101 Switching Protocols\r\n\r\n";
     unsigned char* test_frame = (unsigned char*)malloc(65537 + 10);
+    size_t i;
     test_frame[0] = 0x82;
     test_frame[1] = 0x7F;
     test_frame[2] = 0x00;
@@ -4158,7 +4163,6 @@ TEST_FUNCTION(when_a_65537_bytes_binary_frame_is_received_it_shall_be_indicated_
     test_frame[7] = 0x01;
     test_frame[8] = 0x00;
     test_frame[9] = 0x01;
-    size_t i;
 
     for (i = 0; i < 65537; i++)
     {
@@ -4300,6 +4304,7 @@ TEST_FUNCTION(when_a_65535_byte_binary_frame_is_received_with_64_bit_length_an_e
     UWS_CLIENT_HANDLE uws_client;
     const char test_upgrade_response[] = "HTTP/1.1 101 Switching Protocols\r\n\r\n";
     unsigned char* test_frame = (unsigned char*)malloc(65535 + 10);
+    size_t i;
     test_frame[0] = 0x82;
     test_frame[1] = 0x7F;
     test_frame[2] = 0x00;
@@ -4310,7 +4315,6 @@ TEST_FUNCTION(when_a_65535_byte_binary_frame_is_received_with_64_bit_length_an_e
     test_frame[7] = 0x00;
     test_frame[8] = 0xFF;
     test_frame[9] = 0xFF;
-    size_t i;
 
     for (i = 0; i < 65535; i++)
     {
@@ -4413,6 +4417,7 @@ TEST_FUNCTION(when_the_highest_bit_is_set_in_a_64_bit_length_frame_an_error_is_i
     UWS_CLIENT_HANDLE uws_client;
     const char test_upgrade_response[] = "HTTP/1.1 101 Switching Protocols\r\n\r\n";
     unsigned char* test_frame = (unsigned char*)malloc(65536 + 10);
+    size_t i;
     test_frame[0] = 0x82;
     test_frame[1] = 0x7F;
     test_frame[2] = 0x80;
@@ -4423,7 +4428,6 @@ TEST_FUNCTION(when_the_highest_bit_is_set_in_a_64_bit_length_frame_an_error_is_i
     test_frame[7] = 0x01;
     test_frame[8] = 0x00;
     test_frame[9] = 0x00;
-    size_t i;
 
     for (i = 0; i < 65536; i++)
     {

--- a/tests/vector_ut/vector_ut.c
+++ b/tests/vector_ut/vector_ut.c
@@ -66,9 +66,10 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
 
     TEST_SUITE_INITIALIZE(a)
     {
+		int result;
         TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
 
-        int result = umock_c_init(on_umock_c_error);
+        result = umock_c_init(on_umock_c_error);
         ASSERT_ARE_EQUAL(int, 0, result);
 
         REGISTER_GLOBAL_MOCK_HOOK(gballoc_malloc, my_gballoc_malloc);
@@ -100,11 +101,12 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_create_succeeds)
     {
         ///arrange
+		VECTOR_HANDLE handle;
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument_size();
 
         ///act
-        VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
+        handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
 
         ///assert
         ASSERT_IS_NOT_NULL(handle);
@@ -131,12 +133,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_create_returns_NULL_if_malloc_fails)
     {
         ///arrange
+		VECTOR_HANDLE handle;
 
-        ///act
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
             .IgnoreArgument_size()
             .SetReturn(NULL);
-        VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
+
+		///act
+		handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
 
         ///assert
         ASSERT_IS_NULL(handle);
@@ -147,6 +151,8 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_move_succeeds)
     {
         ///arrange
+		VECTOR_UNITTEST* current;
+		VECTOR_HANDLE test;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {5, 6};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
@@ -157,13 +163,13 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
             .IgnoreArgument_size();
 
         ///act
-        VECTOR_HANDLE test = VECTOR_move(handle);
+        test = VECTOR_move(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(test);
         ASSERT_ARE_EQUAL(size_t, VECTOR_size(test), 2);
         ASSERT_ARE_EQUAL(size_t, VECTOR_size(handle), 0);
-        VECTOR_UNITTEST* current = (VECTOR_UNITTEST *)VECTOR_element(test, 0);
+        current = (VECTOR_UNITTEST *)VECTOR_element(test, 0);
         ASSERT_ARE_EQUAL(int, sItem1.nValue1, current->nValue1);
         ASSERT_ARE_EQUAL(long, sItem1.lValue2, current->lValue2);
         current = (VECTOR_UNITTEST *)VECTOR_element(test, 1);
@@ -191,6 +197,8 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_move_returns_NULL_if_malloc_fails)
     {
         ///arrange
+		VECTOR_HANDLE test;
+		VECTOR_UNITTEST* current;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {5, 6};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
@@ -202,12 +210,12 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
             .SetReturn(NULL);
 
         ///act
-        VECTOR_HANDLE test = VECTOR_move(handle);
+        test = VECTOR_move(handle);
 
         ///assert
         ASSERT_IS_NULL(test);
         ASSERT_ARE_EQUAL(size_t, VECTOR_size(handle), 2);
-        VECTOR_UNITTEST* current = (VECTOR_UNITTEST *)VECTOR_element(handle, 0);
+        current = (VECTOR_UNITTEST *)VECTOR_element(handle, 0);
         ASSERT_ARE_EQUAL(int, sItem1.nValue1, current->nValue1);
         ASSERT_ARE_EQUAL(long, sItem1.lValue2, current->lValue2);
         current = (VECTOR_UNITTEST *)VECTOR_element(handle, 1);
@@ -266,11 +274,12 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_push_back_fails_if_elements_is_NULL)
     {
         ///arrange
+		int result;
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         umock_c_reset_all_calls();
 
         ///act
-        int result = VECTOR_push_back(handle, NULL, 1);
+        result = VECTOR_push_back(handle, NULL, 1);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -284,12 +293,13 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_push_back_fails_if_numElements_is_zero)
     {
         ///arrange
+		int result;
         VECTOR_UNITTEST sItem = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         umock_c_reset_all_calls();
 
         ///act
-        int result = VECTOR_push_back(handle, &sItem, 0);
+        result = VECTOR_push_back(handle, &sItem, 0);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -303,13 +313,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_push_back_succeeds)
     {
         ///arrange
+		int result;
         VECTOR_UNITTEST sItem = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         umock_c_reset_all_calls();
 
         ///act
         STRICT_EXPECTED_CALL(gballoc_realloc(NULL, sizeof(VECTOR_UNITTEST)));
-        int result = VECTOR_push_back(handle, &sItem, 1);
+        result = VECTOR_push_back(handle, &sItem, 1);
 
         ///assert
         ASSERT_ARE_EQUAL(int, 0, result);
@@ -323,6 +334,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_push_back_fails_if_realloc_fails)
     {
         ///arrange
+		int result;
         VECTOR_UNITTEST sItem = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         umock_c_reset_all_calls();
@@ -330,7 +342,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         ///act
         STRICT_EXPECTED_CALL(gballoc_realloc(NULL, sizeof(VECTOR_UNITTEST)))
             .SetReturn(NULL);
-        int result = VECTOR_push_back(handle, &sItem, 1);
+        result = VECTOR_push_back(handle, &sItem, 1);
 
         ///assert
         ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -357,11 +369,12 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_size_succeeds_if_vector_is_empty)
     {
         ///arrange
+		size_t num;
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         umock_c_reset_all_calls();
 
         ///act
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(size_t, 0, num);
@@ -375,13 +388,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_size_succeeds)
     {
         ///arrange
+		size_t num;
         VECTOR_UNITTEST sItem = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem, 1);
         umock_c_reset_all_calls();
 
         ///act
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(size_t, 1, num);
@@ -409,13 +423,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_find_fails_if_pred_is_NULL)
     {
         ///arrange
+		VECTOR_UNITTEST* pfindItem;
         VECTOR_UNITTEST sItem = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem, 1);
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, NULL, &sItem);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, NULL, &sItem);
 
         ///assert
         ASSERT_IS_NULL(pfindItem);
@@ -429,13 +444,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_find_if_succeeds)
     {
         ///arrange
+		VECTOR_UNITTEST* pfindItem;
         VECTOR_UNITTEST sItem = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem, 1);
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem);
 
         ///assert
         ASSERT_IS_NOT_NULL(pfindItem);
@@ -451,14 +467,15 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_find_if_return_null_if_no_match)
     {
         ///arrange
+		VECTOR_UNITTEST* pfindItem;
         VECTOR_UNITTEST sItem1 = {1, 2};
+        VECTOR_UNITTEST sItem2 = {5, 8};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST sItem2 = {5, 8};
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem2);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem2);
 
         ///assert
         ASSERT_IS_NULL(pfindItem);
@@ -503,6 +520,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_clear_succeeds)
     {
         ///arrange
+		size_t num;
         VECTOR_UNITTEST sItem = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem, 1);
@@ -515,7 +533,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         VECTOR_clear(handle);
 
         ///assert
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 0, num);
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
@@ -527,6 +545,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_element_succeeds)
     {
         ///arrange
+		VECTOR_UNITTEST* pResult;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
@@ -535,7 +554,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST* pResult = (VECTOR_UNITTEST*)VECTOR_element(handle, 1);
+        pResult = (VECTOR_UNITTEST*)VECTOR_element(handle, 1);
 
         ///assert
         ASSERT_IS_NOT_NULL(pResult);
@@ -564,6 +583,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_element_fails_if_index_is_out_of_range)
     {
         ///arrange
+		VECTOR_UNITTEST* pResult;
         VECTOR_UNITTEST sItem = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem, 1);
@@ -571,7 +591,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST* pResult = (VECTOR_UNITTEST*)VECTOR_element(handle, 2);
+        pResult = (VECTOR_UNITTEST*)VECTOR_element(handle, 2);
 
         ///assert
         ASSERT_IS_NULL(pResult);
@@ -598,6 +618,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_front_succeeds)
     {
         ///arrange
+		VECTOR_UNITTEST* pResult;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
@@ -606,7 +627,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST* pResult = (VECTOR_UNITTEST*)VECTOR_front(handle);
+        pResult = (VECTOR_UNITTEST*)VECTOR_front(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(pResult);
@@ -622,11 +643,12 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_front_return_null_if_vector_is_empty)
     {
         ///arrange
+		VECTOR_UNITTEST* pResult;
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST* pResult = (VECTOR_UNITTEST*)VECTOR_front(handle);
+        pResult = (VECTOR_UNITTEST*)VECTOR_front(handle);
 
         ///assert
         ASSERT_IS_NULL(pResult);
@@ -640,6 +662,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_back_succeeds)
     {
         ///arrange
+		VECTOR_UNITTEST* pResult;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_UNITTEST sItem3 = {5, 6};
@@ -650,7 +673,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST* pResult = (VECTOR_UNITTEST*)VECTOR_back(handle);
+        pResult = (VECTOR_UNITTEST*)VECTOR_back(handle);
 
         ///assert
         ASSERT_IS_NOT_NULL(pResult);
@@ -679,11 +702,12 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_back_return_null_if_vector_is_empty)
     {
         ///arrange
+		VECTOR_UNITTEST* pResult;
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         umock_c_reset_all_calls();
 
         ///act
-        VECTOR_UNITTEST* pResult = (VECTOR_UNITTEST*)VECTOR_back(handle);
+        pResult = (VECTOR_UNITTEST*)VECTOR_back(handle);
 
         ///assert
         ASSERT_IS_NULL(pResult);
@@ -729,12 +753,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_erase_if_numElements_is_zero)
     {
         ///arrange
+		VECTOR_UNITTEST* pfindItem;
+		size_t num;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         (void)VECTOR_push_back(handle, &sItem2, 1);
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_back(handle);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_back(handle);
         umock_c_reset_all_calls();
 
         ///act
@@ -742,7 +768,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
 
         ///assert
         // Make sure this erase doesn't crash
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 2, num);
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
@@ -754,12 +780,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_erase_succeeds_case_1)
     {
         ///arrange
+		VECTOR_UNITTEST* pfindItem;
+		size_t num;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         (void)VECTOR_push_back(handle, &sItem2, 1);
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         umock_c_reset_all_calls();
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, sizeof(VECTOR_UNITTEST)))
             .IgnoreArgument_ptr();
@@ -768,7 +796,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         VECTOR_erase(handle, pfindItem, 1);
 
         ///assert
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 1, num);
         pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         ASSERT_IS_NULL(pfindItem);
@@ -782,12 +810,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_erase_succeeds_case_2)
     {
         ///arrange
+		VECTOR_UNITTEST* pfindItem;
+		size_t num;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         (void)VECTOR_push_back(handle, &sItem2, 1);
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         umock_c_reset_all_calls();
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
             .IgnoreArgument_ptr();
@@ -796,7 +826,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         VECTOR_erase(handle, pfindItem, 2);
 
         ///assert
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 0, num);
         pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         ASSERT_IS_NULL(pfindItem);
@@ -810,12 +840,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_erase_succeeds_case_3)
     {
         ///arrange
+		size_t num;
+		VECTOR_UNITTEST* pfindItem;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         (void)VECTOR_push_back(handle, &sItem2, 1);
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         umock_c_reset_all_calls();
         STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, IGNORED_NUM_ARG))
             .IgnoreArgument_ptr()
@@ -826,7 +858,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         VECTOR_erase(handle, pfindItem, 1);
 
         ///assert
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 1, num);
         pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         ASSERT_IS_NULL(pfindItem);
@@ -842,19 +874,21 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_erase_numElements_out_of_bound)
     {
         ///arrange
+		size_t num;
+		VECTOR_UNITTEST* pfindItem;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         (void)VECTOR_push_back(handle, &sItem2, 1);
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem2);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem2);
         umock_c_reset_all_calls();
 
         ///act
         VECTOR_erase(handle, pfindItem, 2);
 
         ///assert
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 2, num);
         pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         ASSERT_IS_NOT_NULL(pfindItem);
@@ -870,12 +904,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_erase_elements_out_of_bound_case_1)
     {
         ///arrange
+		VECTOR_UNITTEST* pfindItem;
+		size_t num;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         (void)VECTOR_push_back(handle, &sItem2, 1);
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         pfindItem -= 1;
         umock_c_reset_all_calls();
 
@@ -883,7 +919,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         VECTOR_erase(handle, pfindItem, 1);
 
         ///assert
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 2, num);
         pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         ASSERT_IS_NOT_NULL(pfindItem);
@@ -899,12 +935,14 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_erase_elements_out_of_bound_case_2)
     {
         ///arrange
+		size_t num;
+		VECTOR_UNITTEST* pfindItem;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         (void)VECTOR_push_back(handle, &sItem2, 1);
-        VECTOR_UNITTEST* pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem2);
+        pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem2);
         pfindItem += 2;
         umock_c_reset_all_calls();
 
@@ -912,7 +950,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         VECTOR_erase(handle, pfindItem, 1);
 
         ///assert
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 2, num);
         pfindItem = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         ASSERT_IS_NOT_NULL(pfindItem);
@@ -928,12 +966,15 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
     TEST_FUNCTION(VECTOR_erase_elements_misaligned)
     {
         ///arrange
+		VECTOR_UNITTEST* pResult;
+		void* pfindItem;
+		size_t num;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_UNITTEST sItem2 = {3, 4};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         (void)VECTOR_push_back(handle, &sItem1, 1);
         (void)VECTOR_push_back(handle, &sItem2, 1);
-        void* pfindItem = VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
+        pfindItem = VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         pfindItem = (void*)(((unsigned char*)pfindItem) + 0x1);
         umock_c_reset_all_calls();
 
@@ -941,9 +982,9 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
         VECTOR_erase(handle, pfindItem, 1);
 
         ///assert
-        size_t num = VECTOR_size(handle);
+        num = VECTOR_size(handle);
         ASSERT_ARE_EQUAL(size_t, 2, num);
-        VECTOR_UNITTEST* pResult = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
+        pResult = (VECTOR_UNITTEST*)VECTOR_find_if(handle, VECTOR_UNITTEST_isEqual, &sItem1);
         ASSERT_IS_NOT_NULL(pfindItem);
         ASSERT_ARE_EQUAL(size_t, sItem1.nValue1, pResult->nValue1);
         ASSERT_ARE_EQUAL(long, sItem1.lValue2, pResult->lValue2);
@@ -959,19 +1000,21 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
 
     TEST_FUNCTION(VECTOR_push_back_multiple_elements_succeeds)
     {
-            ///arrange
+        ///arrange
+		size_t nIndex;
+		VECTOR_UNITTEST* pResult;
+        int result = 0;
         VECTOR_UNITTEST sItem1 = {1, 2};
         VECTOR_HANDLE handle = VECTOR_create(sizeof(VECTOR_UNITTEST));
         umock_c_reset_all_calls();
-        for (size_t nIndex = 0; nIndex < NUM_ITEM_PUSH_BACK; nIndex++)
+        for (nIndex = 0; nIndex < NUM_ITEM_PUSH_BACK; nIndex++)
         {
             STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, (nIndex + 1) * sizeof(VECTOR_UNITTEST)))
                 .IgnoreArgument_ptr();
         }
 
         ///act
-        int result = 0;
-        for (size_t nIndex = 0; (nIndex < NUM_ITEM_PUSH_BACK) && (result == 0); nIndex++)
+        for (nIndex = 0; (nIndex < NUM_ITEM_PUSH_BACK) && (result == 0); nIndex++)
         {
             sItem1.nValue1++;
             sItem1.lValue2++;
@@ -980,7 +1023,7 @@ BEGIN_TEST_SUITE(Vector_UnitTests)
 
         ///assert
         ASSERT_ARE_EQUAL(int, 0, result);
-        VECTOR_UNITTEST* pResult = (VECTOR_UNITTEST*)VECTOR_back(handle);
+        pResult = (VECTOR_UNITTEST*)VECTOR_back(handle);
         ASSERT_IS_NOT_NULL(pResult);
         ASSERT_ARE_EQUAL(size_t, sItem1.nValue1, pResult->nValue1);
         ASSERT_ARE_EQUAL(long, sItem1.lValue2, pResult->lValue2);

--- a/tests/wsio_ut/wsio_ut.c
+++ b/tests/wsio_ut/wsio_ut.c
@@ -411,6 +411,7 @@ TEST_FUNCTION(wsio_create_with_NULL_hostname_field_fails)
 TEST_FUNCTION(wsio_create_with_NULL_resource_name_field_fails)
 {
     // arrange
+	CONCRETE_IO_HANDLE wsio;
     WSIO_CONFIG wsio_config;
     wsio_config.hostname = TEST_HOST_ADDRESS;
     wsio_config.port = 443;
@@ -420,7 +421,7 @@ TEST_FUNCTION(wsio_create_with_NULL_resource_name_field_fails)
     wsio_config.underlying_io_parameters = NULL;
 
     // act
-    CONCRETE_IO_HANDLE wsio = wsio_get_interface_description()->concrete_io_create(&wsio_config);
+    wsio = wsio_get_interface_description()->concrete_io_create(&wsio_config);
 
     // assert
     ASSERT_IS_NULL(wsio);
@@ -453,11 +454,12 @@ TEST_FUNCTION(wsio_create_with_NULL_protocol_field_fails)
 TEST_FUNCTION(when_allocating_memory_fails_wsio_create_fails)
 {
     // arrange
+	CONCRETE_IO_HANDLE wsio;
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
         .SetReturn(NULL);
 
     // act
-    CONCRETE_IO_HANDLE wsio = wsio_get_interface_description()->concrete_io_create(&default_wsio_config);
+    wsio = wsio_get_interface_description()->concrete_io_create(&default_wsio_config);
 
     // assert
     ASSERT_IS_NULL(wsio);

--- a/tests/xio_ut/xio_ut.c
+++ b/tests/xio_ut/xio_ut.c
@@ -226,11 +226,12 @@ TEST_FUNCTION_CLEANUP(method_cleanup)
 TEST_FUNCTION(xio_create_with_all_args_except_interface_description_NULL_succeeds)
 {
     // arrange
+	XIO_HANDLE result;
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(test_xio_create(NULL));
 
     // act
-    XIO_HANDLE result = xio_create(&test_io_description, NULL);
+    result = xio_create(&test_io_description, NULL);
 
     // assert
     ASSERT_IS_NOT_NULL(result);
@@ -244,11 +245,12 @@ TEST_FUNCTION(xio_create_with_all_args_except_interface_description_NULL_succeed
 TEST_FUNCTION(xio_create_passes_the_args_to_the_concrete_io_implementation)
 {
     // arrange
+	XIO_HANDLE result;
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(test_xio_create((void*)0x4243));
 
     // act
-    XIO_HANDLE result = xio_create(&test_io_description, (void*)0x4243);
+    result = xio_create(&test_io_description, (void*)0x4243);
 
     // assert
     ASSERT_IS_NOT_NULL(result);
@@ -262,13 +264,14 @@ TEST_FUNCTION(xio_create_passes_the_args_to_the_concrete_io_implementation)
 TEST_FUNCTION(when_concrete_xio_create_fails_then_xio_create_fails)
 {
     // arrange
+	XIO_HANDLE result;
     STRICT_EXPECTED_CALL(test_xio_create(NULL))
         .SetReturn((CONCRETE_IO_HANDLE)NULL);
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
     // act
-    XIO_HANDLE result = xio_create(&test_io_description, NULL);
+    result = xio_create(&test_io_description, NULL);
 
     // assert
     ASSERT_IS_NULL(result);
@@ -483,13 +486,14 @@ TEST_FUNCTION(when_concrete_xio_setoption_is_NULL_then_xio_create_fails)
 TEST_FUNCTION(when_allocating_memory_Fails_then_xio_create_fails)
 {
     // arrange
+	XIO_HANDLE result;
     g_fail_alloc_calls = 1;
 
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
         .SetReturn((void*)NULL);
 
     // act
-    XIO_HANDLE result = xio_create(&test_io_description, NULL);
+    result = xio_create(&test_io_description, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -535,13 +539,14 @@ TEST_FUNCTION(xio_destroy_with_null_handle_does_nothing)
 TEST_FUNCTION(xio_open_calls_the_underlying_concrete_xio_open_and_succeeds)
 {
     // arrange
+	int result;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_xio_open(TEST_CONCRETE_IO_HANDLE, test_on_io_open_complete, (void*)1, test_on_bytes_received, (void*)2, test_on_io_error, (void*)3));
 
     // act
-    int result = xio_open(handle, test_on_io_open_complete, (void*)1, test_on_bytes_received, (void*)2, test_on_io_error, (void*)3);
+    result = xio_open(handle, test_on_io_open_complete, (void*)1, test_on_bytes_received, (void*)2, test_on_io_error, (void*)3);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -568,6 +573,7 @@ TEST_FUNCTION(xio_open_with_NULL_handle_fails)
 TEST_FUNCTION(when_the_concrete_xio_open_fails_then_xio_open_fails)
 {
     // arrange
+	int result;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
 
@@ -575,7 +581,7 @@ TEST_FUNCTION(when_the_concrete_xio_open_fails_then_xio_open_fails)
         .SetReturn(1);
 
     // act
-    int result = xio_open(handle, test_on_io_open_complete, (void*)1, test_on_bytes_received, (void*)2, test_on_io_error, (void*)3);
+    result = xio_open(handle, test_on_io_open_complete, (void*)1, test_on_bytes_received, (void*)2, test_on_io_error, (void*)3);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -592,13 +598,14 @@ TEST_FUNCTION(when_the_concrete_xio_open_fails_then_xio_open_fails)
 TEST_FUNCTION(xio_close_calls_the_underlying_concrete_xio_close_and_succeeds)
 {
     // arrange
+	int result;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_xio_close(TEST_CONCRETE_IO_HANDLE, test_on_io_close_complete, (void*)0x4242));
 
     // act
-    int result = xio_close(handle, test_on_io_close_complete, (void*)0x4242);
+    result = xio_close(handle, test_on_io_close_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -625,6 +632,7 @@ TEST_FUNCTION(xio_close_with_NULL_handle_fails)
 TEST_FUNCTION(when_the_concrete_xio_close_fails_then_xio_close_fails)
 {
     // arrange
+	int result;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
 
@@ -632,7 +640,7 @@ TEST_FUNCTION(when_the_concrete_xio_close_fails_then_xio_close_fails)
         .SetReturn(1);
 
     // act
-    int result = xio_close(handle, test_on_io_close_complete, (void*)0x4242);
+    result = xio_close(handle, test_on_io_close_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -649,6 +657,7 @@ TEST_FUNCTION(when_the_concrete_xio_close_fails_then_xio_close_fails)
 TEST_FUNCTION(xio_send_calls_the_underlying_concrete_xio_send_and_succeeds)
 {
     // arrange
+	int result;
     unsigned char send_data[] = { 0x42, 43 };
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
@@ -656,7 +665,7 @@ TEST_FUNCTION(xio_send_calls_the_underlying_concrete_xio_send_and_succeeds)
     STRICT_EXPECTED_CALL(test_xio_send(TEST_CONCRETE_IO_HANDLE, send_data, sizeof(send_data), test_on_send_complete, (void*)0x4242));
 
     // act
-    int result = xio_send(handle, send_data, sizeof(send_data), test_on_send_complete, (void*)0x4242);
+    result = xio_send(handle, send_data, sizeof(send_data), test_on_send_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -670,11 +679,12 @@ TEST_FUNCTION(xio_send_calls_the_underlying_concrete_xio_send_and_succeeds)
 TEST_FUNCTION(xio_send_with_NULL_handle_fails)
 {
     // arrange
+	int result;
     unsigned char send_data[] = { 0x42, 43 };
     umock_c_reset_all_calls();
 
     // act
-    int result = xio_send(NULL, send_data, sizeof(send_data), test_on_send_complete, (void*)0x4242);
+    result = xio_send(NULL, send_data, sizeof(send_data), test_on_send_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -684,6 +694,7 @@ TEST_FUNCTION(xio_send_with_NULL_handle_fails)
 TEST_FUNCTION(when_the_concrete_xio_send_fails_then_xio_send_fails)
 {
     // arrange
+	int result;
     unsigned char send_data[] = { 0x42, 43 };
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
@@ -692,7 +703,7 @@ TEST_FUNCTION(when_the_concrete_xio_send_fails_then_xio_send_fails)
         .SetReturn(42);
 
     // act
-    int result = xio_send(handle, send_data, sizeof(send_data), test_on_send_complete, (void*)0x4242);
+    result = xio_send(handle, send_data, sizeof(send_data), test_on_send_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -706,13 +717,14 @@ TEST_FUNCTION(when_the_concrete_xio_send_fails_then_xio_send_fails)
 TEST_FUNCTION(xio_send_with_NULL_buffer_and_nonzero_length_passes_the_args_down_and_succeeds)
 {
     // arrange
+	int result;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_xio_send(TEST_CONCRETE_IO_HANDLE, NULL, 1, test_on_send_complete, (void*)0x4242));
 
     // act
-    int result = xio_send(handle, NULL, 1, test_on_send_complete, (void*)0x4242);
+    result = xio_send(handle, NULL, 1, test_on_send_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -726,13 +738,14 @@ TEST_FUNCTION(xio_send_with_NULL_buffer_and_nonzero_length_passes_the_args_down_
 TEST_FUNCTION(xio_send_with_NULL_buffer_and_zero_length_passes_the_args_down_and_succeeds)
 {
     // arrange
+	int result;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_xio_send(TEST_CONCRETE_IO_HANDLE, NULL, 0, test_on_send_complete, (void*)0x4242));
 
     // act
-    int result = xio_send(handle, NULL, 0, test_on_send_complete, (void*)0x4242);
+    result = xio_send(handle, NULL, 0, test_on_send_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -746,6 +759,7 @@ TEST_FUNCTION(xio_send_with_NULL_buffer_and_zero_length_passes_the_args_down_and
 TEST_FUNCTION(xio_send_with_non_NULL_buffer_and_zero_length_passes_the_args_down_and_succeeds)
 {
     // arrange
+	int result;
     unsigned char send_data[] = { 0x42, 43 };
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
@@ -753,7 +767,7 @@ TEST_FUNCTION(xio_send_with_non_NULL_buffer_and_zero_length_passes_the_args_down
     STRICT_EXPECTED_CALL(test_xio_send(TEST_CONCRETE_IO_HANDLE, send_data, 0, test_on_send_complete, (void*)0x4242));
 
     // act
-    int result = xio_send(handle, send_data, 0, test_on_send_complete, (void*)0x4242);
+    result = xio_send(handle, send_data, 0, test_on_send_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -800,13 +814,14 @@ TEST_FUNCTION(xio_dowork_with_NULL_handle_does_nothing)
 TEST_FUNCTION(xio_setoption_with_NULL_handle_fails)
 {
     // arrange
+	int result;
     const char* optionName = "TheOptionName";
     const void* optionValue = (void*)1;
 
     umock_c_reset_all_calls();
 
     // act
-    int result = xio_setoption(NULL, optionName, optionValue);
+    result = xio_setoption(NULL, optionName, optionValue);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -818,12 +833,13 @@ TEST_FUNCTION(xio_setoption_with_NULL_optionName_fails)
 {
     // arrange
     const void* optionValue = (void*)1;
+	int result;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = xio_setoption(handle, NULL, optionValue);
+    result = xio_setoption(handle, NULL, optionValue);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -838,6 +854,7 @@ TEST_FUNCTION(xio_setoption_with_NULL_optionName_fails)
 TEST_FUNCTION(xio_setoption_with_valid_args_passes_the_args_down_and_succeeds)
 {
     // arrange
+	int result;
     const char* optionName = "TheOptionName";
     const void* optionValue = (void*)1;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
@@ -847,7 +864,7 @@ TEST_FUNCTION(xio_setoption_with_valid_args_passes_the_args_down_and_succeeds)
     STRICT_EXPECTED_CALL(test_xio_setoption(TEST_CONCRETE_IO_HANDLE, optionName, optionValue));
 
     // act
-    int result = xio_setoption(handle, optionName, optionValue);
+    result = xio_setoption(handle, optionName, optionValue);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -861,6 +878,7 @@ TEST_FUNCTION(xio_setoption_with_valid_args_passes_the_args_down_and_succeeds)
 TEST_FUNCTION(xio_setoption_fails_when_concrete_xio_setoption_fails)
 {
     // arrange
+	int result;
     const char* optionName = "TheOptionName";
     const void* optionValue = (void*)1;
     XIO_HANDLE handle = xio_create(&test_io_description, NULL);
@@ -871,7 +889,7 @@ TEST_FUNCTION(xio_setoption_fails_when_concrete_xio_setoption_fails)
         .SetReturn(42);
 
     // act
-    int result = xio_setoption(handle, optionName, optionValue);
+    result = xio_setoption(handle, optionName, optionValue);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -916,13 +934,14 @@ static void xio_retrieveoptions_inert_path(void)
 TEST_FUNCTION(xio_retrieveoptions_happypath)
 {
     ///arrange
+	OPTIONHANDLER_HANDLE h;
     XIO_HANDLE x = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
 
     xio_retrieveoptions_inert_path();
 
     ///act
-    OPTIONHANDLER_HANDLE h = xio_retrieveoptions(x);
+    h = xio_retrieveoptions(x);
 
     ///assert
     ASSERT_IS_NOT_NULL(h);
@@ -938,10 +957,12 @@ TEST_FUNCTION(xio_retrieveoptions_happypath)
 TEST_FUNCTION(xio_retrieveoptions_unhappypaths)
 {
     ///arrange
+	XIO_HANDLE x;
+	size_t i;
     int negativeTestsInitResult = umock_c_negative_tests_init();
     ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-    XIO_HANDLE x = xio_create(&test_io_description, NULL);
+    x = xio_create(&test_io_description, NULL);
     umock_c_reset_all_calls();
 
     xio_retrieveoptions_inert_path();
@@ -949,18 +970,19 @@ TEST_FUNCTION(xio_retrieveoptions_unhappypaths)
     umock_c_negative_tests_snapshot();
 
     ///act
-    for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+    for (i = 0; i < umock_c_negative_tests_call_count(); i++)
     {
+        char temp_str[128];
+		OPTIONHANDLER_HANDLE h;
 
-        umock_c_negative_tests_reset();
+		umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
         ///act
-        char temp_str[128];
         (void)sprintf(temp_str, "On failed call %zu", i);
 
         ///act
-        OPTIONHANDLER_HANDLE h = xio_retrieveoptions(x);
+        h = xio_retrieveoptions(x);
 
         ///assert
         ASSERT_IS_NULL_WITH_MSG(h, temp_str);

--- a/testtools/micromock/inc/globalmock.h
+++ b/testtools/micromock/inc/globalmock.h
@@ -26,8 +26,6 @@ public:
         m_GlobalMockInstance = NULL;
     }
 
-    _Check_return_
-    _Post_satisfies_(return != NULL)
     static CGlobalMock<C>* GetSingleton()
     {
         if (NULL == m_GlobalMockInstance)

--- a/testtools/micromock/inc/micromockcharstararenullterminatedstrings.h
+++ b/testtools/micromock/inc/micromockcharstararenullterminatedstrings.h
@@ -49,8 +49,7 @@ public:
         }
     }
 
-    virtual _Check_return_
-    std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
         std::tostringstream strStream;
         if (NULL == m_Value)
@@ -64,8 +63,7 @@ public:
         return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-    bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
         return (*this == *(reinterpret_cast<const CMockValue<char*>*>(right)));
         
@@ -99,7 +97,7 @@ public:
         };
     }
 
-    _Must_inspect_result_ char* GetValue() const
+    char* GetValue() const
     {
         return m_Value;
     }
@@ -137,8 +135,7 @@ public:
         }
     }
 
-    virtual _Check_return_
-    std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
         std::tostringstream strStream;
         if (NULL == m_Value)
@@ -152,8 +149,7 @@ public:
         return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-    bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
         return (*this == *(reinterpret_cast<const CMockValue<const char*>*>(right)));
     }
@@ -186,7 +182,7 @@ public:
         };
     }
 
-    _Must_inspect_result_ const char* GetValue() const
+    const char* GetValue() const
     {
         return m_Value;
     }

--- a/testtools/micromock/inc/mockcallargument.h
+++ b/testtools/micromock/inc/mockcallargument.h
@@ -46,8 +46,7 @@ public:
     }
 
     // TODO: this should be fixed to be const
-    _Must_inspect_result_
-        bool operator==(_In_ CMockCallArgument<T>& rhs)
+    bool operator==(_In_ CMockCallArgument<T>& rhs)
     {
         bool result = true;
 
@@ -88,8 +87,7 @@ public:
         return result;
     }
 
-    _Must_inspect_result_
-        bool ValidateArgumentBuffer(_In_ const std::vector<BUFFER_ARGUMENT_DATA>& bufferValidations) const
+    bool ValidateArgumentBuffer(_In_ const std::vector<BUFFER_ARGUMENT_DATA>& bufferValidations) const
     {
         bool result = true;
 
@@ -109,7 +107,7 @@ public:
         return result;
     }
 
-    virtual _Check_return_ std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
         if (m_ArgumentAsString.length() > 0)
         {
@@ -139,13 +137,12 @@ public:
         }
     }
 
-    _Must_inspect_result_
-        virtual bool EqualTo(_In_ const CMockCallArgumentBase* right)
+    virtual bool EqualTo(_In_ const CMockCallArgumentBase* right)
     {
         return (*this == *(CMockCallArgument<T>*)(const CMockCallArgument<T>*)(right));
     }
 
-    void AddBufferValidation(_In_reads_bytes_(bytesToValidate) const void* expectedBuffer, _In_ size_t bytesToValidate, _In_ size_t byteOffset = 0)
+    void AddBufferValidation(const void* expectedBuffer, _In_ size_t bytesToValidate, _In_ size_t byteOffset = 0)
     {
         if ((NULL != expectedBuffer) &&
             (bytesToValidate > 0))
@@ -184,7 +181,7 @@ public:
         }
     }
 
-    virtual void AddCopyOutArgumentBuffer(_In_reads_bytes_(bytesToCopy) const void* injectedBuffer, _In_ size_t bytesToCopy, _In_ size_t byteOffset = 0)
+    virtual void AddCopyOutArgumentBuffer(const void* injectedBuffer, _In_ size_t bytesToCopy, _In_ size_t byteOffset = 0)
     {
         BUFFER_ARGUMENT_DATA outArgumentCopyData;
 
@@ -262,9 +259,7 @@ private:
         }
     }
 
-    _Must_inspect_result_
-        _Success_(return == true)
-        bool GetArgBufferValidationExpectedByte(_In_ size_t pos, _Out_writes_(1) UINT8* buffer) const
+    bool GetArgBufferValidationExpectedByte(_In_ size_t pos, UINT8* buffer) const
     {
         bool result = false;
 
@@ -281,9 +276,7 @@ private:
         return result;
     }
 
-    _Must_inspect_result_
-        _Success_(return != NULL)
-        UINT8* CreateBufferValidationMask()
+    UINT8* CreateBufferValidationMask()
     {
         UINT8* result = NULL;
 

--- a/testtools/micromock/inc/mockcallargumentbase.h
+++ b/testtools/micromock/inc/mockcallargumentbase.h
@@ -16,7 +16,6 @@ typedef struct BUFFER_ARGUMENT_DATA_TAG
     size_t  m_ByteCount;
     size_t  m_Offset;
 
-    _Must_inspect_result_
     bool operator<(_In_ const BUFFER_ARGUMENT_DATA_TAG& rhs) const
     {
         if (m_Offset < rhs.m_Offset)
@@ -49,10 +48,10 @@ public:
     virtual ~CMockCallArgumentBase() {};
 
     virtual void SetIgnored(_In_ bool ignored) = 0;
-    virtual _Check_return_ std::tstring ToString() const = 0;
+    virtual std::tstring ToString() const = 0;
     virtual bool EqualTo(_In_ const CMockCallArgumentBase* right) = 0;
-    virtual void AddCopyOutArgumentBuffer(_In_reads_bytes_(bytesToCopy) const void* injectedBuffer, _In_ size_t bytesToCopy, _In_ size_t byteOffset = 0) = 0;
-    virtual void AddBufferValidation(_In_reads_bytes_(bytesToValidate) const void* expectedBuffer, _In_ size_t bytesToValidate, _In_ size_t byteOffset = 0) = 0;
+    virtual void AddCopyOutArgumentBuffer(const void* injectedBuffer, _In_ size_t bytesToCopy, _In_ size_t byteOffset = 0) = 0;
+    virtual void AddBufferValidation(const void* expectedBuffer, _In_ size_t bytesToValidate, _In_ size_t byteOffset = 0) = 0;
     virtual void CopyOutArgumentDataFrom(_In_ const CMockCallArgumentBase* sourceMockCallArgument) = 0;
 };
 

--- a/testtools/micromock/inc/mockcallcomparer.h
+++ b/testtools/micromock/inc/mockcallcomparer.h
@@ -18,11 +18,11 @@ public:
     }
 
     void SetIgnoreUnexpectedCalls(_In_ bool ignoreUnexpectedCalls) { m_IgnoreUnexpectedCalls = ignoreUnexpectedCalls; }
-    _Must_inspect_result_ bool GetIgnoreUnexpectedCalls(void) { return m_IgnoreUnexpectedCalls; }
+    bool GetIgnoreUnexpectedCalls(void) { return m_IgnoreUnexpectedCalls; }
 
-    virtual _Must_inspect_result_ bool IsUnexpectedCall(_In_ const CMockMethodCallBase* actualCall) = 0;
-    virtual _Must_inspect_result_ bool IsMissingCall(_In_ const CMockMethodCallBase* actualCall) = 0;
-    virtual _Must_inspect_result_ CMockMethodCallBase* MatchCall(std::vector<CMockMethodCallBase*>& expectedCalls,
+    virtual bool IsUnexpectedCall(_In_ const CMockMethodCallBase* actualCall) = 0;
+    virtual bool IsMissingCall(_In_ const CMockMethodCallBase* actualCall) = 0;
+    virtual CMockMethodCallBase* MatchCall(std::vector<CMockMethodCallBase*>& expectedCalls,
         CMockMethodCallBase* actualCall) = 0;
 
 protected:

--- a/testtools/micromock/inc/mockcallrecorder.h
+++ b/testtools/micromock/inc/mockcallrecorder.h
@@ -35,8 +35,8 @@ public:
     void ResetExpectedCalls();
     void ResetActualCalls();
     void ResetAllCalls();
-    SAL_Acquires_lock_(m_MockCallRecorderCS) void Lock();
-    SAL_Releases_lock_(m_MockCallRecorderCS) void Unlock();
+    void Lock();
+    void Unlock();
     void SetPerformAutomaticCallComparison(AUTOMATIC_CALL_COMPARISON performAutomaticCallComparison);
     void SetMockCallComparer(CMockCallComparer* mockCallComparer) { m_MockCallComparer = mockCallComparer; };
 

--- a/testtools/micromock/inc/mockmethodcall.h
+++ b/testtools/micromock/inc/mockmethodcall.h
@@ -16,7 +16,7 @@ template<typename returnType>
 class CMockMethodCall : public CMockMethodCallBase
 {
 public:
-    CMockMethodCall(_In_ std::tstring methodName, _In_ size_t argCount = 0, _In_reads_(argCount) CMockCallArgumentBase** arguments = NULL) :
+    CMockMethodCall(_In_ std::tstring methodName, _In_ size_t argCount = 0, CMockCallArgumentBase** arguments = NULL) :
         CMockMethodCallBase(methodName, argCount, arguments)
     {
     }
@@ -111,7 +111,7 @@ public:
     }
 
     CMockMethodCall<returnType>& ValidateArgumentBuffer(_In_ size_t argumentNo,
-        _In_reads_bytes_opt_(bytesToValidate) const void* expectedBuffer, _In_ size_t bytesToValidate, _In_ size_t byteOffset = 0)
+        const void* expectedBuffer, _In_ size_t bytesToValidate, _In_ size_t byteOffset = 0)
     {
         if ((argumentNo > 0) &&
             (argumentNo <= m_MockCallArguments.size()) &&
@@ -129,7 +129,7 @@ public:
         return *this;
     }
     CMockMethodCall<returnType>& CopyOutArgumentBuffer(_In_ size_t argumentNo,
-        _In_reads_bytes_opt_(bytesToCopy) const void* injectedBuffer, _In_ size_t bytesToCopy, _In_ size_t byteOffset = 0)
+        const void* injectedBuffer, _In_ size_t bytesToCopy, _In_ size_t byteOffset = 0)
     {
         if ((NULL == injectedBuffer) ||
             (bytesToCopy == 0))

--- a/testtools/micromock/inc/mockmethodcallbase.h
+++ b/testtools/micromock/inc/mockmethodcallbase.h
@@ -36,7 +36,7 @@ public:
     { 
         return m_FailReturnValue; 
     }
-    _Must_inspect_result_ bool HasMatch() const { return (NULL != m_MatchedCall); }
+    bool HasMatch() const { return (NULL != m_MatchedCall); }
     void RollbackMatch();
 
 protected:

--- a/testtools/micromock/inc/mockvalue.h
+++ b/testtools/micromock/inc/mockvalue.h
@@ -25,16 +25,14 @@ public:
     {
     }
 
-    virtual _Check_return_
-    std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
         std::tostringstream strStream;
         strStream << m_Value;
         return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-    bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
         return (*this == *(reinterpret_cast<const CMockValue<T>*>(right)));
     }
@@ -45,7 +43,7 @@ public:
         m_OriginalValue = value;
     }
 
-    _Must_inspect_result_ const T& GetValue() const
+    const T& GetValue() const
     {
         return m_Value;
     }
@@ -68,16 +66,14 @@ public:
     {
     }
 
-    virtual _Check_return_
-        std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
             std::tostringstream strStream;
             strStream << (unsigned int)m_Value;
             return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-        bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
             return (this->m_Value == (reinterpret_cast<const CMockValue<unsigned char>*>(right))->m_Value);
     }
@@ -88,7 +84,7 @@ public:
         m_OriginalValue = value;
     }
 
-    _Must_inspect_result_ const unsigned char& GetValue() const
+    const unsigned char& GetValue() const
     {
         return m_Value;
     }
@@ -111,16 +107,14 @@ public:
     {
     }
 
-    virtual _Check_return_
-        std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
         std::tostringstream strStream;
         strStream << "void";
         return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-        bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
         (void)right;
         return true;
@@ -131,7 +125,7 @@ public:
 
     }
 
-    _Must_inspect_result_ void GetValue() const
+    void GetValue() const
     {
         return;
     }
@@ -164,8 +158,7 @@ public:
     {
     }
 
-    virtual _Check_return_
-        std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
             std::string temp(m_Value.begin(), m_Value.end());
 
@@ -176,8 +169,7 @@ public:
 
     }
 
-    virtual _Must_inspect_result_
-        bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
             return (this->m_Value == (reinterpret_cast<const CMockValue<wchar_t *>*>(right))->m_Value);
     }
@@ -196,7 +188,7 @@ public:
         }
     }
 
-    _Must_inspect_result_ const wchar_t* GetValue() const
+    const wchar_t* GetValue() const
     {
         return m_Value.c_str();
     }
@@ -229,8 +221,7 @@ public:
     {
     }
 
-    virtual _Check_return_
-        std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
             std::string temp(m_Value.begin(), m_Value.end());
 
@@ -239,8 +230,7 @@ public:
             return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-        bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
             return (this->m_Value == (reinterpret_cast<const CMockValue<const wchar_t *>*>(right))->m_Value);
     }
@@ -259,7 +249,7 @@ public:
         }
     }
 
-    _Must_inspect_result_ const wchar_t* GetValue() const
+    const wchar_t* GetValue() const
     {
         return m_Value.c_str();
     }
@@ -284,8 +274,7 @@ public:
     {
     }
 
-    virtual _Check_return_
-    std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
         std::tostringstream strStream;
         if (NULL == m_Value)
@@ -299,8 +288,7 @@ public:
         return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-    bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
         return (*this == *(reinterpret_cast<const CMockValue<T*>*>(right)));
     }
@@ -311,7 +299,7 @@ public:
         m_OriginalValue = value;
     }
 
-    _Must_inspect_result_ T* GetValue() const
+    T* GetValue() const
     {
         return m_Value;
     }
@@ -359,8 +347,7 @@ public:
         }
     }
 
-    virtual _Check_return_
-    std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
         std::tostringstream strStream;
         if (m_Value.isNULL)
@@ -384,8 +371,7 @@ public:
         return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-    bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
         /*this will be interesting*/
         return (*this == *(reinterpret_cast<const CMockValue<T_Array_N>*>(right)));
@@ -437,7 +423,7 @@ public:
         }
     }
 
-    _Must_inspect_result_ const T* GetValue() const
+    const T* GetValue() const
     {
         if (m_Value.isNULL == true)
         {
@@ -492,8 +478,7 @@ public:
         }
     }
 
-    virtual _Check_return_
-        std::tstring ToString() const
+    virtual std::tstring ToString() const
     {
             std::tostringstream strStream;
             if (m_Value.isNULL)
@@ -517,8 +502,7 @@ public:
             return strStream.str();
     }
 
-    virtual _Must_inspect_result_
-        bool EqualTo(_In_ const CMockValueBase* right)
+    virtual bool EqualTo(_In_ const CMockValueBase* right)
     {
             /*this will be interesting*/
             return (*this == *(reinterpret_cast<const CMockValue<const T_Array_N>*>(right)));
@@ -570,7 +554,7 @@ public:
         }
     }
 
-    _Must_inspect_result_ const T* GetValue() const
+    const T* GetValue() const
     {
         if (m_Value.isNULL == true)
         {
@@ -589,14 +573,12 @@ protected:
 
 
 template<typename T>
-_Must_inspect_result_
 static bool operator==(_In_ const CMockValue<T>& lhs, _In_ const CMockValue<T>& rhs)
 {
     return lhs.GetValue() == rhs.GetValue();
 }
 
 template<typename T, size_t N>
-_Must_inspect_result_
 static bool operator==(_In_ const CMockValue<T[N]>& lhs, _In_ const CMockValue<T[N]>& rhs)
 {
     /*comparing two arrays needs to be handled differently than the build in == operator*/

--- a/testtools/micromock/inc/mockvaluebase.h
+++ b/testtools/micromock/inc/mockvaluebase.h
@@ -14,8 +14,8 @@ public:
     virtual ~CMockValueBase();
 
 public:
-    virtual _Check_return_ std::tstring ToString() const = 0;
-    virtual _Must_inspect_result_ bool EqualTo(_In_ const CMockValueBase* right) = 0;
+    virtual std::tstring ToString() const = 0;
+    virtual bool EqualTo(_In_ const CMockValueBase* right) = 0;
 };
 
 #endif // MOCKVALUEBASE_H

--- a/testtools/micromock/inc/strictorderedcallcomparer.h
+++ b/testtools/micromock/inc/strictorderedcallcomparer.h
@@ -20,13 +20,11 @@ public:
         T::SetPerformAutomaticCallComparison(performAutomaticCallComparison);
     }
 
-    _Must_inspect_result_
     virtual bool IsUnexpectedCall(_In_ const CMockMethodCallBase* actualCall)
     {
         return !actualCall->HasMatch();
     }
 
-    _Must_inspect_result_
     virtual bool IsMissingCall(_In_ const CMockMethodCallBase* expectedCall)
     {
         return ((!expectedCall->HasMatch()) &&
@@ -35,7 +33,6 @@ public:
                 (!expectedCall->m_OnlySpecifiesActions));
     }
 
-    _Must_inspect_result_
     virtual CMockMethodCallBase* MatchCall(std::vector<CMockMethodCallBase*>& expectedCalls,
         CMockMethodCallBase* actualCall)
     {

--- a/testtools/micromock/inc/strictunorderedcallcomparer.h
+++ b/testtools/micromock/inc/strictunorderedcallcomparer.h
@@ -22,7 +22,6 @@ public:
         T::CMockCallRecorder::m_MockCallComparer->SetIgnoreUnexpectedCalls(false);
     }
 
-    _Must_inspect_result_
     virtual bool IsUnexpectedCall(_In_ const CMockMethodCallBase* actualCall)
     {
         if (T::CMockCallRecorder::m_MockCallComparer->GetIgnoreUnexpectedCalls())
@@ -35,7 +34,6 @@ public:
         }
     }
 
-    _Must_inspect_result_
     virtual bool IsMissingCall(_In_ const CMockMethodCallBase* expectedCall)
     {
         return ((!expectedCall->HasMatch()) &&
@@ -44,7 +42,6 @@ public:
                 (!expectedCall->m_OnlySpecifiesActions));
     }
 
-    _Must_inspect_result_
     virtual CMockMethodCallBase* MatchCall(std::vector<CMockMethodCallBase*>& expectedCalls,
         CMockMethodCallBase* actualCall)
      {

--- a/testtools/micromock/inc/threadsafeglobalmock.h
+++ b/testtools/micromock/inc/threadsafeglobalmock.h
@@ -38,8 +38,6 @@ public:
         }
     }
 
-    _Check_return_
-    _Post_satisfies_(return != NULL)
     static CThreadSafeGlobalMock<C>* GetSingleton()
     {
         if (NULL == m_GlobalMockInstance)

--- a/testtools/micromock/inc/timediscretemicromock.h
+++ b/testtools/micromock/inc/timediscretemicromock.h
@@ -464,14 +464,12 @@ public:
         }
     }
 
-    _Must_inspect_result_
-        UINT32 getCurrentTick(void)
+    UINT32 getCurrentTick(void)
     {
             return m_currentTick;
     }
 
-    _Must_inspect_result_
-        UINT32 getAndIncOrder(_In_ UINT32 time)
+    UINT32 getAndIncOrder(_In_ UINT32 time)
     {
             if (time<MAXTICK)
             {

--- a/testtools/micromock/src/mockcallrecorder.cpp
+++ b/testtools/micromock/src/mockcallrecorder.cpp
@@ -229,13 +229,11 @@ void CMockCallRecorder::SetPerformAutomaticCallComparison(AUTOMATIC_CALL_COMPARI
     m_PerformAutomaticCallComparison = performAutomaticCallComparison;
 }
 
-SAL_Acquires_lock_(m_MockCallRecorderCS)
 void CMockCallRecorder::Lock()
 {
     MicroMockEnterCriticalSection(&m_MockCallRecorderCS);
 }
 
-SAL_Releases_lock_(m_MockCallRecorderCS)
 void CMockCallRecorder::Unlock()
 {
     MicroMockLeaveCriticalSection(&m_MockCallRecorderCS);

--- a/testtools/micromock/tools/micromockgenerator/micromockgenerator.cpp
+++ b/testtools/micromock/tools/micromockgenerator/micromockgenerator.cpp
@@ -404,7 +404,7 @@ void GenerateTimeDiscreteMockCallMacros(_In_ size_t supportedArgCount)
     fout.close();
 }
 
-int __cdecl _tmain(_In_ const int argc, _In_reads_(argc) const _TCHAR* argv[])
+int __cdecl _tmain(const int argc, const _TCHAR* argv[])
 {
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);


### PR DESCRIPTION
Mostly fix mixing of code and variable declarations.
Some fixes were needed to define EAGAIN and similar error codes (that are not C99)
