### PR TITLE
Add constbuffer_array_create_from_array_array

### DIFF
--- a/devdoc/constbuffer_array_requirements.md
+++ b/devdoc/constbuffer_array_requirements.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-`constbuffer_array` is a module that stiches several `CONSTBUFFER_HANDLE`s together. `constbuffer_array` can add/remove a `CONSTBUFFER_HANDLE` at the beginning (front) of the already constructed stitch. 
+`constbuffer_array` is a module that stiches several `CONSTBUFFER_HANDLE`s together. `constbuffer_array` can add/remove a `CONSTBUFFER_HANDLE` at the beginning (front) of the already constructed stitch. `constbuffer_array` can merge with another `constbuffer_array` by appending the contents of one array to the other.
 
 `CONSTBUFFER_ARRAY_HANDLE`s are immutable, that is, adding/removing a `CONSTBUFFER_HANDLE` to/from an existing `CONSTBUFFER_ARRAY_HANDLE` will result in a new `CONSTBUFFER_ARRAY_HANDLE`.
 
@@ -23,6 +23,9 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_add_front, CONST
 
 /*remove front*/
 MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_remove_front, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_HANDLE *const_buffer_handle);
+
+/*append array (merge)*/
+MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_append, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_ARRAY_HANDLE, appended_constbuffer_array_handle);
 
 /* getters */
 MOCKABLE_FUNCTION(, int, constbuffer_array_get_buffer_count, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, uint32_t*, buffer_count);
@@ -138,6 +141,30 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_remove_front, CO
 **SRS_CONSTBUFFER_ARRAY_02_049: [** `constbuffer_array_remove_front` shall succeed and return a non-`NULL` value. **]**
 
 **SRS_CONSTBUFFER_ARRAY_02_036: [** If there are any failures then `constbuffer_array_remove_front` shall fail and return `NULL`. **]**
