### PR TITLE
Fix UUID_FORMAT_VALUES_OR_NULL to wrap uuid in parentheses

### DIFF
--- a/inc/azure_c_shared_utility/uuid.h
+++ b/inc/azure_c_shared_utility/uuid.h
@@ -27,10 +27,10 @@ typedef unsigned char UUID_T[16];
     (uuid)[8], (uuid)[9], (uuid)[10], (uuid)[11], (uuid)[12], (uuid)[13], (uuid)[14], (uuid)[15]
 
 #define UUID_FORMAT_VALUES_OR_NULL(uuid) \
-    (uuid == NULL) ? 0 : (uuid)[0], (uuid == NULL) ? 0 : (uuid)[1], (uuid == NULL) ? 0 : (uuid)[2], (uuid == NULL) ? 0 : (uuid)[3], \
-    (uuid == NULL) ? 0 : (uuid)[4], (uuid == NULL) ? 0 : (uuid)[5], (uuid == NULL) ? 0 : (uuid)[6], (uuid == NULL) ? 0 : (uuid)[7], \
-    (uuid == NULL) ? 0 : (uuid)[8], (uuid == NULL) ? 0 : (uuid)[9], (uuid == NULL) ? 0 : (uuid)[10], (uuid == NULL) ? 0 : (uuid)[11], \
-    (uuid == NULL) ? 0 : (uuid)[12], (uuid == NULL) ? 0 : (uuid)[13], (uuid == NULL) ? 0 : (uuid)[14], (uuid == NULL) ? 0 : (uuid)[15] \
+    ((uuid) == NULL) ? 0 : (uuid)[0], ((uuid) == NULL) ? 0 : (uuid)[1], ((uuid) == NULL) ? 0 : (uuid)[2], ((uuid) == NULL) ? 0 : (uuid)[3], \
+    ((uuid) == NULL) ? 0 : (uuid)[4], ((uuid) == NULL) ? 0 : (uuid)[5], ((uuid) == NULL) ? 0 : (uuid)[6], ((uuid) == NULL) ? 0 : (uuid)[7], \
+    ((uuid) == NULL) ? 0 : (uuid)[8], ((uuid) == NULL) ? 0 : (uuid)[9], ((uuid) == NULL) ? 0 : (uuid)[10], ((uuid) == NULL) ? 0 : (uuid)[11], \
+    ((uuid) == NULL) ? 0 : (uuid)[12], ((uuid) == NULL) ? 0 : (uuid)[13], ((uuid) == NULL) ? 0 : (uuid)[14], ((uuid) == NULL) ? 0 : (uuid)[15] \
 
 /* @brief               Generates a true UUID
 *  @param uuid          A pre-allocated buffer for the bytes of the generated UUID


### PR DESCRIPTION
Small cleanup to wrap "uuid" in parentheses for all of the NULL checks in `UUID_FORMAT_VALUES_OR_NULL`