### PR TITLE
Fix CMake error with installed dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,8 +505,14 @@ if(${use_installed_dependencies})
 
     # Install Azure C Shared Utility
     set(package_location "cmake")
-
-    install (TARGETS aziotsharedutil aziotsharedutil_dll EXPORT aziotsharedutilTargets
+    
+    if(${build_as_dynamic})
+        set(targets aziotsharedutil aziotsharedutil_dll)
+    else(${build_as_dynamic})
+        set(targets aziotsharedutil)
+    endif(${build_as_dynamic})
+    
+    install (TARGETS ${targets} EXPORT aziotsharedutilTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin


### PR DESCRIPTION
Bug in makefile attempts to install dynamic module when it is not building it. This addresses the issue raised here: https://github.com/Azure/azure-c-shared-utility/issues/98
