### PR TITLE
have the testing tools build even when its own tests are not build

### DIFF
--- a/configs/azure_c_shared_utilityFunctions.cmake
+++ b/configs/azure_c_shared_utilityFunctions.cmake
@@ -253,10 +253,16 @@ function(c_windows_unittests_add_dll whatIsBuilding folder)
 
     set_target_properties(${whatIsBuilding}_dll
                PROPERTIES
-               FOLDER ${folder} )
+               FOLDER ${folder})
 
-    target_include_directories(${whatIsBuilding}_dll PUBLIC ${sharedutil_include_directories} $ENV{VCInstallDir}UnitTest/include)
-    target_compile_definitions(${whatIsBuilding}_dll PUBLIC -DCPP_UNITTEST)
+    set_source_files_properties(${${whatIsBuilding}_c_files} ${logging_files}
+               PROPERTIES
+               COMPILE_FLAGS /TC)
+
+    set_source_files_properties(${${whatIsBuilding}_cpp_files}
+               PROPERTIES
+               COMPILE_FLAGS /TP)
+
     target_link_libraries(${whatIsBuilding}_dll umock_c ctest testrunnerswitcher ${whatIsBuilding}_testsonly_lib )
 
     set(PARSING_ADDITIONAL_LIBS OFF)

--- a/configs/azure_c_shared_utilityFunctions.cmake
+++ b/configs/azure_c_shared_utilityFunctions.cmake
@@ -392,7 +392,7 @@ function(c_linux_unittests_add_exe whatIsBuilding folder)
 
     endforeach()
 
-    target_link_libraries(${whatIsBuilding}_exe umock_c ctest)
+    target_link_libraries(${whatIsBuilding}_exe umock_c ctest m)
 
     add_test(NAME ${whatIsBuilding} COMMAND $<TARGET_FILE:${whatIsBuilding}_exe>)
 

--- a/configs/azure_c_shared_utilityFunctions.cmake
+++ b/configs/azure_c_shared_utilityFunctions.cmake
@@ -257,7 +257,7 @@ function(c_windows_unittests_add_dll whatIsBuilding folder)
 
     target_include_directories(${whatIsBuilding}_dll PUBLIC ${sharedutil_include_directories} $ENV{VCInstallDir}UnitTest/include)
     target_compile_definitions(${whatIsBuilding}_dll PUBLIC -DCPP_UNITTEST)
-    target_link_libraries(${whatIsBuilding}_dll micromock_cpp_unittest umock_c ctest testrunnerswitcher ${whatIsBuilding}_testsonly_lib )
+    target_link_libraries(${whatIsBuilding}_dll umock_c ctest testrunnerswitcher ${whatIsBuilding}_testsonly_lib )
 
     set(PARSING_ADDITIONAL_LIBS OFF)
     set(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
@@ -311,7 +311,7 @@ function(c_windows_unittests_add_exe whatIsBuilding folder)
 
     target_compile_definitions(${whatIsBuilding}_exe PUBLIC -DUSE_CTEST)
     target_include_directories(${whatIsBuilding}_exe PUBLIC ${sharedutil_include_directories})
-    target_link_libraries(${whatIsBuilding}_exe micromock_ctest umock_c ctest testrunnerswitcher)
+    target_link_libraries(${whatIsBuilding}_exe umock_c ctest testrunnerswitcher)
 
     set(PARSING_ADDITIONAL_LIBS OFF)
     set(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
@@ -392,7 +392,7 @@ function(c_linux_unittests_add_exe whatIsBuilding folder)
 
     endforeach()
 
-    target_link_libraries(${whatIsBuilding}_exe micromock_ctest umock_c ctest)
+    target_link_libraries(${whatIsBuilding}_exe umock_c ctest)
 
     add_test(NAME ${whatIsBuilding} COMMAND $<TARGET_FILE:${whatIsBuilding}_exe>)
 


### PR DESCRIPTION
upstream projects that have their own unittests / int tests / e2e tests should not necessarily need to generate / build / run azure-c-shared-utility's own unittests/int_tests/e2e_tests.

This always builds the testing tools (even when azure-c-shared-utility's unittests are disabled).

Example of such a CMakefile:

#bring in dependencies
#do not add or build any tests of the dependencies
set(original_run_e2e_tests ${run_e2e_tests})
set(original_run_int_tests ${run_int_tests})
set(original_run_unittests ${run_unittests})

set(run_e2e_tests OFF)
set(run_int_tests OFF)
set(run_unittests OFF)

add_subdirectory(deps/azure-macro-utils-c)
include_directories(${MACRO_UTILS_INC_FOLDER})

add_subdirectory(deps/azure-ctest)
include_directories(${CTEST_INC_FOLDER})

add_subdirectory(deps/azure-c-testrunnerswitcher)
include_directories(${TESTRUNNERSWITCHER_INC_FOLDER})

add_subdirectory(deps/umock-c)
include_directories(${UMOCK_C_INC_FOLDER})

add_subdirectory(deps/azure-c-shared-utility)
include_directories(${SHARED_UTIL_INC_FOLDER})

set(run_e2e_tests ${original_run_e2e_tests})
set(run_int_tests ${original_run_int_tests})
set(run_unittests ${original_run_unittests})

/*add here the upstream's project own work*/ 

note how azure-c-shared-utility is build without tests, but the upstream project is having its own switches.