+
+### constbuffer_array_append
+
+```c
+MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_append, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_ARRAY_HANDLE, appended_constbuffer_array_handle);
+```
+
+`constbuffer_array_append` creates a new const buffer array with all of the const buffers from the first parameter, followed by all of the const buffers from the second parameter.
+
+**SRS_CONSTBUFFER_ARRAY_42_001: [** If `constbuffer_array_handle` is `NULL` then `constbuffer_array_append` shall fail and return `NULL`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_002: [** If `appended_constbuffer_array_handle` is `NULL` then `constbuffer_array_append` shall fail and return `NULL`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_003: [** `appended_constbuffer_array_handle` shall allocate memory to hold all of the `CONSTBUFFER_HANDLES` from `constbuffer_array_handle` and from `appended_constbuffer_array_handle`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_004: [** `appended_constbuffer_array_handle` shall copy all of the `CONSTBUFFER_HANDLES` from `constbuffer_array_handle` to the newly constructed array. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_005: [** `appended_constbuffer_array_handle` shall copy all of the `CONSTBUFFER_HANDLES` from `appended_constbuffer_array_handle` to the newly constructed array. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_006: [** `appended_constbuffer_array_handle` shall increment the ref count of all the copied `CONSTBUFFER_HANDLES`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_007: [** `appended_constbuffer_array_handle` shall succeed and return a non-`NULL` value. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_008: [** If there are any failures then `appended_constbuffer_array_handle` shall fail and return `NULL`. **]**
 
 ### constbuffer_array_get_buffer_count
 

--- a/devdoc/constbuffer_array_requirements.md
+++ b/devdoc/constbuffer_array_requirements.md
@@ -156,9 +156,9 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_append, CONSTBUF
 
 **SRS_CONSTBUFFER_ARRAY_42_003: [** `appended_constbuffer_array_handle` shall allocate memory to hold all of the `CONSTBUFFER_HANDLES` from `constbuffer_array_handle` and from `appended_constbuffer_array_handle`. **]**
 
-**SRS_CONSTBUFFER_ARRAY_42_004: [** `appended_constbuffer_array_handle` shall copy all of the `CONSTBUFFER_HANDLES` from `constbuffer_array_handle` to the newly constructed array. **]**
+**SRS_CONSTBUFFER_ARRAY_42_004: [** `appended_constbuffer_array_handle` shall copy all of the `CONSTBUFFER_HANDLES` from `constbuffer_array_handle` to the newly constructed array, incrementing their ref counts. **]**
 
-**SRS_CONSTBUFFER_ARRAY_42_005: [** `appended_constbuffer_array_handle` shall copy all of the `CONSTBUFFER_HANDLES` from `appended_constbuffer_array_handle` to the newly constructed array. **]**
+**SRS_CONSTBUFFER_ARRAY_42_005: [** `appended_constbuffer_array_handle` shall copy all of the `CONSTBUFFER_HANDLES` from `appended_constbuffer_array_handle` to the newly constructed array, incrementing their ref counts. **]**
 
 **SRS_CONSTBUFFER_ARRAY_42_006: [** `appended_constbuffer_array_handle` shall increment the ref count of all the copied `CONSTBUFFER_HANDLES`. **]**
 

--- a/devdoc/constbuffer_array_requirements.md
+++ b/devdoc/constbuffer_array_requirements.md
@@ -14,6 +14,7 @@ typedef struct CONSTBUFFER_ARRAY_HANDLE_DATA_TAG* CONSTBUFFER_ARRAY_HANDLE;
 
 MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create, const CONSTBUFFER_HANDLE*, buffers, uint32_t, buffer_count);
 MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create_empty);
+MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create_from_array_array, const CONSTBUFFER_ARRAY_HANDLE*, buffer_arrays, uint32_t, buffer_array_count);
 
 MOCKABLE_FUNCTION(, void, constbuffer_array_inc_ref, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle);
 MOCKABLE_FUNCTION(, void, constbuffer_array_dec_ref, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle);
@@ -23,9 +24,6 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_add_front, CONST
 
 /*remove front*/
 MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_remove_front, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_HANDLE *const_buffer_handle);
-
-/*append array (merge)*/
-MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_append, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_ARRAY_HANDLE, appended_constbuffer_array_handle);
 
 /* getters */
 MOCKABLE_FUNCTION(, int, constbuffer_array_get_buffer_count, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, uint32_t*, buffer_count);
@@ -65,6 +63,28 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create_empty);
 **SRS_CONSTBUFFER_ARRAY_02_041: [** `constbuffer_array_create_empty` shall succeed and return a non-`NULL` value. **]**
 
 **SRS_CONSTBUFFER_ARRAY_02_001: [** If are any failure is encountered, `constbuffer_array_create_empty` shall fail and return `NULL`. **]**
+
+### constbuffer_array_create_from_array_array
+
+```c
+MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create_from_array_array, const CONSTBUFFER_ARRAY_HANDLE*, buffer_arrays, uint32_t, buffer_array_count);
+```
+
+`constbuffer_array_create_from_array_array` creates a new const buffer array made of all the const buffers in `buffer_arrays`.
+
+**SRS_CONSTBUFFER_ARRAY_42_009: [** If `buffer_arrays` is `NULL` and `buffer_array_count` is not 0 then `constbuffer_array_create_from_array_array` shall fail and return `NULL`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_001: [** If `buffer_arrays` is `NULL` or `buffer_array_count` is 0 then `constbuffer_array_create_from_array_array` shall create a new, empty `CONSTBUFFER_ARRAY_HANDLE`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_002: [** If any const buffer array in `buffer_arrays` is `NULL` then `constbuffer_array_create_from_array_array` shall fail and return `NULL`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_003: [** `constbuffer_array_create_from_array_array` shall allocate memory to hold all of the `CONSTBUFFER_HANDLES` from `buffer_arrays`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_004: [** `constbuffer_array_create_from_array_array` shall copy all of the `CONSTBUFFER_HANDLES` from each const buffer array in `buffer_arrays` to the newly constructed array by calling `CONSTBUFFER_Clone`. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_007: [** `constbuffer_array_create_from_array_array` shall succeed and return a non-`NULL` value. **]**
+
+**SRS_CONSTBUFFER_ARRAY_42_008: [** If there are any failures then `constbuffer_array_create_from_array_array` shall fail and return `NULL`. **]**
 
 ### constbuffer_array_inc_ref
 
@@ -141,30 +161,6 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_remove_front, CO
 **SRS_CONSTBUFFER_ARRAY_02_049: [** `constbuffer_array_remove_front` shall succeed and return a non-`NULL` value. **]**
 
 **SRS_CONSTBUFFER_ARRAY_02_036: [** If there are any failures then `constbuffer_array_remove_front` shall fail and return `NULL`. **]**
-
-### constbuffer_array_append
-
-```c
-MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_append, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_ARRAY_HANDLE, appended_constbuffer_array_handle);
-```
-
-`constbuffer_array_append` creates a new const buffer array with all of the const buffers from the first parameter, followed by all of the const buffers from the second parameter.
-
-**SRS_CONSTBUFFER_ARRAY_42_001: [** If `constbuffer_array_handle` is `NULL` then `constbuffer_array_append` shall fail and return `NULL`. **]**
-
-**SRS_CONSTBUFFER_ARRAY_42_002: [** If `appended_constbuffer_array_handle` is `NULL` then `constbuffer_array_append` shall fail and return `NULL`. **]**
-
-**SRS_CONSTBUFFER_ARRAY_42_003: [** `appended_constbuffer_array_handle` shall allocate memory to hold all of the `CONSTBUFFER_HANDLES` from `constbuffer_array_handle` and from `appended_constbuffer_array_handle`. **]**
-
-**SRS_CONSTBUFFER_ARRAY_42_004: [** `appended_constbuffer_array_handle` shall copy all of the `CONSTBUFFER_HANDLES` from `constbuffer_array_handle` to the newly constructed array, incrementing their ref counts. **]**
-
-**SRS_CONSTBUFFER_ARRAY_42_005: [** `appended_constbuffer_array_handle` shall copy all of the `CONSTBUFFER_HANDLES` from `appended_constbuffer_array_handle` to the newly constructed array, incrementing their ref counts. **]**
-
-**SRS_CONSTBUFFER_ARRAY_42_006: [** `appended_constbuffer_array_handle` shall increment the ref count of all the copied `CONSTBUFFER_HANDLES`. **]**
-
-**SRS_CONSTBUFFER_ARRAY_42_007: [** `appended_constbuffer_array_handle` shall succeed and return a non-`NULL` value. **]**
-
-**SRS_CONSTBUFFER_ARRAY_42_008: [** If there are any failures then `appended_constbuffer_array_handle` shall fail and return `NULL`. **]**
 
 ### constbuffer_array_get_buffer_count
 

--- a/inc/azure_c_shared_utility/constbuffer_array.h
+++ b/inc/azure_c_shared_utility/constbuffer_array.h
@@ -29,6 +29,9 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_add_front, CONST
 /*remove front*/
 MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_remove_front, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_HANDLE *, constbuffer_handle);
 
+/*append array (merge)*/
+MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_append, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_ARRAY_HANDLE, appended_constbuffer_array_handle);
+
 /* getters */
 MOCKABLE_FUNCTION(, int, constbuffer_array_get_buffer_count, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, uint32_t*, buffer_count);
 MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, constbuffer_array_get_buffer, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, uint32_t, buffer_index);

--- a/inc/azure_c_shared_utility/constbuffer_array.h
+++ b/inc/azure_c_shared_utility/constbuffer_array.h
@@ -19,6 +19,7 @@ typedef struct CONSTBUFFER_ARRAY_HANDLE_DATA_TAG* CONSTBUFFER_ARRAY_HANDLE;
 /*create*/
 MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create, const CONSTBUFFER_HANDLE*, buffers, uint32_t, buffer_count);
 MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create_empty);
+MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create_from_array_array, const CONSTBUFFER_ARRAY_HANDLE*, buffer_arrays, uint32_t, buffer_array_count);
 
 MOCKABLE_FUNCTION(, void, constbuffer_array_inc_ref, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle);
 MOCKABLE_FUNCTION(, void, constbuffer_array_dec_ref, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle);
