### PR TITLE
Add stdint.h back in because it breaks parent project

### DIFF
--- a/inc/azure_c_shared_utility/tickcounter.h
+++ b/inc/azure_c_shared_utility/tickcounter.h
@@ -8,6 +8,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include <stdint.h>
+
 #include "azure_c_shared_utility/umock_c_prod.h"
 
     typedef uint_fast32_t tickcounter_ms_t;


### PR DESCRIPTION
Removing stdint.h broke the azure-iot-sdk-c compile. Added back stdint.h which should be fine with both C and C++ compilers. Include cstdint is missing from early g++ compilers.