### PR TITLE
Move includes to outside extern "C"

### DIFF
--- a/inc/azure_c_shared_utility/consolelogger.h
+++ b/inc/azure_c_shared_utility/consolelogger.h
@@ -4,11 +4,11 @@
 #ifndef CONSOLELOGGER_H
 #define CONSOLELOGGER_H
 
+#include "azure_c_shared_utility/xlogging.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xlogging.h"
 
     extern void consolelogger_log(LOG_CATEGORY log_category, const char* file, const char* func, int line, unsigned int options, const char* format, ...);
 

--- a/inc/azure_c_shared_utility/constmap.h
+++ b/inc/azure_c_shared_utility/constmap.h
@@ -9,6 +9,11 @@
 #ifndef CONSTMAP_H
 #define CONSTMAP_H
 
+#include "azure_c_shared_utility/macro_utils.h"
+#include "azure_c_shared_utility/crt_abstractions.h"
+#include "azure_c_shared_utility/map.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 #include <cstddef>
 extern "C"
@@ -17,11 +22,6 @@ extern "C"
 #include <stddef.h>
 #endif
 
-
-#include "azure_c_shared_utility/macro_utils.h"
-#include "azure_c_shared_utility/crt_abstractions.h"
-#include "azure_c_shared_utility/map.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 #define CONSTMAP_RESULT_VALUES \
     CONSTMAP_OK, \

--- a/inc/azure_c_shared_utility/dns_async.h
+++ b/inc/azure_c_shared_utility/dns_async.h
@@ -8,12 +8,12 @@
 #ifndef AZURE_IOT_DNS_H
 #define AZURE_IOT_DNS_H
 
+#include "azure_c_shared_utility/macro_utils.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "azure_c_shared_utility/macro_utils.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
     typedef void* DNS_ASYNC_HANDLE;
 

--- a/inc/azure_c_shared_utility/etwlogger_driver.h
+++ b/inc/azure_c_shared_utility/etwlogger_driver.h
@@ -4,11 +4,11 @@
 #ifndef ETWLOGGER_DRIVER_H
 #define ETWLOGGER_DRIVER_H
 
+#include "azure_c_shared_utility/xlogging.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xlogging.h"
 
     extern void etwlogger_log(LOG_CATEGORY log_category, const char* file, const char* func, int line, unsigned int options, const char* format, ...);
 

--- a/inc/azure_c_shared_utility/hmac.h
+++ b/inc/azure_c_shared_utility/hmac.h
@@ -4,12 +4,12 @@
 #ifndef HMAC_H
 #define HMAC_H
 