@@ -28,9 +29,6 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_add_front, CONST
 
 /*remove front*/
 MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_remove_front, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_HANDLE *, constbuffer_handle);
-
-/*append array (merge)*/
-MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_append, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, CONSTBUFFER_ARRAY_HANDLE, appended_constbuffer_array_handle);
 
 /* getters */
 MOCKABLE_FUNCTION(, int, constbuffer_array_get_buffer_count, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_handle, uint32_t*, buffer_count);

--- a/src/constbuffer_array.c
+++ b/src/constbuffer_array.c
@@ -184,7 +184,7 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_remove_front(CONSTBUFFER_ARRAY_HANDLE
     CONSTBUFFER_ARRAY_HANDLE result;
     if (
         /*Codes_SRS_CONSTBUFFER_ARRAY_02_012: [ If constbuffer_array_handle is NULL then constbuffer_array_remove_front shall fail and return NULL. ]*/
-        (constbuffer_array_handle == NULL) || 
+        (constbuffer_array_handle == NULL) ||
         /*Codes_SRS_CONSTBUFFER_ARRAY_02_045: [ If constbuffer_handle is NULL then constbuffer_array_remove_front shall fail and return NULL. ]*/
         (constbuffer_handle == NULL)
         )
@@ -262,6 +262,93 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_remove_front(CONSTBUFFER_ARRAY_HANDLE
     }
     /*Codes_SRS_CONSTBUFFER_ARRAY_02_036: [ If there are any failures then constbuffer_array_remove_front shall fail and return NULL. ]*/
     result = NULL;
+allOk:;
+    return result;
+}
+
+CONSTBUFFER_ARRAY_HANDLE constbuffer_array_append(CONSTBUFFER_ARRAY_HANDLE constbuffer_array_handle, CONSTBUFFER_ARRAY_HANDLE appended_constbuffer_array_handle)
+{
+    CONSTBUFFER_ARRAY_HANDLE result;
+    if (
+        /*Codes_SRS_CONSTBUFFER_ARRAY_42_001: [ If constbuffer_array_handle is NULL then constbuffer_array_append shall fail and return NULL. ]*/
+        (constbuffer_array_handle == NULL) ||
+        /*Codes_SRS_CONSTBUFFER_ARRAY_42_002: [ If appended_constbuffer_array_handle is NULL then constbuffer_array_append shall fail and return NULL. ]*/
+        (appended_constbuffer_array_handle == NULL)
+        )
+    {
+        LogError("invalid arguments CONSTBUFFER_ARRAY_HANDLE constbuffer_array_handle=%p, CONSTBUFFER_ARRAY_HANDLE appended_constbuffer_array_handle=%p", constbuffer_array_handle, appended_constbuffer_array_handle);
+        result = NULL;
+    }
+    else
+    {
+        /*Codes_SRS_CONSTBUFFER_ARRAY_42_003: [ appended_constbuffer_array_handle shall allocate memory to hold all of the CONSTBUFFER_HANDLES from constbuffer_array_handle and from appended_constbuffer_array_handle. ]*/
+        result = REFCOUNT_TYPE_CREATE_WITH_EXTRA_SIZE(CONSTBUFFER_ARRAY_HANDLE_DATA, (constbuffer_array_handle->nBuffers + appended_constbuffer_array_handle->nBuffers) * sizeof(CONSTBUFFER_HANDLE));
+        if (result == NULL)
+        {
+            /*Codes_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+            LogError("failure in malloc");
+            /*return as is*/
+        }
+        else
+        {
+            result->nBuffers = constbuffer_array_handle->nBuffers + appended_constbuffer_array_handle->nBuffers;
+
+            uint32_t result_idx;
+            uint32_t original_idx;
+            for (result_idx = 0, original_idx = 0; original_idx < constbuffer_array_handle->nBuffers; original_idx++, result_idx++)
+            {
+                /*Codes_SRS_CONSTBUFFER_ARRAY_42_004: [ appended_constbuffer_array_handle shall copy all of the CONSTBUFFER_HANDLES from constbuffer_array_handle to the newly constructed array, incrementing their ref counts. ]*/
+                result->buffers[result_idx] = CONSTBUFFER_Clone(constbuffer_array_handle->buffers[original_idx]);
+                if (result->buffers[result_idx] == NULL)
+                {
+                    /*Codes_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+                    LogError("failure in CONSTBUFFER_Clone");
+                    break;
+                }
+            }
+
+            if (original_idx != constbuffer_array_handle->nBuffers)
+            {
+                // Cleanup on partial copy
+                for (uint32_t i = 0; i < result_idx; i++)
+                {
+                    CONSTBUFFER_Destroy(result->buffers[i]);
+                }
+            }
+            else
+            {
+                uint32_t appended_idx;
+                for (appended_idx = 0; appended_idx < appended_constbuffer_array_handle->nBuffers; appended_idx++, result_idx++)
+                {
+                    /*Codes_SRS_CONSTBUFFER_ARRAY_42_005: [ appended_constbuffer_array_handle shall copy all of the CONSTBUFFER_HANDLES from appended_constbuffer_array_handle to the newly constructed array, incrementing their ref counts. ]*/
+                    result->buffers[result_idx] = CONSTBUFFER_Clone(appended_constbuffer_array_handle->buffers[appended_idx]);
+                    if (result->buffers[result_idx] == NULL)
+                    {
+                        /*Codes_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+                        LogError("failure in CONSTBUFFER_Clone");
+                        break;
+                    }
+                }
+
+                if (appended_idx != appended_constbuffer_array_handle->nBuffers)
+                {
+                    // Cleanup on partial copy
+                    for (uint32_t i = 0; i < result_idx; i++)
+                    {
+                        CONSTBUFFER_Destroy(result->buffers[i]);
+                    }
+                }
+                else
+                {
+                    /*Codes_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+                    goto allOk;
+                }
+            }
+
+            REFCOUNT_TYPE_DESTROY(CONSTBUFFER_ARRAY_HANDLE_DATA, result);
+            result = NULL;
+        }
+    }
 allOk:;
     return result;
 }

--- a/src/constbuffer_array.c
+++ b/src/constbuffer_array.c
@@ -118,7 +118,6 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create_from_array_array(const CONSTBU
         )
     {
         LogError("invalid arguments: const CONSTBUFFER_ARRAY_HANDLE* buffer_arrays=%p, uint32_t buffer_array_count=%" PRIu32, buffer_arrays, buffer_array_count);
-        result = NULL;
     }
     else
     {
@@ -126,6 +125,15 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create_from_array_array(const CONSTBU
         if (buffer_arrays == NULL || buffer_array_count == 0)
         {
             result = constbuffer_array_create_empty();
+
+            if (result == NULL)
+            {
+                LogError("constbuffer_array_create_empty failed");
+            }
+            else
+            {
+                goto allOk;
+            }
         }
         else
         {
@@ -151,9 +159,9 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create_from_array_array(const CONSTBU
                 }
             }
 
-            if (i != buffer_array_count)
+            if (i < buffer_array_count)
             {
-                result = NULL;
+                // Failed in loop, fall through to cleanup
             }
             else
             {
@@ -163,7 +171,6 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create_from_array_array(const CONSTBU
                 {
                     /*Codes_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then constbuffer_array_create_from_array_array shall fail and return NULL. ]*/
                     LogError("failure in malloc");
-                    /*return as is*/
                 }
                 else
                 {
@@ -186,13 +193,13 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create_from_array_array(const CONSTBU
                             }
                         }
 
-                        if (source_idx != buffer_arrays[array_idx]->nBuffers)
+                        if (source_idx < buffer_arrays[array_idx]->nBuffers)
                         {
                             break;
                         }
                     }
 
-                    if (array_idx != buffer_array_count)
+                    if (array_idx < buffer_array_count)
                     {
                         // Cleanup on partial copy
                         for (i = 0; i < dest_idx; i++)
@@ -207,11 +214,11 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create_from_array_array(const CONSTBU
                     }
 
                     REFCOUNT_TYPE_DESTROY(CONSTBUFFER_ARRAY_HANDLE_DATA, result);
-                    result = NULL;
                 }
             }
         }
     }
+    result = NULL;
 allOk:;
     return result;
 }

