### PR TITLE
Add ECC support for curl in HTTP API

### DIFF
--- a/adapters/httpapi_curl.c
+++ b/adapters/httpapi_curl.c
@@ -854,7 +854,7 @@ HTTPAPI_RESULT HTTPAPI_CloneOption(const char* optionName, const void* value, co
                 result = HTTPAPI_OK;
             }
         }
-        else if (strcmp(SU_OPTION_X509_CERT, optionName) == 0)
+        else if (strcmp(SU_OPTION_X509_CERT, optionName) == 0 || strcmp(OPTION_X509_ECC_CERT, optionName) == 0)
         {
             /*this is getting the x509 certificate. In this case, value is a pointer to a const char* that contains the certificate as a null terminated string*/
             if (mallocAndStrcpy_s((char**)savedValue, value) != 0)
@@ -868,7 +868,7 @@ HTTPAPI_RESULT HTTPAPI_CloneOption(const char* optionName, const void* value, co
                 result = HTTPAPI_OK;
             }
         }
-        else if (strcmp(SU_OPTION_X509_PRIVATE_KEY, optionName) == 0)
+        else if (strcmp(SU_OPTION_X509_PRIVATE_KEY, optionName) == 0 || strcmp(OPTION_X509_ECC_KEY, optionName) == 0)
         {
             /*this is getting the x509 private key. In this case, value is a pointer to a const char* that contains the private key as a null terminated string*/
             if (mallocAndStrcpy_s((char**)savedValue, value) != 0)


### PR DESCRIPTION
Hi,

We need ECC support in HTTP API for Linux but the adapter for curl does not implement the option to set ECC credentials.

We added the support of `OPTION_X509_ECC_KEY` and `OPTION_X509_ECC_CERT` options in  in `HTTPAPI_SetOption` method.

We also added a boolean flag `isECC` that let us know if we need to use the `x509_openssl_add_credentials` of `x509_openssl_add_ecc_credentials` function.

We checked that the unit tests pass.