### PR TITLE
Fix #174: avoid new GCC 8.2 warnings (s/strncpy/memcpy/)

### DIFF
--- a/src/crt_abstractions.c
+++ b/src/crt_abstractions.c
@@ -146,7 +146,7 @@ int strncpy_s(char* dst, size_t dstSizeInBytes, const char* src, size_t maxCount
             }
             else
             {
-                (void)strncpy(dst, src, srcLength);
+                (void)memcpy(dst, src, srcLength);
                 dst[srcLength] = '\0';
                 /*Codes_SRS_CRT_ABSTRACTIONS_99_018: [strncpy_s shall return Zero upon success]*/
                 result = 0;
@@ -160,7 +160,7 @@ int strncpy_s(char* dst, size_t dstSizeInBytes, const char* src, size_t maxCount
                 srcLength = dstSizeInBytes - 1;
                 truncationFlag = 1;
             }
-            (void)strncpy(dst, src, srcLength);
+            (void)memcpy(dst, src, srcLength);
             dst[srcLength] = '\0';
             result = 0;
         }


### PR DESCRIPTION
GCC 8.2 is not able to determine that the length is OK for dst
and thus moans about the usage of strncpy.

How it is done, memcpy seems more appropriate to be used.

Maybe in the future this code can be even more simplified.