### PR TITLE
Avoid warnings about narrowing wchar_t -> char in basic_string's range constructor

### DIFF
--- a/testtools/micromock/inc/mockvalue.h
+++ b/testtools/micromock/inc/mockvalue.h
@@ -160,13 +160,18 @@ public:
 
     virtual std::tstring ToString() const
     {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4244)
+#endif // _MSC_VER
             std::string temp(m_Value.begin(), m_Value.end());
 
             std::tostringstream strStream;
             strStream << temp.c_str();
             return strStream.str();
-
-
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
     }
 
     virtual bool EqualTo(_In_ const CMockValueBase* right)
@@ -223,11 +228,18 @@ public:
 
     virtual std::tstring ToString() const
     {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4244)
+#endif // _MSC_VER
             std::string temp(m_Value.begin(), m_Value.end());
 
             std::tostringstream strStream;
             strStream << temp.c_str();
             return strStream.str();
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
     }
 
     virtual bool EqualTo(_In_ const CMockValueBase* right)


### PR DESCRIPTION
This change preserves the existing behavior rather than doing an encoding transformation; an encoding transform may be desired instead.

This warning was exposed by removal of an unintentional static_cast previously in basic_string which will be removed in a future release of Visual C++.