### PR TITLE
Put VS2017 folders in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 /cmake
 /devdoc/~$o_requirements.docm
 /.vscode
+/.vs
 *.jar
 *.aps
 /res
+/testtools/SerialPort/SerialPort/obj/
+/tools/compilembed/obj/
+/tools/macro_utils_h_generator/obj/


### PR DESCRIPTION
When opening azure-c-shared-utility in VS2017 (using its CMake support),
VS2017 creates a couple folders.

* .vs
* obj folders next to .slns

This adds those folders into the .gitignore file