### PR TITLE
change Proxy to default access in httpapi_winhttp.c

### DIFF
--- a/adapters/httpapi_winhttp.c
+++ b/adapters/httpapi_winhttp.c
@@ -130,7 +130,7 @@ HTTPAPI_RESULT HTTPAPI_Init(void)
     {
         if ((g_SessionHandle = WinHttpOpen(
             NULL,
-            WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+            WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
             WINHTTP_NO_PROXY_NAME,
             WINHTTP_NO_PROXY_BYPASS,
             0)) == NULL)


### PR DESCRIPTION
This PR is to change the default proxy configuration so that the SDK can retreive the system configuration on Windows for the HTTP API.

As I understood this should have been the normal behavior as @tameraw told me in a previous issue ( see https://github.com/Azure/azure-c-shared-utility/issues/103#issuecomment-325265256 )

I also aded in the SetOption the OPTION_HTTP_PROXY case, that has a similar behavior as the "TrustedCerts" option.