### PR TITLE
Remove unnecessary xlogging include from xio.h

### DIFF
--- a/adapters/platform_linux.c
+++ b/adapters/platform_linux.c
@@ -3,6 +3,7 @@
 
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/xlogging.h"
 #ifdef USE_OPENSSL
 #include "azure_c_shared_utility/tlsio_openssl.h"
 #endif

--- a/adapters/platform_win32.c
+++ b/adapters/platform_win32.c
@@ -5,6 +5,7 @@
 #include "azure_c_shared_utility/optimize_size.h"
 #include "azure_c_shared_utility/xio.h"
 #include "azure_c_shared_utility/strings.h"
+#include "azure_c_shared_utility/xlogging.h"
 #include "winsock2.h"
 
 #ifdef USE_OPENSSL

--- a/inc/azure_c_shared_utility/xio.h
+++ b/inc/azure_c_shared_utility/xio.h
@@ -6,7 +6,6 @@
 
 #include "azure_c_shared_utility/optionhandler.h"
 
-#include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/umock_c_prod.h"
 #include "azure_c_shared_utility/macro_utils.h"
 

--- a/src/xio.c
+++ b/src/xio.c
@@ -6,6 +6,7 @@
 #include "azure_c_shared_utility/gballoc.h"
 #include "azure_c_shared_utility/optimize_size.h"
 #include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/xlogging.h"
 
 static const char* CONCRETE_OPTIONS = "concreteOptions";
 


### PR DESCRIPTION
Remove unnecessary xlogging include from xio.h.
Fixes #93.