### PR TITLE
Add UUID_FORMAT_VALUES_OR_NULL to print UUID_T's that may be NULL

### DIFF
--- a/inc/azure_c_shared_utility/uuid.h
+++ b/inc/azure_c_shared_utility/uuid.h
@@ -24,7 +24,13 @@ typedef unsigned char UUID_T[16];
 #define PRI_UUID        "02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
 #define UUID_FORMAT_VALUES(uuid) \
     (uuid)[0], (uuid)[1], (uuid)[2], (uuid)[3], (uuid)[4], (uuid)[5], (uuid)[6], (uuid)[7], \
-    (uuid)[8], (uuid)[9], (uuid)[10], (uuid)[11], (uuid)[12], (uuid)[13], (uuid)[14], (uuid)[15] \
+    (uuid)[8], (uuid)[9], (uuid)[10], (uuid)[11], (uuid)[12], (uuid)[13], (uuid)[14], (uuid)[15]
+
+#define UUID_FORMAT_VALUES_OR_NULL(uuid) \
+    (uuid == NULL) ? 0 : (uuid)[0], (uuid == NULL) ? 0 : (uuid)[1], (uuid == NULL) ? 0 : (uuid)[2], (uuid == NULL) ? 0 : (uuid)[3], \
+    (uuid == NULL) ? 0 : (uuid)[4], (uuid == NULL) ? 0 : (uuid)[5], (uuid == NULL) ? 0 : (uuid)[6], (uuid == NULL) ? 0 : (uuid)[7], \
+    (uuid == NULL) ? 0 : (uuid)[8], (uuid == NULL) ? 0 : (uuid)[9], (uuid == NULL) ? 0 : (uuid)[10], (uuid == NULL) ? 0 : (uuid)[11], \
+    (uuid == NULL) ? 0 : (uuid)[12], (uuid == NULL) ? 0 : (uuid)[13], (uuid == NULL) ? 0 : (uuid)[14], (uuid == NULL) ? 0 : (uuid)[15] \
 
 /* @brief               Generates a true UUID
 *  @param uuid          A pre-allocated buffer for the bytes of the generated UUID


### PR DESCRIPTION
Allows code like this:

```
int foo(const UUID_T uuid, void* bar)
{
    if (uuid == NULL || bar == NULL)
    {
        Log("Invalid args: uuid=%" PRI_UUID ", bar=%p", UUID_FORMAT_VALUES_OR_NULL(uuid), bar);
        return -1;
    }
    return 0;
}
```

NULL UUID_T is printed as "0000-00-00-00-000000"