### PR TITLE
Remove Unused #includes

### DIFF
--- a/inc/azure_c_shared_utility/buffer_.h
+++ b/inc/azure_c_shared_utility/buffer_.h
@@ -6,7 +6,6 @@
 
 #ifdef __cplusplus
 #include <cstddef>
-#include <cstdbool>
 extern "C"
 {
 #else

--- a/inc/azure_c_shared_utility/tickcounter.h
+++ b/inc/azure_c_shared_utility/tickcounter.h
@@ -4,13 +4,6 @@
 #ifndef TICKCOUNTER_H
 #define TICKCOUNTER_H
 
-#ifdef __cplusplus
-extern "C" {
-#include <cstdint>
-#else
-#include <stdint.h>
-#endif /* __cplusplus */
-
 #include "azure_c_shared_utility/umock_c_prod.h"
 
     typedef uint_fast32_t tickcounter_ms_t;

--- a/inc/azure_c_shared_utility/tickcounter.h
+++ b/inc/azure_c_shared_utility/tickcounter.h
@@ -4,6 +4,10 @@
 #ifndef TICKCOUNTER_H
 #define TICKCOUNTER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #include "azure_c_shared_utility/umock_c_prod.h"
 
     typedef uint_fast32_t tickcounter_ms_t;


### PR DESCRIPTION
On earlier versions of GCC that do not fully support C++11, two includes cause build failures. Having review these two build failures it is apparent that they are not even required for C++ builds. 

This change simply deletes unused #includes to enable earlier GCC versions to successfully compile the SDK.