### PR TITLE
The refcount include directories are not needed on installed libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,17 +383,17 @@ endif()
 add_library(aziotsharedutil ${source_c_files} ${source_h_files})
 
 
-target_include_directories(aziotsharedutil PUBLIC ${SHARED_UTIL_INC_FOLDER})
+target_include_directories(aziotsharedutil PRIVATE ${SHARED_UTIL_INC_FOLDER})
 if(MSVC)
     set(source_h_files ${source_h_files}
         ./pal/windows/refcount_os.h
     )
-    target_include_directories(aziotsharedutil PUBLIC ${SHARED_UTIL_FOLDER}/pal/windows)
+    target_include_directories(aziotsharedutil PRIVATE ${SHARED_UTIL_FOLDER}/pal/windows)
 else()
     set(source_h_files ${source_h_files}
         ./pal/linux/refcount_os.h
     )
-    target_include_directories(aziotsharedutil PUBLIC ${SHARED_UTIL_FOLDER}/pal/linux)
+    target_include_directories(aziotsharedutil PRIVATE ${SHARED_UTIL_FOLDER}/pal/linux)
 endif()
 
 


### PR DESCRIPTION
Changed calls to `target_include_directories()`  to add the source include directories as PRIVATE, so that CMake doesn't balk at these directories on installation.  On c-utility installation, the appropriate files are copied into `${INSTALL_PATH}/azureiot/azure_c_shared_utility`, so these source directories shouldn't be a part of the `INTERFACE_INCLUDE_DIRECTORIES`.

I was able to compile the c-sdk with this change on Linux x64 and Windows.  It seems that when c-utility is pulled in as a subdirectory, CMake finds the correct include directories.  The trick is you won't know if all the platforms work until you attempt to build the C-SDK with this change. :(