### PR TITLE
Improve const buffer to do only one malloc

### DIFF
--- a/inc/azure_c_shared_utility/refcount.h
+++ b/inc/azure_c_shared_utility/refcount.h
@@ -63,15 +63,19 @@ static type* REFCOUNT_TYPE_DECLARE_CREATE(type) (void)                          
 #ifndef DEC_RETURN_ZERO
 #error refcount_os.h does not define DEC_RETURN_ZERO
 #endif // !DEC_RETURN_ZERO
-#ifndef INC_REF
-#error refcount_os.h does not define INC_REF
+#ifndef INC_REF_VAR
+#error refcount_os.h does not define INC_REF_VAR
 #endif // !INC_REF
-#ifndef DEC_REF
-#error refcount_os.h does not define DEC_REF
+#ifndef DEC_REF_VAR
+#error refcount_os.h does not define DEC_REF_VAR
 #endif // !DEC_REF
-#ifndef INIT_REF
-#error refcount_os.h does not define INIT_REF
+#ifndef INIT_REF_VAR
+#error refcount_os.h does not define INIT_REF_VAR
 #endif // !INIT_REF
+
+#define INC_REF(type, var) INC_REF_VAR(((REFCOUNT_TYPE(type)*)var)->count)
+#define DEC_REF(type, var) DEC_REF_VAR(((REFCOUNT_TYPE(type)*)var)->count)
+#define INIT_REF(type, var) INIT_REF_VAR(((REFCOUNT_TYPE(type)*)var)->count)
 
 #ifdef __cplusplus
 }

--- a/pal/generic/refcount_os.h
+++ b/pal/generic/refcount_os.h
@@ -13,8 +13,9 @@
 #define COUNT_TYPE uint32_t
 
 #define DEC_RETURN_ZERO (0)
-#define INC_REF(type, var) ++((((REFCOUNT_TYPE(type)*)var)->count))
-#define DEC_REF(type, var) --((((REFCOUNT_TYPE(type)*)var)->count))
-#define INIT_REF(type, var) do { ((REFCOUNT_TYPE(type)*)var)->count = 1; } while((void)0,0)
+
+#define INC_REF_VAR(count) ++(count)
+#define DEC_REF_VAR(count) --(count)
+#define INIT_REF_VAR(count) do { count = 1; } while((void)0,0)
 
 #endif // REFCOUNT_OS_H__GENERIC

--- a/pal/linux/refcount_os.h
+++ b/pal/linux/refcount_os.h
@@ -57,22 +57,22 @@ gcc
 /*if macro DEC_REF returns DEC_RETURN_ZERO that means the ref count has reached zero.*/
 #if defined(REFCOUNT_ATOMIC_DONTCARE)
 #define DEC_RETURN_ZERO (0)
-#define INC_REF(type, var) ++((((REFCOUNT_TYPE(type)*)var)->count))
-#define DEC_REF(type, var) --((((REFCOUNT_TYPE(type)*)var)->count))
-#define INIT_REF(type, var) do { ((REFCOUNT_TYPE(type)*)var)->count = 1; } while((void)0,0)
+#define INC_REF_VAR(count) ++(count)
+#define DEC_REF_VAR(count) --(count)
+#define INIT_REF_VAR(count) do { count = 1; } while((void)0,0)
 
 #elif defined(REFCOUNT_USE_STD_ATOMIC)
 #include <stdatomic.h>
 #define DEC_RETURN_ZERO (1)
-#define INC_REF(type, var) atomic_fetch_add((&((REFCOUNT_TYPE(type)*)var)->count), 1)
-#define DEC_REF(type, var) atomic_fetch_sub((&((REFCOUNT_TYPE(type)*)var)->count), 1)
-#define INIT_REF(type, var) atomic_store(&((REFCOUNT_TYPE(type)*)var)->count, 1)
+#define INC_REF_VAR(count) atomic_fetch_add(&(count), 1)
+#define DEC_REF_VAR(count) atomic_fetch_sub(&(count), 1)
+#define INIT_REF_VAR(count) atomic_store(&(count), 1)
 
 #elif defined(REFCOUNT_USE_GNU_C_ATOMIC)
 #define DEC_RETURN_ZERO (0)
