### PR TITLE
[0] -> [] in refcount test code

### DIFF
--- a/tests/refcount_ut/some_refcount_impl.c
+++ b/tests/refcount_ut/some_refcount_impl.c
@@ -12,7 +12,7 @@ typedef struct pos_TAG
     /*warning C4200: nonstandard extension used: zero-sized array in struct/union */
 #pragma warning(disable:4200)
 #endif
-    int flexible_array[0];
+    int flexible_array[];
 } pos;
 
 DEFINE_REFCOUNT_TYPE(pos);


### PR DESCRIPTION
Update some_refcount_impl.c that is used in refcount tests to have [] instead of [0]