### PR TITLE
Rename UUID type to UUID_T to avoid collisions with Windows types

### DIFF
--- a/devdoc/uuid_requirements.md
+++ b/devdoc/uuid_requirements.md
@@ -6,16 +6,16 @@ The UUID module provides functions to create and convert UUID values.
 
 ## Exposed API
 ```c
-typedef unsigned char UUID[16];
+typedef unsigned char UUID_T[16];
 
-extern int UUID_generate(UUID* uuid);
-extern int UUID_from_string(char* uuid_string, UUID* uuid);
-extern char* UUID_to_string(UUID* uuid);
+extern int UUID_generate(UUID_T* uuid);
+extern int UUID_from_string(char* uuid_string, UUID_T* uuid);
+extern char* UUID_to_string(UUID_T* uuid);
 ```
 
 ###  UUID_generate
 ```c
-extern int UUID_generate(UUID* uuid);
+extern int UUID_generate(UUID_T* uuid);
 ```
 **SRS_UUID_09_001: [** If `uuid` is NULL, UUID_generate shall return a non-zero value **]**
 
@@ -23,7 +23,7 @@ extern int UUID_generate(UUID* uuid);
 
 **SRS_UUID_09_003: [** If the UUID string fails to be obtained, UUID_generate shall fail and return a non-zero value **]**
 
-**SRS_UUID_09_004: [** The UUID string shall be parsed into an UUID type (16 unsigned char array) and filled in `uuid` **]**  
+**SRS_UUID_09_004: [** The UUID string shall be parsed into an UUID_T type (16 unsigned char array) and filled in `uuid` **]**  
 
 **SRS_UUID_09_005: [** If `uuid` fails to be set, UUID_generate shall fail and return a non-zero value **]**
 
@@ -32,7 +32,7 @@ extern int UUID_generate(UUID* uuid);
 
 ###  UUID_from_string
 ```c
-extern int UUID_from_string(char* uuid_string, UUID* uuid);
+extern int UUID_from_string(char* uuid_string, UUID_T* uuid);
 ```
 **SRS_UUID_09_007: [** If `uuid_string` or `uuid` are NULL, UUID_from_string shall return a non-zero value **]**
 
@@ -45,7 +45,7 @@ extern int UUID_from_string(char* uuid_string, UUID* uuid);
 
 ###  UUID_to_string
 ```c
-extern char* UUID_to_string(UUID* uuid);
+extern char* UUID_to_string(UUID_T* uuid);
 ```
 **SRS_UUID_09_011: [** If `uuid` is NULL, UUID_to_string shall return a non-zero value **]**  
 

--- a/inc/azure_c_shared_utility/uuid.h
+++ b/inc/azure_c_shared_utility/uuid.h
@@ -16,26 +16,26 @@ extern "C" {
 
 #include "azure_c_shared_utility/umock_c_prod.h"
 
-typedef unsigned char UUID[16];
+typedef unsigned char UUID_T[16];
 
 /* @brief               Generates a true UUID
 *  @param uuid          A pre-allocated buffer for the bytes of the generated UUID
 *  @returns             Zero if no failures occur, non-zero otherwise.
 */
-MOCKABLE_FUNCTION(, int, UUID_generate, UUID*, uuid);
+MOCKABLE_FUNCTION(, int, UUID_generate, UUID_T*, uuid);
 
 /* @brief               Gets the UUID value (byte sequence) of an well-formed UUID string.
 *  @param uuid_string   A null-terminated well-formed UUID string (e.g., "7f907d75-5e13-44cf-a1a3-19a01a2b4528").
 *  @param uuid          Sequence of bytes representing an UUID.
 *  @returns             Zero if no failures occur, non-zero otherwise.
 */
-MOCKABLE_FUNCTION(, int, UUID_from_string, const char*, uuid_string, UUID*, uuid);
+MOCKABLE_FUNCTION(, int, UUID_from_string, const char*, uuid_string, UUID_T*, uuid);
 
 /* @brief               Gets the string representation of the UUID value.
 *  @param uuid          Sequence of bytes representing an UUID.
 *  @returns             A null-terminated string representation of the UUID value provided (e.g., "7f907d75-5e13-44cf-a1a3-19a01a2b4528").
 */
-MOCKABLE_FUNCTION(, char*, UUID_to_string, UUID*, uuid);
+MOCKABLE_FUNCTION(, char*, UUID_to_string, UUID_T*, uuid);
 
 #ifdef __cplusplus
 }

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -14,7 +14,7 @@
 #define __SUCCESS__                 0
 #define UUID_FORMAT_STRING          "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
 
