### PR TITLE
Support for building with VC++ 9.0

### DIFF
--- a/adapters/x509_schannel.c
+++ b/adapters/x509_schannel.c
@@ -73,7 +73,18 @@ static unsigned char* convert_cert_to_binary(const char* crypt_value, DWORD* cry
 static unsigned char* decode_crypt_object(unsigned char* private_key, DWORD key_length, DWORD* blob_size, x509_CERT_TYPE* cert_type)
 {
     unsigned char* result;
+    
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4306)
+#endif // _MSC_VER
+
     LPCSTR key_type = PKCS_RSA_PRIVATE_KEY;
+    
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
+
     DWORD private_key_blob_size = 0;
 
     /*Codes_SRS_X509_SCHANNEL_02_004: [ x509_schannel_create shall decode the private key by calling CryptDecodeObjectEx. ]*/


### PR DESCRIPTION
Suppresses the following warning when building x64 in Visual Studio 2008:
```
azure-c-shared-utility\adapters\x509_schannel.c(76) : warning C4306: 'type cast' : conversion from 'int' to 'LPCSTR' of greater size
```

Resolves issue #187 