--- a/src/constbuffer_array.c
+++ b/src/constbuffer_array.c
@@ -174,11 +174,12 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create_from_array_array(const CONSTBU
                 }
                 else
                 {
-                    result->nBuffers = total_buffer_count;
-
                     uint32_t dest_idx;
                     uint32_t array_idx;
                     uint32_t source_idx;
+
+                    result->nBuffers = total_buffer_count;
+
                     for (dest_idx = 0, array_idx = 0; array_idx < buffer_array_count; ++array_idx)
                     {
                         for (source_idx = 0; source_idx < buffer_arrays[array_idx]->nBuffers; ++source_idx, ++dest_idx)

--- a/tests/constbuffer_array_ut/constbuffer_array_ut.c
+++ b/tests/constbuffer_array_ut/constbuffer_array_ut.c
@@ -48,10 +48,12 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 static const unsigned char one = '1';
 static const unsigned char two[] = { '2', '2' };
 static const unsigned char three[] = { '3', '3', '3' };
+static const unsigned char four[] = { '4', '4', '4', '4' };
 
 static CONSTBUFFER_HANDLE TEST_CONSTBUFFER_HANDLE_1;
 static CONSTBUFFER_HANDLE TEST_CONSTBUFFER_HANDLE_2;
 static CONSTBUFFER_HANDLE TEST_CONSTBUFFER_HANDLE_3;
+static CONSTBUFFER_HANDLE TEST_CONSTBUFFER_HANDLE_4;
 
 BEGIN_TEST_SUITE(constbuffer_array_unittests)
 
@@ -73,11 +75,11 @@ TEST_SUITE_INITIALIZE(suite_init)
 
     result = umocktypes_bool_register_types();
     ASSERT_ARE_EQUAL(int, 0, result, "umocktypes_bool_register_types");
-    
+
     REGISTER_CONSTBUFFER_GLOBAL_MOCK_HOOK();
-    
+
     REGISTER_UMOCK_ALIAS_TYPE(CONSTBUFFER_HANDLE, void*);
-    
+
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(CONSTBUFFER_Clone, NULL);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(CONSTBUFFER_GetContent, NULL);
 
@@ -109,12 +111,17 @@ TEST_FUNCTION_INITIALIZE(method_init)
 
     TEST_CONSTBUFFER_HANDLE_3 = CONSTBUFFER_Create(three, sizeof(three));
     ASSERT_IS_NOT_NULL(TEST_CONSTBUFFER_HANDLE_3);
+
+    TEST_CONSTBUFFER_HANDLE_4 = CONSTBUFFER_Create(four, sizeof(four));
+    ASSERT_IS_NOT_NULL(TEST_CONSTBUFFER_HANDLE_4);
+
     umock_c_reset_all_calls();
     umock_c_negative_tests_init();
 }
 
 TEST_FUNCTION_CLEANUP(method_cleanup)
 {
+    CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_4);
     CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_3);
     CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_2);
     CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_1);