-int UUID_from_string(const char* uuid_string, UUID* uuid)
+int UUID_from_string(const char* uuid_string, UUID_T* uuid)
 {
     int result;
 
@@ -75,7 +75,7 @@ int UUID_from_string(const char* uuid_string, UUID* uuid)
     return result;
 }
 
-char* UUID_to_string(UUID* uuid)
+char* UUID_to_string(UUID_T* uuid)
 {
     char* result;
 
@@ -119,7 +119,7 @@ char* UUID_to_string(UUID* uuid)
     return result;
 }
 
-int UUID_generate(UUID* uuid)
+int UUID_generate(UUID_T* uuid)
 {
     int result;
 
@@ -141,7 +141,7 @@ int UUID_generate(UUID* uuid)
         }
         else
         {
-            memset(uuid_string, 0, sizeof(char) * UUID_STRING_SIZE);
+            (void)memset(uuid_string, 0, sizeof(char) * UUID_STRING_SIZE);
 
             // Codes_SRS_UUID_09_002: [ UUID_generate shall obtain an UUID string from UniqueId_Generate ]
             if (UniqueId_Generate(uuid_string, UUID_STRING_SIZE) != UNIQUEID_OK)
@@ -150,7 +150,7 @@ int UUID_generate(UUID* uuid)
                 LogError("Failed generating UUID");
                 result = __FAILURE__;
             }
-            // Codes_SRS_UUID_09_004: [ The UUID string shall be parsed into an UUID type (16 unsigned char array) and filled in `uuid` ]  
+            // Codes_SRS_UUID_09_004: [ The UUID string shall be parsed into an UUID_T type (16 unsigned char array) and filled in `uuid` ]  
             else if (UUID_from_string(uuid_string, uuid) != 0)
             {
                 // Codes_SRS_UUID_09_005: [ If `uuid` fails to be set, UUID_generate shall fail and return a non-zero value ]

--- a/tests/uuid_ut/uuid_ut.c
+++ b/tests/uuid_ut/uuid_ut.c
@@ -37,7 +37,7 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 #define UUID_STRING_LENGTH  36
 #define UUID_STRING_SIZE    (UUID_STRING_LENGTH + 1)
 
-static UUID TEST_UUID = { 222, 193, 74, 152, 197, 252, 67, 14, 180, 227, 51, 193, 196, 52, 220, 175 };
+static UUID_T TEST_UUID = { 222, 193, 74, 152, 197, 252, 67, 14, 180, 227, 51, 193, 196, 52, 220, 175 };
 static char* TEST_UUID_STRING = "dec14a98-c5fc-430e-b4e3-33c1c434dcaf";
 
 static UNIQUEID_RESULT mock_UniqueId_Generate_result;
@@ -124,12 +124,12 @@ TEST_FUNCTION(UUID_generate_NULL_uuid)
 }
 
 // Tests_SRS_UUID_09_002: [ UUID_generate shall obtain an UUID string from UniqueId_Generate ]
-// Tests_SRS_UUID_09_004: [ The UUID string shall be parsed into an UUID type (16 unsigned char array) and filled in `uuid` ]  
+// Tests_SRS_UUID_09_004: [ The UUID string shall be parsed into an UUID_T type (16 unsigned char array) and filled in `uuid` ]  
 // Tests_SRS_UUID_09_006: [ If no failures occur, UUID_generate shall return zero ]
 TEST_FUNCTION(UUID_generate_succeed)
 {
     //Arrange
-    UUID uuid;
+    UUID_T uuid;
     int result;
     char uuid_string[UUID_STRING_SIZE];
 
@@ -160,7 +160,7 @@ TEST_FUNCTION(UUID_generate_succeed)
 TEST_FUNCTION(UUID_generate_failure_checks)
 {
     //Arrange
-    UUID uuid;
+    UUID_T uuid;
     int result;
     size_t i;
     char uuid_string[UUID_STRING_SIZE];
@@ -271,7 +271,7 @@ TEST_FUNCTION(UUID_from_string_NULL_uuid_string)
 {
     //Arrange
     int result;
-    UUID uuid;
+    UUID_T uuid;
 
     umock_c_reset_all_calls();
 
@@ -305,7 +305,7 @@ TEST_FUNCTION(UUID_from_string_succeed)
 {
     //Arrange
     int result;
-    UUID uuid;
+    UUID_T uuid;
 
     umock_c_reset_all_calls();
 


### PR DESCRIPTION
This addresses the collision reported in #162.
After this is merged in a PR for uamqp will be issued, since that seems to be the only downstream repo that needs it.