### PR TITLE
add sas support without changing APIs

### DIFF
--- a/devdoc/httpapiexsas_requirements.md
+++ b/devdoc/httpapiexsas_requirements.md
@@ -92,6 +92,8 @@ The caller of HTTPAPIEX_SAS_ExecuteRequest may know that there is no "Authorizat
 
 The size_t value ((size_t) (difftime(currentTime,0) + 3600)) is obtained an shall be known as expiry.
 
+**SRS_HTTPAPIEXSAS_06_017: [** If state->key is prefixed with "sas=", SharedAccessSignature will be used rather than created.  STRING_construct will be invoked. **]**  
+
 **SRS_HTTPAPIEXSAS_06_011: [** SASToken_Create shall be invoked. **]**  
 
  **SRS_HTTPAPIEXSAS_06_012: [** If the return result of SASToken_Create is NULL then fallthrough. **]**

--- a/tests/httpapiexsas_ut/httpapiexsas_ut.c
+++ b/tests/httpapiexsas_ut/httpapiexsas_ut.c
@@ -66,6 +66,8 @@ IMPLEMENT_UMOCK_C_ENUM_TYPE(HTTP_HEADERS_RESULT, HTTP_HEADERS_RESULT_VALUES);
 #define TEST_TIME_T ((time_t)-1)
 
 static const char* TEST_KEY = "key";
+static const char* TEST_SAS = "signature";
+static const char* TEST_SAS_KEY = "sas=signature";
 static const char* TEST_URI_RESOURCE = "test_uri";
 static const char* TEST_KEY_NAME = "key_name";
 
@@ -79,6 +81,14 @@ static int my_mallocAndStrcpy_s(char** destination, const char* source)
     *destination = (char*)my_gballoc_malloc(len+1);
     (void)strcpy(*destination, source);
     return 0;
+}
+
+static STRING_HANDLE my_STRING_construct(const char* psz)
+{
+    char* temp = (char*)my_gballoc_malloc(strlen(psz) + 1);
+    ASSERT_IS_NOT_NULL(temp);
+    (void)memcpy(temp, psz, strlen(psz) + 1);
+    return (STRING_HANDLE)temp;
 }
 
 static void my_STRING_delete(STRING_HANDLE handle)
@@ -103,10 +113,10 @@ static void setupSASString_Create_happy_path(bool allocateKeyName)
     }
 }
 
-static void setupSAS_Create_happy_path(bool allocateKeyName)
+static void setupSAS_Create_happy_path_provide_key(bool useSasKey, bool allocateKeyName)
 {
     // HTTPAPIEX_SAS_Create
-    STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_KEY);
+    STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(useSasKey ? TEST_SAS_KEY : TEST_KEY);
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_URI_RESOURCE);
     if (allocateKeyName)
     {
@@ -119,6 +129,11 @@ static void setupSAS_Create_happy_path(bool allocateKeyName)
     {
         STRICT_EXPECTED_CALL(mallocAndStrcpy_s(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     }
+}
+
+static void setupSAS_Create_happy_path(bool allocateKeyName)
+{
+    setupSAS_Create_happy_path_provide_key(false, allocateKeyName);
 }
 
 DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
@@ -204,6 +219,7 @@ TEST_SUITE_INITIALIZE(TestClassInitialize)
 
     REGISTER_GLOBAL_MOCK_RETURN(STRING_c_str, TEST_CONST_CHAR_STAR_NULL);
     REGISTER_GLOBAL_MOCK_RETURN(STRING_length, 0);
+    REGISTER_GLOBAL_MOCK_HOOK(STRING_construct, my_STRING_construct);
     REGISTER_GLOBAL_MOCK_HOOK(STRING_delete, my_STRING_delete);
 
     REGISTER_GLOBAL_MOCK_RETURN(HTTPAPIEX_ExecuteRequest, HTTPAPIEX_OK);
@@ -577,6 +593,38 @@ TEST_FUNCTION(HTTPAPIEX_SAS_invoke_executerequest_get_time_fails)
 
     STRICT_EXPECTED_CALL(HTTPHeaders_FindHeaderValue(TEST_REQUEST_HTTP_HEADERS_HANDLE, "Authorization")).SetReturn(TEST_CHAR_ARRAY);
     STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn((time_t)-1);
+    STRICT_EXPECTED_CALL(HTTPAPIEX_ExecuteRequest(TEST_HTTPAPIEX_HANDLE, TEST_HTTPAPI_REQUEST_TYPE, TEST_CHAR_ARRAY, TEST_REQUEST_HTTP_HEADERS_HANDLE, TEST_REQUEST_CONTENT, &statusCode, TEST_RESPONSE_HTTP_HEADERS_HANDLE, TEST_RESPONSE_CONTENT)).SetReturn(HTTPAPIEX_OK);
+
+    // act
+    result = HTTPAPIEX_SAS_ExecuteRequest(sasHandle, TEST_HTTPAPIEX_HANDLE, TEST_HTTPAPI_REQUEST_TYPE, TEST_CHAR_ARRAY, TEST_REQUEST_HTTP_HEADERS_HANDLE, TEST_REQUEST_CONTENT, &statusCode, TEST_RESPONSE_HTTP_HEADERS_HANDLE, TEST_RESPONSE_CONTENT);
+
+    // assert
+    ASSERT_ARE_EQUAL(HTTPAPIEX_RESULT, result, HTTPAPIEX_OK);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // Cleanup
+    HTTPAPIEX_SAS_Destroy(sasHandle);
+}
+
+/*Tests_SRS_HTTPAPIEXSAS_06_017: [If state->key is prefixed with "sas=", SharedAccessSignature will be used rather than created.  STRING_construct will be invoked.]*/
+TEST_FUNCTION(HTTPAPIEX_SAS_invoke_executerequest_sas_is_provided_succeeds)
+{
+
+    HTTPAPIEX_RESULT result;
+    unsigned int statusCode;
+    HTTPAPIEX_SAS_HANDLE sasHandle;
+
+    // arrange
+    setupSAS_Create_happy_path_provide_key(true, true);
+    sasHandle = HTTPAPIEX_SAS_Create(TEST_KEY_HANDLE, TEST_URIRESOURCE_HANDLE, TEST_KEYNAME_HANDLE);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(HTTPHeaders_FindHeaderValue(TEST_REQUEST_HTTP_HEADERS_HANDLE, "Authorization")).SetReturn(TEST_CHAR_ARRAY);
+    STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn(3600);
+    STRICT_EXPECTED_CALL(STRING_construct(TEST_SAS));
+    STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_CHAR_ARRAY);
+    STRICT_EXPECTED_CALL(HTTPHeaders_ReplaceHeaderNameValuePair(TEST_REQUEST_HTTP_HEADERS_HANDLE, "Authorization", IGNORED_PTR_ARG)).SetReturn(HTTP_HEADERS_ERROR);
+    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(HTTPAPIEX_ExecuteRequest(TEST_HTTPAPIEX_HANDLE, TEST_HTTPAPI_REQUEST_TYPE, TEST_CHAR_ARRAY, TEST_REQUEST_HTTP_HEADERS_HANDLE, TEST_REQUEST_CONTENT, &statusCode, TEST_RESPONSE_HTTP_HEADERS_HANDLE, TEST_RESPONSE_CONTENT)).SetReturn(HTTPAPIEX_OK);
 
     // act


### PR DESCRIPTION
Currently, only SharedAccessKey access is enabled through the c SDK.  This attempts to add SharedAccessSignature support without changing any APIs (and trying not to break any backward compat).