### PR TITLE
Fix compilation with older GCC

### DIFF
--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -263,7 +263,7 @@ static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* soc
 
     struct addrinfo addrInfoHintIp;
     struct sockaddr_un addrInfoUn;
-    struct sockaddr* connect_addr;
+    struct sockaddr* connect_addr = NULL;
     socklen_t connect_addr_len;
     struct addrinfo* addrInfoIp = NULL;
 


### PR DESCRIPTION
## Reference/Link to the issue solved with this PR (if any)
None. 

## Description of the problem
Old `gcc` was unable to deduce that certain pointer is being initialized inside the function and it produced a warning which led to a build-time error. Error message as follows:

```
c-utility/adapters/socketio_berkeley.c: In function 'socketio_open':
c-utility/adapters/socketio_berkeley.c:323:17: error: 'connect_addr' may be used uninitialized in this function [-Werror=maybe-uninitialized]
             err = connect(socket_io_instance->socket, connect_addr, connect_addr_len);
                 ^
c-utility/adapters/socketio_berkeley.c:266:22: note: 'connect_addr' was declared here
     struct sockaddr* connect_addr;
                      ^
cc1: all warnings being treated as errors
```

Compiler version:
```
mips-openwrt-linux-gcc (OpenWrt/Linaro GCC 4.8-2014.04 r49163) 4.8.3
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

## Description of the solution
Now variable `connect_addr` is explicitly initialized to `NULL` pointer to silence the compiler warning (also it definitely won't harm to initialize it anyway).