### PR TITLE
Fix HTTP_API proxy credentials

### DIFF
--- a/inc/azure_c_shared_utility/httpapi.h
+++ b/inc/azure_c_shared_utility/httpapi.h
@@ -68,6 +68,8 @@ DEFINE_ENUM(HTTPAPI_RESULT, HTTPAPI_RESULT_VALUES);
 DEFINE_ENUM(HTTPAPI_REQUEST_TYPE, HTTPAPI_REQUEST_TYPE_VALUES);
 
 #define MAX_HOSTNAME_LEN        65
+#define MAX_USERNAME_LEN        65
+#define MAX_PASSWORD_LEN        65
 
 /**
  * @brief	Global initialization for the HTTP API component.


### PR DESCRIPTION
Hi,

It seems that the current implementation of the proxy support for HTTP_API contains a bug. When sending the request to a proxy server that requests user name and password, the expected http header `Proxy-Authorization` ([see](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization)) is missing:

**Problem**: Using `WinHttpSetOption` with the option flag `WINHTTP_OPTION_PROXY_USERNAME` or `WINHTTP_OPTION_PROXY_PASSWORD` seems not  to have any effect on the corresponding `HINTERNET` request.

**Solution**: Using `WinHttpSetCredentials` function instead of `WinHttpSetOption` fixes the missing header in the http request and is recommended ([see](https://msdn.microsoft.com/en-us/library/windows/desktop/aa384112(v=vs.85).aspx)).

I also changed the previous use of `mbstowcs` and used the secure `mbstowcs_s`.

Thanks,
Alexis.