@@ -184,7 +191,7 @@ TEST_FUNCTION(constbuffer_array_create_with_0_buffer_count_succeeds)
     CONSTBUFFER_ARRAY_HANDLE constbuffer_array;
 
     test_buffers[0] = TEST_CONSTBUFFER_HANDLE_1;
-    
+
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
     ///act
@@ -412,7 +419,7 @@ TEST_FUNCTION(constbuffer_array_add_front_unhappy_paths)
         ///assert
         ASSERT_IS_NULL(result);
     }
-    
+
     ///clean
     constbuffer_array_dec_ref(TEST_CONSTBUFFER_ARRAY_HANDLE);
 }
@@ -517,7 +524,7 @@ TEST_FUNCTION(constbuffer_array_remove_front_with_constbuffer_array_handle_empty
     CONSTBUFFER_Destroy(removed);
     TEST_constbuffer_array_dec_ref(afterAdd, 1);
     umock_c_reset_all_calls();
-   
+
     ///act
     result = constbuffer_array_remove_front(afterRemove, &removed2);
 
@@ -572,7 +579,7 @@ TEST_FUNCTION(constbuffer_array_remove_front_with_1_item_succeeds)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     ///cleanup
-    constbuffer_array_dec_ref(afterRemove); 
+    constbuffer_array_dec_ref(afterRemove);
     constbuffer_array_dec_ref(afterAdd);
     CONSTBUFFER_Destroy(removed);
     constbuffer_array_dec_ref(TEST_CONSTBUFFER_ARRAY_HANDLE);
@@ -642,6 +649,438 @@ TEST_FUNCTION(constbuffer_array_remove_front_unhappy_paths)
     ///clean
     constbuffer_array_dec_ref(TEST_CONSTBUFFER_ARRAY_HANDLE);
     constbuffer_array_dec_ref(afterAdd);
+}
+
+/* constbuffer_array_append */
+
+static void constbuffer_array_append_inert_path(uint32_t existing_item_count)
+{
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    for (uint32_t i = 0; i < existing_item_count; i++)
+    {
+        STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG));
+    }
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_001: [ If constbuffer_array_handle is NULL then constbuffer_array_append shall fail and return NULL. ]*/
+TEST_FUNCTION(constbuffer_array_append_returns_null_when_constbuffer_array_handle_is_null)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(NULL, empty_array);
+
+    ///assert
+    ASSERT_IS_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_002: [ If appended_constbuffer_array_handle is NULL then constbuffer_array_append shall fail and return NULL. ]*/
+TEST_FUNCTION(constbuffer_array_append_returns_null_when_appended_constbuffer_array_handle_is_null)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(empty_array, NULL);
+
+    ///assert
+    ASSERT_IS_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ appended_constbuffer_array_handle shall succeed and return a non-NULL value. ]*/
+TEST_FUNCTION(constbuffer_array_append_two_empty_arrays_succeeds)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE empty_array2 = TEST_constbuffer_array_create_empty();
+
+    constbuffer_array_append_inert_path(0);
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(empty_array, empty_array2);
+
+    ///assert
+    ASSERT_IS_NOT_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    uint32_t count;
+    int count_result = constbuffer_array_get_buffer_count(result, &count);
+    ASSERT_ARE_EQUAL(int, 0, count_result);
+    ASSERT_ARE_EQUAL(uint32_t, 0, count);
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(empty_array2);
+    constbuffer_array_dec_ref(result);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ appended_constbuffer_array_handle shall allocate memory to hold all of the CONSTBUFFER_HANDLES from constbuffer_array_handle and from appended_constbuffer_array_handle. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_005: [ appended_constbuffer_array_handle shall copy all of the CONSTBUFFER_HANDLES from appended_constbuffer_array_handle to the newly constructed array, incrementing their ref counts. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_006: [ appended_constbuffer_array_handle shall increment the ref count of all the copied CONSTBUFFER_HANDLES. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ appended_constbuffer_array_handle shall succeed and return a non-NULL value. ]*/
+TEST_FUNCTION(constbuffer_array_append_1_element_array_to_empty_array_succeeds)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1 = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_1);
+
+    constbuffer_array_append_inert_path(1);
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(empty_array, after_add_1);
+
+    ///assert
+    ASSERT_IS_NOT_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    uint32_t count;
+    int count_result = constbuffer_array_get_buffer_count(result, &count);
+    ASSERT_ARE_EQUAL(int, 0, count_result);
+    ASSERT_ARE_EQUAL(uint32_t, 1, count);
+
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_1, constbuffer_array_get_buffer(result, 0), "Validate result[0]");
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1);
+    constbuffer_array_dec_ref(result);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ appended_constbuffer_array_handle shall allocate memory to hold all of the CONSTBUFFER_HANDLES from constbuffer_array_handle and from appended_constbuffer_array_handle. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ appended_constbuffer_array_handle shall copy all of the CONSTBUFFER_HANDLES from constbuffer_array_handle to the newly constructed array, incrementing their ref counts. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_006: [ appended_constbuffer_array_handle shall increment the ref count of all the copied CONSTBUFFER_HANDLES. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ appended_constbuffer_array_handle shall succeed and return a non-NULL value. ]*/
+TEST_FUNCTION(constbuffer_array_append_empty_array_to_1_element_array_succeeds)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1 = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_1);
+
+    constbuffer_array_append_inert_path(1);
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_1, empty_array);
+
+    ///assert
+    ASSERT_IS_NOT_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    uint32_t count;
+    int count_result = constbuffer_array_get_buffer_count(result, &count);
+    ASSERT_ARE_EQUAL(int, 0, count_result);
+    ASSERT_ARE_EQUAL(uint32_t, 1, count);
+
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_1, constbuffer_array_get_buffer(result, 0), "Validate result[0]");
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1);
+    constbuffer_array_dec_ref(result);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ appended_constbuffer_array_handle shall allocate memory to hold all of the CONSTBUFFER_HANDLES from constbuffer_array_handle and from appended_constbuffer_array_handle. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ appended_constbuffer_array_handle shall copy all of the CONSTBUFFER_HANDLES from constbuffer_array_handle to the newly constructed array, incrementing their ref counts. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_005: [ appended_constbuffer_array_handle shall copy all of the CONSTBUFFER_HANDLES from appended_constbuffer_array_handle to the newly constructed array, incrementing their ref counts. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_006: [ appended_constbuffer_array_handle shall increment the ref count of all the copied CONSTBUFFER_HANDLES. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ appended_constbuffer_array_handle shall succeed and return a non-NULL value. ]*/
+TEST_FUNCTION(constbuffer_array_append_2_1_element_arrays_succeeds)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_first = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_1);
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_second = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_2);
+
+    constbuffer_array_append_inert_path(2);
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_1_first, after_add_1_second);
+
+    ///assert
+    ASSERT_IS_NOT_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    uint32_t count;
+    int count_result = constbuffer_array_get_buffer_count(result, &count);
+    ASSERT_ARE_EQUAL(int, 0, count_result);
+    ASSERT_ARE_EQUAL(uint32_t, 2, count);
+
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_1, constbuffer_array_get_buffer(result, 0), "Validate result[0]");
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_2, constbuffer_array_get_buffer(result, 1), "Validate result[1]");
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1_first);
+    constbuffer_array_dec_ref(after_add_1_second);
+    constbuffer_array_dec_ref(result);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ appended_constbuffer_array_handle shall succeed and return a non-NULL value. ]*/
+TEST_FUNCTION(constbuffer_array_append_2_2_element_arrays_succeeds)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_first = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_2);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_first = TEST_constbuffer_array_add_front(after_add_1_first, 1, TEST_CONSTBUFFER_HANDLE_1);
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_second = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_4);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_second = TEST_constbuffer_array_add_front(after_add_1_second, 1, TEST_CONSTBUFFER_HANDLE_3);
+
+    constbuffer_array_append_inert_path(4);
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_2_first, after_add_2_second);
+
+    ///assert
+    ASSERT_IS_NOT_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    uint32_t count;
+    int count_result = constbuffer_array_get_buffer_count(result, &count);
+    ASSERT_ARE_EQUAL(int, 0, count_result);
+    ASSERT_ARE_EQUAL(uint32_t, 4, count);
+
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_1, constbuffer_array_get_buffer(result, 0), "Validate result[0]");
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_2, constbuffer_array_get_buffer(result, 1), "Validate result[1]");
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_3, constbuffer_array_get_buffer(result, 2), "Validate result[2]");
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_4, constbuffer_array_get_buffer(result, 3), "Validate result[3]");
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1_first);
+    constbuffer_array_dec_ref(after_add_2_first);
+    constbuffer_array_dec_ref(after_add_1_second);
+    constbuffer_array_dec_ref(after_add_2_second);
+    constbuffer_array_dec_ref(result);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ appended_constbuffer_array_handle shall succeed and return a non-NULL value. ]*/
+TEST_FUNCTION(constbuffer_array_append_2_same_pointer_2_element_arrays_succeeds)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1 = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_2);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2 = TEST_constbuffer_array_add_front(after_add_1, 1, TEST_CONSTBUFFER_HANDLE_1);
+
+    constbuffer_array_append_inert_path(4);
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_2, after_add_2);
+
+    ///assert
+    ASSERT_IS_NOT_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    uint32_t count;
+    int count_result = constbuffer_array_get_buffer_count(result, &count);
+    ASSERT_ARE_EQUAL(int, 0, count_result);
+    ASSERT_ARE_EQUAL(uint32_t, 4, count);
+
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_1, constbuffer_array_get_buffer(result, 0), "Validate result[0]");
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_2, constbuffer_array_get_buffer(result, 1), "Validate result[1]");
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_1, constbuffer_array_get_buffer(result, 2), "Validate result[2]");
+    ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_2, constbuffer_array_get_buffer(result, 3), "Validate result[3]");
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1);
+    constbuffer_array_dec_ref(after_add_2);
+    constbuffer_array_dec_ref(result);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+TEST_FUNCTION(constbuffer_array_append_fails_if_malloc_fails)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_first = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_2);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_first = TEST_constbuffer_array_add_front(after_add_1_first, 1, TEST_CONSTBUFFER_HANDLE_1);
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_second = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_4);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_second = TEST_constbuffer_array_add_front(after_add_1_second, 1, TEST_CONSTBUFFER_HANDLE_3);
+
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
+        .SetReturn(NULL);
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_2_first, after_add_2_second);
+
+    ///assert
+    ASSERT_IS_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1_first);
+    constbuffer_array_dec_ref(after_add_2_first);
+    constbuffer_array_dec_ref(after_add_1_second);
+    constbuffer_array_dec_ref(after_add_2_second);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+TEST_FUNCTION(constbuffer_array_append_fails_if_first_clone_fails)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_first = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_2);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_first = TEST_constbuffer_array_add_front(after_add_1_first, 1, TEST_CONSTBUFFER_HANDLE_1);
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_second = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_4);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_second = TEST_constbuffer_array_add_front(after_add_1_second, 1, TEST_CONSTBUFFER_HANDLE_3);
+
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .SetReturn(NULL);
+
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_2_first, after_add_2_second);
+
+    ///assert
+    ASSERT_IS_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1_first);
+    constbuffer_array_dec_ref(after_add_2_first);
+    constbuffer_array_dec_ref(after_add_1_second);
+    constbuffer_array_dec_ref(after_add_2_second);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+TEST_FUNCTION(constbuffer_array_append_fails_if_second_clone_fails)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_first = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_2);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_first = TEST_constbuffer_array_add_front(after_add_1_first, 1, TEST_CONSTBUFFER_HANDLE_1);
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_second = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_4);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_second = TEST_constbuffer_array_add_front(after_add_1_second, 1, TEST_CONSTBUFFER_HANDLE_3);
+
+    CONSTBUFFER_HANDLE first_cloned;
+
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .CaptureReturn(&first_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .SetReturn(NULL);
+
+    // All cloned buffers are destroyed
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
+        .ValidateArgumentValue_constbufferHandle(&first_cloned);
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_2_first, after_add_2_second);
+
+    ///assert
+    ASSERT_IS_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1_first);
+    constbuffer_array_dec_ref(after_add_2_first);
+    constbuffer_array_dec_ref(after_add_1_second);
+    constbuffer_array_dec_ref(after_add_2_second);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+TEST_FUNCTION(constbuffer_array_append_fails_if_third_clone_fails)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_first = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_2);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_first = TEST_constbuffer_array_add_front(after_add_1_first, 1, TEST_CONSTBUFFER_HANDLE_1);
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_second = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_4);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_second = TEST_constbuffer_array_add_front(after_add_1_second, 1, TEST_CONSTBUFFER_HANDLE_3);
+
+    CONSTBUFFER_HANDLE first_cloned;
+    CONSTBUFFER_HANDLE second_cloned;
+
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .CaptureReturn(&first_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .CaptureReturn(&second_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .SetReturn(NULL);
+
+    // All cloned buffers are destroyed
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
+        .ValidateArgumentValue_constbufferHandle(&first_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
+        .ValidateArgumentValue_constbufferHandle(&second_cloned);
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_2_first, after_add_2_second);
+
+    ///assert
+    ASSERT_IS_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1_first);
+    constbuffer_array_dec_ref(after_add_2_first);
+    constbuffer_array_dec_ref(after_add_1_second);
+    constbuffer_array_dec_ref(after_add_2_second);
+}
+
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
+TEST_FUNCTION(constbuffer_array_append_fails_if_fourth_clone_fails)
+{
+    ///arrange
+    CONSTBUFFER_ARRAY_HANDLE empty_array = TEST_constbuffer_array_create_empty();
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_first = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_2);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_first = TEST_constbuffer_array_add_front(after_add_1_first, 1, TEST_CONSTBUFFER_HANDLE_1);
+    CONSTBUFFER_ARRAY_HANDLE after_add_1_second = TEST_constbuffer_array_add_front(empty_array, 0, TEST_CONSTBUFFER_HANDLE_4);
+    CONSTBUFFER_ARRAY_HANDLE after_add_2_second = TEST_constbuffer_array_add_front(after_add_1_second, 1, TEST_CONSTBUFFER_HANDLE_3);
+
+    CONSTBUFFER_HANDLE first_cloned;
+    CONSTBUFFER_HANDLE second_cloned;
+    CONSTBUFFER_HANDLE third_cloned;
+
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .CaptureReturn(&first_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .CaptureReturn(&second_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .CaptureReturn(&third_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
+        .SetReturn(NULL);
+
+    // All cloned buffers are destroyed
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
+        .ValidateArgumentValue_constbufferHandle(&first_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
+        .ValidateArgumentValue_constbufferHandle(&second_cloned);
+    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
+        .ValidateArgumentValue_constbufferHandle(&third_cloned);
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+
+    ///act
+    CONSTBUFFER_ARRAY_HANDLE result = constbuffer_array_append(after_add_2_first, after_add_2_second);
+
+    ///assert
+    ASSERT_IS_NULL(result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    constbuffer_array_dec_ref(empty_array);
+    constbuffer_array_dec_ref(after_add_1_first);
+    constbuffer_array_dec_ref(after_add_2_first);
+    constbuffer_array_dec_ref(after_add_1_second);
+    constbuffer_array_dec_ref(after_add_2_second);
 }
 
 /* constbuffer_array_get_buffer_count */


### PR DESCRIPTION
`constbuffer_array_append` takes two `constbuffer_array_handle`s and creates a new `constbuffer_array_handle` with the contents of the first followed by the contents of the second.