-#define INC_REF(type, var) __sync_add_and_fetch((&((REFCOUNT_TYPE(type)*)var)->count), 1)
-#define DEC_REF(type, var) __sync_sub_and_fetch((&((REFCOUNT_TYPE(type)*)var)->count), 1)
-#define INIT_REF(type, var) do { ((REFCOUNT_TYPE(type)*)var)->count = 1; __sync_synchronize(); } while((void)0,0)
+#define INC_REF_VAR(count) __sync_add_and_fetch(&(count), 1)
+#define DEC_REF_VAR(count) __sync_sub_and_fetch(&(count), 1)
+#define INIT_REF_VAR(count) do { count = 1; __sync_synchronize(); } while((void)0,0)
 
 #endif /*defined(REFCOUNT_USE_GNU_C_ATOMIC)*/
 

--- a/pal/windows/refcount_os.h
+++ b/pal/windows/refcount_os.h
@@ -14,8 +14,8 @@
 
 /*if macro DEC_REF returns DEC_RETURN_ZERO that means the ref count has reached zero.*/
 #define DEC_RETURN_ZERO (0)
-#define INC_REF(type, var) InterlockedIncrement(&(((REFCOUNT_TYPE(type)*)var)->count))
-#define DEC_REF(type, var) InterlockedDecrement(&(((REFCOUNT_TYPE(type)*)var)->count))
-#define INIT_REF(type, var) InterlockedExchange(&(((REFCOUNT_TYPE(type)*)var)->count), 1)
+#define INC_REF_VAR(count) InterlockedIncrement(&(count))
+#define DEC_REF_VAR(count) InterlockedDecrement(&(count))
+#define INIT_REF_VAR(count) InterlockedExchange(&(count), 1)
 
 #endif // REFCOUNT_OS_H__WINDOWS

--- a/tests/constbuffer_ut/constbuffer_ut.c
+++ b/tests/constbuffer_ut/constbuffer_ut.c
@@ -9,32 +9,11 @@
 #include <stddef.h>
 #endif
 
-
 #include "testrunnerswitcher.h"
-
-static size_t currentmalloc_call = 0;
-static size_t whenShallmalloc_fail = 0;
 
 void* my_gballoc_malloc(size_t size)
 {
-    void* result;
-    currentmalloc_call++;
-    if (whenShallmalloc_fail > 0)
-    {
-        if (currentmalloc_call == whenShallmalloc_fail)
-        {
-            result = NULL;
-        }
-        else
-        {
-            result = malloc(size);
-        }
-    }
-    else
-    {
-        result = malloc(size);
-    }
-    return result;
+    return malloc(size);
 }
 
 void my_gballoc_free(void* ptr)
@@ -139,10 +118,6 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         }
 
         umock_c_reset_all_calls();
-
-        currentmalloc_call = 0;
-        whenShallmalloc_fail = 0;
-
     }
 
     TEST_FUNCTION_CLEANUP(cleans)
@@ -173,11 +148,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         const CONSTBUFFER* content;
 
         ///act
-        /*this is the handle*/
-        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
-            .IgnoreArgument(1);
-        /*this is the content*/
-        STRICT_EXPECTED_CALL(gballoc_malloc(BUFFER1_length));
+        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
         handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
 
@@ -206,11 +177,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ///act
         STRICT_EXPECTED_CALL(BUFFER_length(BUFFER1_HANDLE));
         STRICT_EXPECTED_CALL(BUFFER_u_char(BUFFER1_HANDLE));
-        /*this is the handle*/
-        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
-            .IgnoreArgument(1);
-        /*this is the content*/
-        STRICT_EXPECTED_CALL(gballoc_malloc(BUFFER1_length));
+        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
         handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
 
@@ -229,7 +196,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     }
 
     /*Tests_SRS_CONSTBUFFER_02_008: [If copying the content fails, then CONSTBUFFER_CreateFromBuffer shall fail and return NULL.]*/
