### PR TITLE
Fix compiling for MinGW-W64

### DIFF
--- a/inc/azure_c_shared_utility/crt_abstractions.h
+++ b/inc/azure_c_shared_utility/crt_abstractions.h
@@ -81,8 +81,8 @@ typedef unsigned char bool;
 /* Codes_SRS_CRT_ABSTRACTIONS_99_001:[The module shall not redefine the secure functions implemented by Microsoft CRT.] */
 /* Codes_SRS_CRT_ABSTRACTIONS_99_040 : [The module shall still compile when building on a Microsoft platform.] */
 /* Codes_SRS_CRT_ABSTRACTIONS_99_002: [CRTAbstractions module shall expose the following API]*/
-#ifdef _MSC_VER
-#else // _MSC_VER
+#if defined (_MSC_VER) || defined (MINGW_HAS_SECURE_API)
+#else // _MSC_VER || MINGW_HAS_SECURE_API
 
 /* Adding definitions from errno.h & crtdefs.h */
 #if !defined (_TRUNCATE)
@@ -97,7 +97,7 @@ extern int strcpy_s(char* dst, size_t dstSizeInBytes, const char* src);
 extern int strcat_s(char* dst, size_t dstSizeInBytes, const char* src);
 extern int strncpy_s(char* dst, size_t dstSizeInBytes, const char* src, size_t maxCount);
 extern int sprintf_s(char* dst, size_t dstSizeInBytes, const char* format, ...);
-#endif // _MSC_VER
+#endif // _MSC_VER || MINGW_HAS_SECURE_API
 
 extern unsigned long long strtoull_s(const char* nptr, char** endPtr, int base);
 extern float strtof_s(const char* nptr, char** endPtr);

--- a/src/crt_abstractions.c
+++ b/src/crt_abstractions.c
@@ -41,7 +41,7 @@
 #define NAN        ((float)(INFINITY * 0.0F))
 #endif
 
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined (MINGW_HAS_SECURE_API)
 #else
 
 /*Codes_SRS_CRT_ABSTRACTIONS_99_008: [strcat_s shall append the src to dst and terminates the resulting string with a null character.]*/
@@ -274,7 +274,7 @@ int sprintf_s(char* dst, size_t dstSizeInBytes, const char* format, ...)
     }
     return result;
 }
-#endif /* _MSC_VER */
+#endif /* _MSC_VER || MINGW_HAS_SECURE_API */
 
 /*Codes_SRS_CRT_ABSTRACTIONS_21_006: [The strtoull_s must use the letters from a(or A) through z(or Z) to represent the numbers between 10 to 35.]*/
 /* returns the integer value that correspond to the character 'c'. If the character is invalid, it returns -1. */


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
None.

# Description of the problem
Azure IoT SDK does not compile in Windows using MinGW-W64 compiler.

# Description of the solution
1) Disabled secure string functions "strcpy_s", "strcat_s", "strncpy_s", "sprintf_s" in 'azure-c-shared-utility' if they are already defined and implemented in MinGW-W64.
2) Added missing LogErrorWinHTTPWithGetLastErrorAsString macro definition for non-Microsoft compilers.