### PR TITLE
Add more public functions to c-shared DEF file.

### DIFF
--- a/src/aziotsharedutil.def
+++ b/src/aziotsharedutil.def
@@ -1,6 +1,7 @@
 LIBRARY aziotsharedutil
 EXPORTS
     BUFFER_append
+    BUFFER_append_build
     BUFFER_build
     BUFFER_clone
     BUFFER_content
@@ -11,6 +12,7 @@ EXPORTS
     BUFFER_new
     BUFFER_pre_build
     BUFFER_prepend
+    BUFFER_shrink
     BUFFER_size
     BUFFER_u_char
     BUFFER_unbuild
@@ -151,6 +153,8 @@ EXPORTS
     THREADAPI_RESULTStringStorage
     THREADAPI_RESULTStrings
     THREADAPI_RESULT_FromString
+    TLSIO_STATE_FromString
+    TLSIO_STATEStrings
     ThreadAPI_Create
     ThreadAPI_Exit
     ThreadAPI_Join
@@ -181,7 +185,12 @@ EXPORTS
     VECTOR_push_back
     VECTOR_size
     connectionstringparser_parse
+    connectionstringparser_parse_from_char
+    connectionstringparser_splitHostName
+    connectionstringparser_splitHostName_from_char
     consolelogger_log
+    consolelogger_log_with_GetLastError
+    gb_rand
     gballoc_calloc
     gballoc_deinit
     gballoc_free
@@ -205,6 +214,7 @@ EXPORTS
     mallocAndStrcpy_s
     platform_deinit
     platform_get_default_tlsio
+    platform_get_platform_info
     platform_init
     singlylinkedlist_add
     singlylinkedlist_create
@@ -235,7 +245,27 @@ EXPORTS
     tlsio_schannel_send
     tlsio_schannel_setoption
     unsignedIntToString
+    utf8_checker_is_valid_utf8
+    uws_client_close_async
+    uws_client_close_handshake_async
+    uws_client_create
+    uws_client_create_with_io
+    uws_client_destroy
+    uws_client_dowork
+    uws_client_open_async
+    uws_client_retrieve_options
+    uws_client_send_frame_async
+    uws_client_set_option
+    uws_frame_encoder_encode
+    wsio_close
+    wsio_create
+    wsio_destroy
+    wsio_dowork
     wsio_get_interface_description
+    wsio_open
+    wsio_retrieveoptions
+    wsio_send
+    wsio_setoption
     x509_schannel_create
     x509_schannel_destroy
     x509_schannel_get_certificate_context
@@ -249,4 +279,6 @@ EXPORTS
     xio_setoption
     xlogging_dump_buffer
     xlogging_get_log_function
+    xlogging_get_log_function_GetLastError
     xlogging_set_log_function
+    xlogging_set_log_function_GetLastError


### PR DESCRIPTION
Building the azure edge, linker failed to find "platform_get_platform_info" - the GW builds this as a shared library, and so this function needs to be exposed, along with a few more I found. 