### PR TITLE
Avoid syntax error if CMAKE_SYSTEM_VERSION is not defined (fixes #251)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ if(${use_applessl})
     include_directories(./pal/ios-osx/)
 endif()
 
-if (WIN32 AND (${CMAKE_SYSTEM_VERSION} VERSION_EQUAL "10.0.17763.0" OR ${CMAKE_SYSTEM_VERSION} VERSION_GREATER "10.0.17763.0"))
+if (WIN32 AND ("${CMAKE_SYSTEM_VERSION}" VERSION_EQUAL "10.0.17763.0" OR "${CMAKE_SYSTEM_VERSION}" VERSION_GREATER "10.0.17763.0"))
     # Windows added support for UNIX domain sockets to the OS and SDK
     # in the Oct 2018 update (10.0.17763.0, aka RS5)
     add_definitions(-DAF_UNIX_ON_WINDOWS)


### PR DESCRIPTION
In some cross-compilation environments, CMAKE_SYSTEM_VERSION is not
defined. Without, the expression itself is invalid. After the change,
the expression is valid and will result in false as expected.