-    TEST_FUNCTION(CONSTBUFFER_CreateFromBuffer_fails_when_malloc_fails_1)
+    TEST_FUNCTION(CONSTBUFFER_CreateFromBuffer_fails_when_malloc_fails)
     {
         ///arrange
         CONSTBUFFER_HANDLE handle;
@@ -238,41 +205,9 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         STRICT_EXPECTED_CALL(BUFFER_length(BUFFER1_HANDLE));
         STRICT_EXPECTED_CALL(BUFFER_u_char(BUFFER1_HANDLE));
 
-        /*this is the handle*/
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
-            .IgnoreArgument(1);
+            .SetReturn(NULL);
 
-        /*this is the content*/
-        whenShallmalloc_fail = 2;
-        STRICT_EXPECTED_CALL(gballoc_malloc(BUFFER1_length));
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument(1);
-
-
-        handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
-
-        ///assert
-        ASSERT_IS_NULL(handle);
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-        ///cleanup
-        CONSTBUFFER_Destroy(handle);
-    }
-
-    /*Tests_SRS_CONSTBUFFER_02_008: [If copying the content fails, then CONSTBUFFER_CreateFromBuffer shall fail and return NULL.]*/
-    TEST_FUNCTION(CONSTBUFFER_CreateFromBuffer_fails_when_malloc_fails_2)
-    {
-        ///arrange
-        CONSTBUFFER_HANDLE handle;
-
-        ///act
-        STRICT_EXPECTED_CALL(BUFFER_length(BUFFER1_HANDLE));
-        STRICT_EXPECTED_CALL(BUFFER_u_char(BUFFER1_HANDLE));
-
-        /*this is the handle*/
-        whenShallmalloc_fail = 1;
-        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
-            .IgnoreArgument(1);
 
         handle = CONSTBUFFER_CreateFromBuffer(BUFFER1_HANDLE);
 
@@ -310,12 +245,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         umock_c_reset_all_calls();
         ///act
 
-        /*this is the content*/
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument(1);
-        /*this is the handle*/
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument(1);
+        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
         CONSTBUFFER_Destroy(handle);
 
@@ -326,41 +256,14 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     }
 
     /*Tests_SRS_CONSTBUFFER_02_003: [If creating the copy fails then CONSTBUFFER_Create shall return NULL.]*/
-    TEST_FUNCTION(CONSTBUFFER_Create_fails_when_malloc_fails_1)
+    TEST_FUNCTION(CONSTBUFFER_Create_fails_when_malloc_fails)
     {
         ///arrange
         CONSTBUFFER_HANDLE handle;
 
         ///act
-        /*this is the handle*/
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
-            .IgnoreArgument(1);
-        /*this is the content*/
-        whenShallmalloc_fail = 2;
-        STRICT_EXPECTED_CALL(gballoc_malloc(BUFFER1_length));
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument(1);
-
-        handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
-
-        ///assert
-        ASSERT_IS_NULL(handle);
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-        ///cleanup
-    }
-
-    /*Tests_SRS_CONSTBUFFER_02_003: [If creating the copy fails then CONSTBUFFER_Create shall return NULL.]*/
-    TEST_FUNCTION(CONSTBUFFER_Create_fails_when_malloc_fails_2)
-    {
-        ///arrange
-        CONSTBUFFER_HANDLE handle;
-
-        ///act
-        /*this is the handle*/
-        whenShallmalloc_fail = 1;
-        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
-            .IgnoreArgument(1);
+            .SetReturn(NULL);
 
         handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
 
@@ -380,12 +283,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         umock_c_reset_all_calls();
         ///act
 
-        /*this is the content*/
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument(1);
-        /*this is the handle*/
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument(1);
+        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
         CONSTBUFFER_Destroy(handle);
 
@@ -403,9 +301,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         const CONSTBUFFER* content;
 
         ///act
-        /*this is the handle*/
-        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
-            .IgnoreArgument(1);
+        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
         handle = CONSTBUFFER_Create(BUFFER2_u_char, BUFFER2_length);
 
@@ -430,9 +326,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         const CONSTBUFFER* content;
 
         ///act
-        /*this is the handle*/
-        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
-            .IgnoreArgument(1);
+        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
         handle = CONSTBUFFER_Create(BUFFER3_u_char, BUFFER3_length);
 
@@ -577,12 +471,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         umock_c_reset_all_calls();
 
         ///act
-        /*this is the content*/
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument(1);
-        /*this is the handle*/
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument(1);
+        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
         CONSTBUFFER_Destroy(clone);
 
         ///assert


### PR DESCRIPTION
- Improve const buffer to do only one malloc
- Created INIT_VAR/INC_VAR/DEC_VAR macros in the refcount_os implementations for Windows/Linux/Generic. This is in order that we can use this abstraction without being bound to a ref count type from refcount.h. This will also help us in other projects :-).
- Removed some oldies but goldies from the const buffer tests

Having the specs and test suite there was so awesome!


