### PR TITLE
Support UNIX domain sockets in Windows RS5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ if(${use_applessl})
     include_directories(./pal/ios-osx/)
 endif()
 
-if (WIN32 AND ${CMAKE_SYSTEM_VERSION} VERSION_GREATER_EQUAL "10.0.17763.0")
+if (WIN32 AND (${CMAKE_SYSTEM_VERSION} VERSION_EQUAL "10.0.17763.0" OR ${CMAKE_SYSTEM_VERSION} VERSION_GREATER "10.0.17763.0"))
     # Windows added support for UNIX domain sockets to the OS and SDK
     # in the Oct 2018 update (10.0.17763.0, aka RS5)
     add_definitions(-DAF_UNIX_ON_WINDOWS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,12 @@ if(${use_applessl})
     include_directories(./pal/ios-osx/)
 endif()
 
+if (WIN32 AND ${CMAKE_SYSTEM_VERSION} VERSION_GREATER_EQUAL "10.0.17763.0")
+    # Windows added support for UNIX domain sockets to the OS and SDK
+    # in the Oct 2018 update (10.0.17763.0, aka RS5)
+    add_definitions(-DAF_UNIX_ON_WINDOWS)
+endif()
+
 #these are the C headers
 set(source_h_files
 ./inc/azure_c_shared_utility/agenttime.h

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -67,12 +67,6 @@ typedef enum IO_STATE_TAG
     IO_STATE_ERROR
 } IO_STATE;
 
-typedef enum ADDRESS_TYPE_TAG
-{
-    ADDRESS_TYPE_IP,
-    ADDRESS_TYPE_DOMAIN_SOCKET
-} ADDRESS_TYPE;
-
 typedef struct PENDING_SOCKET_IO_TAG
 {
     unsigned char* bytes;
@@ -85,7 +79,7 @@ typedef struct PENDING_SOCKET_IO_TAG
 typedef struct SOCKET_IO_INSTANCE_TAG
 {
     int socket;
-    ADDRESS_TYPE address_type;
+    SOCKETIO_ADDRESS_TYPE address_type;
     ON_BYTES_RECEIVED on_bytes_received;
     ON_IO_ERROR on_io_error;
     void* on_bytes_received_context;

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -8,11 +8,15 @@
 #include <ws2tcpip.h>
 #include <windows.h>
 #include <mstcpip.h>
+#ifdef AF_UNIX_ON_WINDOWS
+#include <afunix.h>
+#endif
 #include "azure_c_shared_utility/socketio.h"
 #include "azure_c_shared_utility/singlylinkedlist.h"
 #include "azure_c_shared_utility/gballoc.h"
 #include "azure_c_shared_utility/gbnetwork.h"
 #include "azure_c_shared_utility/optimize_size.h"
+#include "azure_c_shared_utility/shared_util_options.h"
 #include "azure_c_shared_utility/xlogging.h"
 
 typedef enum IO_STATE_TAG
@@ -35,6 +39,7 @@ typedef struct PENDING_SOCKET_IO_TAG
 typedef struct SOCKET_IO_INSTANCE_TAG
 {
     SOCKET socket;
+    SOCKETIO_ADDRESS_TYPE address_type;
     ON_BYTES_RECEIVED on_bytes_received;
     ON_IO_ERROR on_io_error;
     void* on_bytes_received_context;
@@ -157,6 +162,7 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
         result = (SOCKET_IO_INSTANCE*)malloc(sizeof(SOCKET_IO_INSTANCE));
         if (result != NULL)
         {
+            result->address_type = ADDRESS_TYPE_IP;
             result->pending_io_list = singlylinkedlist_create();
             if (result->pending_io_list == NULL)
             {
@@ -245,6 +251,83 @@ void socketio_destroy(CONCRETE_IO_HANDLE socket_io)
     }
 }
 
+static int connect_socket(SOCKET socket, struct sockaddr* addr, size_t len)
+{
+    int result;
+    u_long iMode = 1;
+
+    if (connect(socket, addr, (int)len) != 0)
+    {
+        LogError("Failure: connect failure %d.", WSAGetLastError());
+        result = __FAILURE__;
+    }
+    else if (ioctlsocket(socket, FIONBIO, &iMode) != 0)
+    {
+        LogError("Failure: ioctlsocket failure %d.", WSAGetLastError());
+        result = __FAILURE__;
+    }
+    else
+    {
+        result = 0;
+    }
+
+    return result;
+}
+
+static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    int result;
+
+#ifdef AF_UNIX_ON_WINDOWS
+    if (socket_io_instance->address_type == ADDRESS_TYPE_IP)
+    {
+#endif
+        char portString[16];
+        ADDRINFO* addr_info = NULL;
+        ADDRINFO addrHint = { 0 };
+        addrHint.ai_family = AF_INET;
+        addrHint.ai_socktype = SOCK_STREAM;
+        addrHint.ai_protocol = 0;
+
+        sprintf(portString, "%u", socket_io_instance->port);
+        if (getaddrinfo(socket_io_instance->hostname, portString, &addrHint, &addr_info) != 0)
+        {
+            LogError("Failure: getaddrinfo failure %d.", WSAGetLastError());
+            result = __FAILURE__;
+        }
+        else
+        {
+            result = connect_socket(socket_io_instance->socket, addr_info->ai_addr, sizeof(*addr_info->ai_addr));
+            freeaddrinfo(addr_info);
+        }
+#ifdef AF_UNIX_ON_WINDOWS
+    }
+    else // ADDRESS_TYPE_DOMAIN_SOCKET
+    {
+        SOCKADDR_UN addr_un;
+        char* path = socket_io_instance->hostname;
+        size_t path_len = strlen(socket_io_instance->hostname);
+
+        if (path_len + 1 > sizeof(addr_un.sun_path))
+        {
+            LogError("Path '%s' is too long for a unix socket (max len = %zu)", path, sizeof(addr_un.sun_path));
+            result = __FAILURE__;
+        }
+        else
+        {
+            memset(&addr_un, 0, sizeof(addr_un));
+            addr_un.sun_family = AF_UNIX;
+            // No need to add NULL terminator due to the above memset
+            (void)memcpy(addr_un.sun_path, path, path_len);
+
+            result = connect_socket(socket_io_instance->socket, (struct sockaddr*)&addr_un, sizeof(addr_un));
+        }
+    }
+#endif
+
+    return result;
+}
+
 int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_complete, void* on_io_open_complete_context, ON_BYTES_RECEIVED on_bytes_received, void* on_bytes_received_context, ON_IO_ERROR on_io_error, void* on_io_error_context)
 {
     int result;
@@ -276,62 +359,34 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
         }
         else
         {
-            socket_io_instance->socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+#ifdef AF_UNIX_ON_WINDOWS
+            int addr_family = socket_io_instance->address_type == ADDRESS_TYPE_IP ? AF_INET : AF_UNIX;
+#else
+            int addr_family = AF_INET;
+#endif
+            socket_io_instance->socket = socket(addr_family, SOCK_STREAM, 0);
             if (socket_io_instance->socket == INVALID_SOCKET)
             {
                 LogError("Failure: socket create failure %d.", WSAGetLastError());
                 result = __FAILURE__;
             }
+            else if (lookup_address_and_initiate_socket_connection(socket_io_instance) != 0)
+            {
+                LogError("lookup_address_and_connect_socket failed");
+                (void)closesocket(socket_io_instance->socket);
+                socket_io_instance->socket = INVALID_SOCKET;
+                result = __FAILURE__;
+            }
             else
             {
-                char portString[16];
-                ADDRINFO addrHint = { 0 };
-                ADDRINFO* addrInfo = NULL;
+                socket_io_instance->on_bytes_received_context = on_bytes_received_context;
+                socket_io_instance->on_bytes_received = on_bytes_received;
+                socket_io_instance->on_io_error = on_io_error;
+                socket_io_instance->on_io_error_context = on_io_error_context;
 
-                addrHint.ai_family = AF_INET;
-                addrHint.ai_socktype = SOCK_STREAM;
-                addrHint.ai_protocol = 0;
-                sprintf(portString, "%u", socket_io_instance->port);
-                if (getaddrinfo(socket_io_instance->hostname, portString, &addrHint, &addrInfo) != 0)
-                {
-                    LogError("Failure: getaddrinfo failure %d.", WSAGetLastError());
-                    (void)closesocket(socket_io_instance->socket);
-                    socket_io_instance->socket = INVALID_SOCKET;
-                    result = __FAILURE__;
-                }
-                else
-                {
-                    u_long iMode = 1;
+                socket_io_instance->io_state = IO_STATE_OPEN;
 
-                    if (connect(socket_io_instance->socket, addrInfo->ai_addr, (int)addrInfo->ai_addrlen) != 0)
-                    {
-                        LogError("Failure: connect failure %d.", WSAGetLastError());
-                        (void)closesocket(socket_io_instance->socket);
-                        socket_io_instance->socket = INVALID_SOCKET;
-                        result = __FAILURE__;
-                    }
-                    else if (ioctlsocket(socket_io_instance->socket, FIONBIO, &iMode) != 0)
-                    {
-                        LogError("Failure: ioctlsocket failure %d.", WSAGetLastError());
-                        (void)closesocket(socket_io_instance->socket);
-                        socket_io_instance->socket = INVALID_SOCKET;
-                        result = __FAILURE__;
-                    }
-                    else
-                    {
-                        socket_io_instance->on_bytes_received = on_bytes_received;
-                        socket_io_instance->on_bytes_received_context = on_bytes_received_context;
-
-                        socket_io_instance->on_io_error = on_io_error;
-                        socket_io_instance->on_io_error_context = on_io_error_context;
-
-                        socket_io_instance->io_state = IO_STATE_OPEN;
-
-                        result = 0;
-                    }
-
-                    freeaddrinfo(addrInfo);
-                }
+                result = 0;
             }
         }
     }
@@ -561,6 +616,36 @@ static int set_keepalive(SOCKET_IO_INSTANCE* socket_io, struct tcp_keepalive* ke
     return result;
 }
 
+static int socketio_setaddresstype_option(SOCKET_IO_INSTANCE* socket_io_instance, const char* addressType)
+{
+    int result;
+
+    if (socket_io_instance->io_state != IO_STATE_CLOSED)
+    {
+        LogError("Socket's type can only be changed when in state 'IO_STATE_CLOSED'. Current state=%d", socket_io_instance->io_state);
+        result = __FAILURE__;
+    }
+#ifdef AF_UNIX_ON_WINDOWS
+    else if (strcmp(addressType, OPTION_ADDRESS_TYPE_DOMAIN_SOCKET) == 0)
+    {
+        socket_io_instance->address_type = ADDRESS_TYPE_DOMAIN_SOCKET;
+        result = 0;
+    }
+#endif
+    else if (strcmp(addressType, OPTION_ADDRESS_TYPE_IP_SOCKET) == 0)
+    {
+        socket_io_instance->address_type = ADDRESS_TYPE_IP;
+        result = 0;
+    }
+    else
+    {
+        LogError("Address type %s is not supported", addressType);
+        result = __FAILURE__;
+    }
+
+    return result;
+}
+
 int socketio_setoption(CONCRETE_IO_HANDLE socket_io, const char* optionName, const void* value)
 {
     int result;
@@ -597,6 +682,10 @@ int socketio_setoption(CONCRETE_IO_HANDLE socket_io, const char* optionName, con
             keepAlive.keepaliveinterval = kaInterval;
 
             result = set_keepalive(socket_io_instance, &keepAlive);
+        }
+        else if (strcmp(optionName, OPTION_ADDRESS_TYPE) == 0)
+        {
+            result = socketio_setaddresstype_option(socket_io_instance, (const char*)value);
         }
         else
         {

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -305,8 +305,19 @@ static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* soc
     else // ADDRESS_TYPE_DOMAIN_SOCKET
     {
         SOCKADDR_UN addr_un;
-        char* path = socket_io_instance->hostname;
-        size_t path_len = strlen(socket_io_instance->hostname);
+        const char* path = socket_io_instance->hostname;
+        size_t path_len = strlen(path);
+
+        // If the value of hostname was parsed out of a 'unix://' URL, it might have a
+        // leading forward slash ('/'). That's because the domain socket path is found
+        // in the path portion of the URL, not the hostname portion. The hostname is
+        // empty and the forward slash delimits the start of the path. For Unix domain
+        // socket paths on Windows, discard the leading forward slash.
+        if (path[0] == '/')
+        {
+            ++path;
+            --path_len;
+        }
 
         if (path_len + 1 > sizeof(addr_un.sun_path))
         {

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -289,8 +289,12 @@ static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* soc
         addrHint.ai_socktype = SOCK_STREAM;
         addrHint.ai_protocol = 0;
 
-        sprintf(portString, "%u", socket_io_instance->port);
-        if (getaddrinfo(socket_io_instance->hostname, portString, &addrHint, &addr_info) != 0)
+        if (sprintf(portString, "%u", socket_io_instance->port) < 0)
+        {
+            LogError("Failure: sprintf failed to encode the port.");
+            result = __FAILURE__;
+        }
+        else if (getaddrinfo(socket_io_instance->hostname, portString, &addrHint, &addr_info) != 0)
         {
             LogError("Failure: getaddrinfo failure %d.", WSAGetLastError());
             result = __FAILURE__;
@@ -326,7 +330,7 @@ static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* soc
         }
         else
         {
-            memset(&addr_un, 0, sizeof(addr_un));
+            (void)memset(&addr_un, 0, sizeof(addr_un));
             addr_un.sun_family = AF_UNIX;
             // No need to add NULL terminator due to the above memset
             (void)memcpy(addr_un.sun_path, path, path_len);

--- a/inc/azure_c_shared_utility/socketio.h
+++ b/inc/azure_c_shared_utility/socketio.h
@@ -22,6 +22,12 @@ typedef struct SOCKETIO_CONFIG_TAG
     void* accepted_socket;
 } SOCKETIO_CONFIG;
 
+typedef enum SOCKETIO_ADDRESS_TYPE_TAG
+{
+    ADDRESS_TYPE_IP,
+    ADDRESS_TYPE_DOMAIN_SOCKET
+} SOCKETIO_ADDRESS_TYPE;
+
 #define RECEIVE_BYTES_VALUE     64
 
 MOCKABLE_FUNCTION(, CONCRETE_IO_HANDLE, socketio_create, void*, io_create_parameters);


### PR DESCRIPTION
Windows supports UNIX domain sockets, but only on RS5 or later. So this change includes logic in CMakeLists.txt which adds the compiler definition `AF_UNIX_ON_WINDOWS` when building on RS5 or later. It also makes the Winsock2 adapter for socketio look a lot more like the Berkeley adapter, including support for the `ADDRESS_TYPE` option in `socketio_setoption`.