+#include "azure_c_shared_utility/sha.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "azure_c_shared_utility/sha.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
     MOCKABLE_FUNCTION(, int, hmac, SHAversion, whichSha, const unsigned char *, text, int, text_len,
     const unsigned char *, key, int, key_len,

--- a/inc/azure_c_shared_utility/http_proxy_io.h
+++ b/inc/azure_c_shared_utility/http_proxy_io.h
@@ -4,12 +4,12 @@
 #ifndef HTTP_PROXY_IO_H
 #define HTTP_PROXY_IO_H
 
+#include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 typedef struct HTTP_PROXY_IO_CONFIG_TAG
 {

--- a/inc/azure_c_shared_utility/platform.h
+++ b/inc/azure_c_shared_utility/platform.h
@@ -4,13 +4,13 @@
 #ifndef PLATFORM_H
 #define PLATFORM_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include "azure_c_shared_utility/strings.h"
 #include "azure_c_shared_utility/xio.h"
 #include "azure_c_shared_utility/umock_c_prod.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
     MOCKABLE_FUNCTION(, int, platform_init);
     MOCKABLE_FUNCTION(, void, platform_deinit);

--- a/inc/azure_c_shared_utility/refcount.h
+++ b/inc/azure_c_shared_utility/refcount.h
@@ -14,6 +14,9 @@ will interact with deallocated memory / resources resulting in an undefined beha
 #ifndef REFCOUNT_H
 #define REFCOUNT_H
 
+#include "azure_c_shared_utility/gballoc.h"
+#include "azure_c_shared_utility/macro_utils.h"
+
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstdint>
@@ -23,9 +26,6 @@ extern "C"
 #include <stdlib.h>
 #include <stdint.h>
 #endif
-
-#include "azure_c_shared_utility/gballoc.h"
-#include "azure_c_shared_utility/macro_utils.h"
 
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ == 201112) && (__STDC_NO_ATOMICS__!=1)
 #define REFCOUNT_USE_STD_ATOMIC 1

--- a/inc/azure_c_shared_utility/sntp.h
+++ b/inc/azure_c_shared_utility/sntp.h
@@ -9,12 +9,12 @@
 #ifndef AZURE_IOT_SNTP_H
 #define AZURE_IOT_SNTP_H
 
+#include "azure_c_shared_utility/macro_utils.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "azure_c_shared_utility/macro_utils.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 
 /**

--- a/inc/azure_c_shared_utility/socket_async.h
+++ b/inc/azure_c_shared_utility/socket_async.h
@@ -8,14 +8,15 @@
 #ifndef AZURE_SOCKET_ASYNC_H
 #define AZURE_SOCKET_ASYNC_H
 
+#include "azure_c_shared_utility/macro_utils.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "azure_c_shared_utility/macro_utils.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 // socket_async exposes asynchronous socket operations while hiding OS-specifics. Committing to
 // asynchronous operation also simplifies the interface compared to generic sockets.

--- a/inc/azure_c_shared_utility/socketio.h
+++ b/inc/azure_c_shared_utility/socketio.h
@@ -4,16 +4,16 @@
 #ifndef SOCKETIO_H
 #define SOCKETIO_H
 
+#include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/xlogging.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #include <cstddef>
 #else
 #include <stddef.h>
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/xlogging.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 typedef struct SOCKETIO_CONFIG_TAG
 {

--- a/inc/azure_c_shared_utility/threadapi.h
+++ b/inc/azure_c_shared_utility/threadapi.h
@@ -9,12 +9,12 @@
 #ifndef THREADAPI_H
 #define THREADAPI_H
 
+#include "azure_c_shared_utility/macro_utils.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "azure_c_shared_utility/macro_utils.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
     
 typedef int(*THREAD_START_FUNC)(void *);
 

--- a/inc/azure_c_shared_utility/tlsio.h
+++ b/inc/azure_c_shared_utility/tlsio.h
@@ -4,11 +4,11 @@
 #ifndef TLSIO_H
 #define TLSIO_H
 
+#include "xio.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include "xio.h"
 
 typedef struct TLSIO_CONFIG_TAG
 {

--- a/inc/azure_c_shared_utility/tlsio_cyclonessl.h
+++ b/inc/azure_c_shared_utility/tlsio_cyclonessl.h
@@ -4,15 +4,15 @@
 #ifndef TLSIO_CYCLONESSL_H
 #define TLSIO_CYCLONESSL_H
 
+#include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #include <cstddef>
 #else
 #include <stddef.h>
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 MOCKABLE_FUNCTION(, const IO_INTERFACE_DESCRIPTION*, tlsio_cyclonessl_get_interface_description);
 

--- a/inc/azure_c_shared_utility/tlsio_cyclonessl_socket.h
+++ b/inc/azure_c_shared_utility/tlsio_cyclonessl_socket.h
@@ -4,12 +4,12 @@
 #ifndef TLSIO_CYCLONESSL_SOCKET_H
 #define TLSIO_CYCLONESSL_SOCKET_H
 
+#include "tls.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include "tls.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 MOCKABLE_FUNCTION(, int, tlsio_cyclonessl_socket_create, const char*, hostname, unsigned int, port, TlsSocket*, new_socket);
 MOCKABLE_FUNCTION(, void, tlsio_cyclonessl_socket_destroy, TlsSocket, socket);

--- a/inc/azure_c_shared_utility/tlsio_mbedtls.h
+++ b/inc/azure_c_shared_utility/tlsio_mbedtls.h
@@ -10,16 +10,16 @@
 // DEPRECATED: the USE_MBED_TLS #define is deprecated.
 #ifdef USE_MBED_TLS
 
+#include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/xlogging.h"
+#include "azure_c_shared_utility/optionhandler.h"
+
 #ifdef __cplusplus
 extern "C" {
 #include <cstddef>
 #else
 #include <stddef.h>
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/xlogging.h"
-#include "azure_c_shared_utility/optionhandler.h"
 
 // DEPRECATED: the functions below do not neet to be exposed.
 extern CONCRETE_IO_HANDLE tlsio_mbedtls_create(void* io_create_parameters);

--- a/inc/azure_c_shared_utility/tlsio_openssl.h
+++ b/inc/azure_c_shared_utility/tlsio_openssl.h
@@ -4,15 +4,15 @@
 #ifndef TLSIO_OPENSSL_H
 #define TLSIO_OPENSSL_H
 
+#include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #include <cstddef>
 #else
 #include <stddef.h>
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 MOCKABLE_FUNCTION(, int, tlsio_openssl_init);
 MOCKABLE_FUNCTION(, void, tlsio_openssl_deinit);

--- a/inc/azure_c_shared_utility/tlsio_openssl_compact.h
+++ b/inc/azure_c_shared_utility/tlsio_openssl_compact.h
@@ -4,11 +4,11 @@
 #ifndef TLSIO_OPENSSL_COMPACT_H
 #define TLSIO_OPENSSL_COMPACT_H
 
+#include "azure_c_shared_utility/tlsio.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/tlsio.h"
 
 	MOCKABLE_FUNCTION(, const IO_INTERFACE_DESCRIPTION*, tlsio_openssl_compact_get_interface_description);
 

--- a/inc/azure_c_shared_utility/tlsio_schannel.h
+++ b/inc/azure_c_shared_utility/tlsio_schannel.h
@@ -4,15 +4,15 @@
 #ifndef TLSIO_SCHANNEL_H
 #define TLSIO_SCHANNEL_H
 
+#include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #include <cstddef>
 #else
 #include <stddef.h>
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 MOCKABLE_FUNCTION(, CONCRETE_IO_HANDLE, tlsio_schannel_create, void*, io_create_parameters);
 MOCKABLE_FUNCTION(, void, tlsio_schannel_destroy, CONCRETE_IO_HANDLE, tls_io);

--- a/inc/azure_c_shared_utility/tlsio_wolfssl.h
+++ b/inc/azure_c_shared_utility/tlsio_wolfssl.h
@@ -4,16 +4,16 @@
 #ifndef TLSIO_WOLFSSL_H
 #define TLSIO_WOLFSSL_H
 
+#include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/xlogging.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #include <cstddef>
 #else
 #include <stddef.h>
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/xlogging.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 MOCKABLE_FUNCTION(, CONCRETE_IO_HANDLE, tlsio_wolfssl_create, void*, io_create_parameters);
 MOCKABLE_FUNCTION(, void, tlsio_wolfssl_destroy, CONCRETE_IO_HANDLE, tls_io);

--- a/inc/azure_c_shared_utility/uws_client.h
+++ b/inc/azure_c_shared_utility/uws_client.h
@@ -4,6 +4,10 @@
 #ifndef UWS_CLIENT_H
 #define UWS_CLIENT_H
 
+#include "xio.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+#include "azure_c_shared_utility/optionhandler.h"
+
 #ifdef __cplusplus
 #include <cstdbool>
 #include <cstddef>
@@ -14,10 +18,6 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 #endif
-
-#include "xio.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
-#include "azure_c_shared_utility/optionhandler.h"
 
 typedef struct UWS_CLIENT_INSTANCE_TAG* UWS_CLIENT_HANDLE;
 

--- a/inc/azure_c_shared_utility/uws_frame_encoder.h
+++ b/inc/azure_c_shared_utility/uws_frame_encoder.h
@@ -4,6 +4,10 @@
 #ifndef UWS_FRAME_ENCODER_H
 #define UWS_FRAME_ENCODER_H
 
+#include "azure_c_shared_utility/buffer_.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+#include "azure_c_shared_utility/macro_utils.h"
+
 #ifdef __cplusplus
 #include <cstdbool>
 #include <cstddef>
@@ -12,10 +16,6 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 #endif
-
-#include "azure_c_shared_utility/buffer_.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
-#include "azure_c_shared_utility/macro_utils.h"
 
 #define RESERVED_1  0x04
 #define RESERVED_2  0x02

--- a/inc/azure_c_shared_utility/vector.h
+++ b/inc/azure_c_shared_utility/vector.h
@@ -6,6 +6,7 @@
 
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "azure_c_shared_utility/umock_c_prod.h"
+#include "azure_c_shared_utility/vector_types.h"
 
 #ifdef __cplusplus
 #include <cstddef>
@@ -16,8 +17,6 @@ extern "C"
 #include <stddef.h>
 #include <stdbool.h>
 #endif
-
-#include "azure_c_shared_utility/vector_types.h"
 
 /* creation */
 MOCKABLE_FUNCTION(, VECTOR_HANDLE, VECTOR_create, size_t, elementSize);

--- a/inc/azure_c_shared_utility/wsio.h
+++ b/inc/azure_c_shared_utility/wsio.h
@@ -4,6 +4,10 @@
 #ifndef WSIO_H
 #define WSIO_H
 
+#include "azure_c_shared_utility/xio.h"
+#include "azure_c_shared_utility/xlogging.h"
+#include "azure_c_shared_utility/umock_c_prod.h"
+
 #ifdef __cplusplus
 extern "C" {
 #include <cstddef>
@@ -12,10 +16,6 @@ extern "C" {
 #include <stddef.h>
 #include <stdbool.h>
 #endif /* __cplusplus */
-
-#include "azure_c_shared_utility/xio.h"
-#include "azure_c_shared_utility/xlogging.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
 
 typedef struct WSIO_CONFIG_TAG
 {


### PR DESCRIPTION
Otherwise building with g++ may fail if headers are included in
"wrong" order.

This should fix #101 