### PR TITLE
Add UUID defines to .DEF file, since a call to UUID_to_string was added

### DIFF
--- a/src/aziotsharedutil.def
+++ b/src/aziotsharedutil.def
@@ -174,6 +174,9 @@ EXPORTS
     USHAResult
     UniqueId_Generate
     Unlock
+    UUID_generate
+    UUID_from_string
+    UUID_to_string
     VECTOR_back
     VECTOR_clear
     VECTOR_create


### PR DESCRIPTION
Add UUID defines to .DEF file, since a call to UUID_to_string was added in uamqp_messaging.c