### PR TITLE
MOD: %zu->%lu to mbed-related files

### DIFF
--- a/adapters/httpapi_curl.c
+++ b/adapters/httpapi_curl.c
@@ -206,7 +206,7 @@ static size_t ContentWriteFunction(void *ptr, size_t size, size_t nmemb, void *u
         }
         else
         {
-            LogError("Could not allocate buffer of size %zu", (size_t)(responseContentBuffer->bufferSize + (size * nmemb)));
+            LogError("Could not allocate buffer of size %lu", (unsigned long)(responseContentBuffer->bufferSize + (size * nmemb)));
             responseContentBuffer->error = 1;
             if (responseContentBuffer->buffer != NULL)
             {

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -289,7 +289,7 @@ static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* soc
         size_t hostname_len = strlen(socket_io_instance->hostname);
         if (hostname_len + 1 > sizeof(addrInfoUn.sun_path))
         {
-            LogError("Hostname %s is too long for a unix socket (max len = %zu)", socket_io_instance->hostname, sizeof(addrInfoUn.sun_path));
+            LogError("Hostname %s is too long for a unix socket (max len = %lu)", socket_io_instance->hostname, (unsigned long)sizeof(addrInfoUn.sun_path));
             result = __FAILURE__;
         }
         else

--- a/pal/ios-osx/tlsio_appleios.c
+++ b/pal/ios-osx/tlsio_appleios.c
@@ -648,7 +648,7 @@ static int tlsio_appleios_send_async(CONCRETE_IO_HANDLE tls_io, const void* buff
     {
         /* Codes_SRS_TLSIO_30_062: [ If the on_send_complete is NULL, tlsio_appleios_compact_send shall log the error and return FAILURE. ]*/
         result = __FAILURE__;
-        LogError("Invalid parameter specified: tls_io: %p, buffer: %p, size: %zu, on_send_complete: %p", tls_io, buffer, size, on_send_complete);
+        LogError("Invalid parameter specified: tls_io: %p, buffer: %p, size: %lu, on_send_complete: %p", tls_io, buffer, (unsigned long)size, on_send_complete);
     }
     else
     {

--- a/samples/socketio_connect/main.c
+++ b/samples/socketio_connect/main.c
@@ -40,7 +40,7 @@ static void on_io_open_complete(void* context, IO_OPEN_RESULT open_result)
 static void on_io_bytes_received(void* context, const unsigned char* buffer, size_t size)
 {
     (void)context, (void)buffer;
-    (void)printf("Received %zu bytes\r\n", size);
+    (void)printf("Received %lu bytes\r\n", (unsigned long)size);
 }
 
 static void on_io_error(void* context)

--- a/samples/tlsio_connect/main.c
+++ b/samples/tlsio_connect/main.c
@@ -40,7 +40,7 @@ static void on_io_open_complete(void* context, IO_OPEN_RESULT open_result)
 static void on_io_bytes_received(void* context, const unsigned char* buffer, size_t size)
 {
     (void)context, (void)buffer;
-    (void)printf("Received %zu bytes\r\n", size);
+    (void)printf("Received %lu bytes\r\n", (unsigned long)size);
 }
 
 static void on_io_error(void* context)

--- a/tests/base32_ut/base32_ut.c
+++ b/tests/base32_ut/base32_ut.c
@@ -249,7 +249,7 @@ BEGIN_TEST_SUITE(base32_ut)
         for (index = 0; index < num_elements; index++)
         {
             char tmp_msg[64];
-            sprintf(tmp_msg, "Base32_Encode_Bytes failure in test %zu", index);
+            sprintf(tmp_msg, "Base32_Encode_Bytes failure in test %lu", (unsigned long)index);
 
             result = Base32_Encode_Bytes(test_val_len[index].input_data, test_val_len[index].input_len);
 
@@ -316,7 +316,7 @@ BEGIN_TEST_SUITE(base32_ut)
         {
             BUFFER_HANDLE input_buff;
             char tmp_msg[64];
-            sprintf(tmp_msg, "Base32_Encode failure in test %zu", index);
+            sprintf(tmp_msg, "Base32_Encode failure in test %lu", (unsigned long)index);
 
             input_buff = (BUFFER_HANDLE)&test_val_len[index];
             result = Base32_Encode(input_buff);
@@ -408,7 +408,7 @@ BEGIN_TEST_SUITE(base32_ut)
 
             result = Base32_Decode_String(test_val_len[index].base32_data);
 
-            sprintf(tmp_msg, "Base32_Decode failure in test %zu", index);
+            sprintf(tmp_msg, "Base32_Decode failure in test %lu", (unsigned long)index);
 
             //assert
             ASSERT_IS_NOT_NULL(result);

--- a/tests/http_proxy_io_ut/http_proxy_io_ut.c
+++ b/tests/http_proxy_io_ut/http_proxy_io_ut.c
@@ -581,7 +581,7 @@ TEST_FUNCTION(when_a_call_made_by_http_proxy_io_create_fails_then_http_proxy_io_
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        (void)sprintf(temp_str, "On failed call %zu", i);
+        (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
         // act
         http_io = http_proxy_io_get_interface_description()->concrete_io_create((void*)&default_http_proxy_io_config);

--- a/tests/optionhandler_ut/optionhandler_ut.c
+++ b/tests/optionhandler_ut/optionhandler_ut.c
@@ -257,7 +257,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            (void)sprintf(temp_str, "On failed call %zu", i);
+            (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
             ///act
             h = OptionHandler_Create(aCloneOption, aDestroyOption, aSetOption);
@@ -891,7 +891,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            (void)sprintf(temp_str, "On failed call %zu", i);
+            (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
             ///act
             result = OptionHandler_AddOption(handle, "name", value);
@@ -1041,7 +1041,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            (void)sprintf(temp_str, "On failed call %zu", i);
+            (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
             ///act
             result = OptionHandler_FeedOptions(handle, (void*)42);
@@ -1144,7 +1144,7 @@ BEGIN_TEST_SUITE(optionhandler_unittests)
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            (void)sprintf(temp_str, "On failed call %zu", i);
+            (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
             ///act
             result = OptionHandler_FeedOptions(handle, (void*)42);

--- a/tests/string_token_ut/string_token_ut.c
+++ b/tests/string_token_ut/string_token_ut.c
@@ -268,7 +268,7 @@ BEGIN_TEST_SUITE(string_token_ut)
             // act
             handle = StringToken_GetFirst(string, length, delimiters, 1);
 
-            sprintf(error_msg, "On failed call %zu", i);
+            sprintf(error_msg, "On failed call %lu", (unsigned long)i);
             ASSERT_IS_NULL(handle, error_msg);
         }
 
@@ -1096,7 +1096,7 @@ BEGIN_TEST_SUITE(string_token_ut)
             // act
             result = StringToken_Split(string, length, delimiters, 2, false, &tokens, &token_count);
 
-            sprintf(error_msg, "On failed call %zu", i);
+            sprintf(error_msg, "On failed call %lu", (unsigned long)i);
             ASSERT_ARE_NOT_EQUAL(int, 0, result, error_msg);
         }
 

--- a/tests/strings_ut/strings_ut.c
+++ b/tests/strings_ut/strings_ut.c
@@ -173,7 +173,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
             str_handle = STRING_new();
 
-            sprintf(tmp_msg, "STRING_new failure in test %zu/%zu", index+1, count);
+            sprintf(tmp_msg, "STRING_new failure in test %lu/%lu", (unsigned long)index+1, (unsigned long)count);
 
             //assert
             ASSERT_IS_NULL(str_handle, tmp_msg);
@@ -269,7 +269,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
             str_handle = STRING_construct(TEST_STRING_VALUE);
 
-            sprintf(tmp_msg, "STRING_construct failure in test %zu/%zu", index+1, count);
+            sprintf(tmp_msg, "STRING_construct failure in test %lu/%lu", (unsigned long)index+1, (unsigned long)count);
 
             //assert
             ASSERT_IS_NULL(str_handle, tmp_msg);
@@ -413,7 +413,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
             str_handle = STRING_construct_sprintf(FORMAT_STRING, TEST_STRING_VALUE);
 
-            sprintf(tmp_msg, "STRING_construct_sprintf failure in test %zu/%zu", index+1, count);
+            sprintf(tmp_msg, "STRING_construct_sprintf failure in test %lu/%lu", (unsigned long)index+1, (unsigned long)count);
 
             //assert
             ASSERT_IS_NULL(str_handle, tmp_msg);
@@ -781,7 +781,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
             nResult = STRING_quote(str_handle);
 
-            sprintf(tmp_msg, "STRING_quote failure in test %zu/%zu", index+1, count);
+            sprintf(tmp_msg, "STRING_quote failure in test %lu/%lu", (unsigned long)index+1, (unsigned long)count);
 
             //assert
             ASSERT_ARE_NOT_EQUAL(int, 0, nResult, tmp_msg);
@@ -1011,7 +1011,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
             str_result = STRING_clone(str_handle);
 
-            sprintf(tmp_msg, "STRING_clone failure in test %zu/%zu", index+1, count);
+            sprintf(tmp_msg, "STRING_clone failure in test %lu/%lu", (unsigned long)index+1, (unsigned long)count);
 
             //assert
             ASSERT_IS_NULL(str_result, tmp_msg);
@@ -1120,7 +1120,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
             result = STRING_construct_n("qq", 2);
 
-            sprintf(tmp_msg, "STRING_construct_n failure in test %zu/%zu", index+1, count);
+            sprintf(tmp_msg, "STRING_construct_n failure in test %lu/%lu", (unsigned long)index+1, (unsigned long)count);
 
             //assert
             ASSERT_IS_NULL(result, tmp_msg);
@@ -1321,7 +1321,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
             result = STRING_new_JSON("ab");
 
-            sprintf(tmp_msg, "STRING_new_JSON failure in test %zu/%zu", index+1, count);
+            sprintf(tmp_msg, "STRING_new_JSON failure in test %lu/%lu", (unsigned long)index+1, (unsigned long)count);
 
             //assert
             ASSERT_IS_NULL(result, tmp_msg);
@@ -1559,7 +1559,7 @@ BEGIN_TEST_SUITE(strings_unittests)
 
             str_result = STRING_sprintf(str_handle, FORMAT_STRING, TEST_STRING_VALUE);
 
-            sprintf(tmp_msg, "STRING_sprintf failure in test %zu/%zu", index+1, count);
+            sprintf(tmp_msg, "STRING_sprintf failure in test %lu/%lu", (unsigned long)index+1, (unsigned long)count);
 
             ///assert
             ASSERT_ARE_NOT_EQUAL(int, str_result, 0);

--- a/tests/template_ut/template_ut.c
+++ b/tests/template_ut/template_ut.c
@@ -353,7 +353,7 @@ BEGIN_TEST_SUITE(template_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(i);
 
-            (void)sprintf(temp_str, "On failed call %zu", i);
+            (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
             ///act
             result = target_create(SIZEOF_FOO_MEMORY);
@@ -403,7 +403,7 @@ BEGIN_TEST_SUITE(template_ut)
                 umock_c_negative_tests_reset();
                 umock_c_negative_tests_fail_call(i);
 
-                (void)sprintf(temp_str, "On failed call %zu", i);
+                (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
                 ///act
                 result = target_create(SIZEOF_FOO_MEMORY);
@@ -452,7 +452,7 @@ BEGIN_TEST_SUITE(template_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(i);
 
-            (void)sprintf(temp_str, "On failed call %zu", i);
+            (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
             ///act
             result = target_foo();

--- a/tests/tlsio_cyclonessl_socket_bsd_ut/tlsio_cyclonessl_socket_bsd_ut.c
+++ b/tests/tlsio_cyclonessl_socket_bsd_ut/tlsio_cyclonessl_socket_bsd_ut.c
@@ -224,7 +224,7 @@ TEST_FUNCTION(when_a_failure_occurs_for_tlsio_cyclonessl_socket_create_then_crea
         umock_c_negative_tests_fail_call(i);
 
         char temp_str[128];
-        (void)sprintf(temp_str, "On failed call %zu", i);
+        (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
         ///act
         int result = tlsio_cyclonessl_socket_create("testhostname", 4242, &socket);

--- a/tests/tlsio_cyclonessl_ut/tlsio_cyclonessl_ut.c
+++ b/tests/tlsio_cyclonessl_ut/tlsio_cyclonessl_ut.c
@@ -326,7 +326,7 @@ TEST_FUNCTION(when_a_failure_occurs_for_tlsio_cyclonessl_create_then_create_fail
         umock_c_negative_tests_fail_call(i);
 
         char temp_str[128];
-        (void)sprintf(temp_str, "On failed call %zu", i);
+        (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
         ///act
         CONCRETE_IO_HANDLE tlsio_handle = tlsio_cyclonessl_get_interface_description()->concrete_io_create(&tlsio_config);
@@ -628,7 +628,7 @@ TEST_FUNCTION(when_a_failure_occurs_for_tlsio_cyclonessl_open_then_create_fails)
         umock_c_negative_tests_fail_call(i);
 
         char temp_str[128];
-        (void)sprintf(temp_str, "On failed call %zu", i);
+        (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
         ///act
         int result = tlsio_cyclonessl_get_interface_description()->concrete_io_open(tlsio_handle, test_on_io_open_complete, (void*)0x4242, test_on_bytes_received, (void*)0x4243, NULL, (void*)0x4244);

--- a/tests/tlsio_mbedtls_ut/tlsio_mbedtls_ut.c
+++ b/tests/tlsio_mbedtls_ut/tlsio_mbedtls_ut.c
@@ -465,7 +465,7 @@ BEGIN_TEST_SUITE(tlsio_mbedtls_ut)
             umock_c_negative_tests_fail_call(index);
 
             char tmp_msg[64];
-            sprintf(tmp_msg, "tlsio_mbedtls_create failure in test %zu/%zu", index, count);
+            sprintf(tmp_msg, "tlsio_mbedtls_create failure in test %lu/%lu", (unsigned long)index, (unsigned long)count);
 
             //act
             CONCRETE_IO_HANDLE handle = tlsio_mbedtls_create(&tls_io_config);

--- a/tests/uuid_ut/uuid_ut.c
+++ b/tests/uuid_ut/uuid_ut.c
@@ -178,7 +178,7 @@ TEST_FUNCTION(UUID_generate_failure_checks)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        (void)sprintf(temp_str, "On failed call %zu", i);
+        (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
         // act
         result = UUID_generate(&uuid);
@@ -248,7 +248,7 @@ TEST_FUNCTION(UUID_to_string_failure_checks)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        (void)sprintf(temp_str, "On failed call %zu", i);
+        (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
         // act
         result = UUID_to_string(&TEST_UUID);

--- a/tests/uws_client_ut/uws_client_ut.c
+++ b/tests/uws_client_ut/uws_client_ut.c
@@ -1327,7 +1327,7 @@ TEST_FUNCTION(when_any_call_fails_uws_client_create_with_io_fails)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        (void)sprintf(temp_str, "On failed call %zu", i);
+        (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
         // act
         uws_client = uws_client_create_with_io(TEST_SOCKET_IO_INTERFACE_DESCRIPTION, &socketio_config, "test_host", 80, "111", two_protocols, sizeof(two_protocols) / sizeof(two_protocols[0]));
@@ -7676,7 +7676,7 @@ TEST_FUNCTION(uws_client_set_request_header_negative_tests)
         // act
         result = uws_client_set_request_header(uws_client, req_header1_key, req_header1_value);
 
-        sprintf(error_msg, "On failed call %zu", i);
+        sprintf(error_msg, "On failed call %lu", (unsigned long)i);
         ASSERT_ARE_NOT_EQUAL(int, 0, result, error_msg);
     }
 

--- a/tests/ws_url_ut/ws_url_ut.c
+++ b/tests/ws_url_ut/ws_url_ut.c
@@ -323,7 +323,7 @@ BEGIN_TEST_SUITE(ws_url_ut)
             ws_url = ws_url_create(url);
 
             // assert
-            sprintf(error_msg, "On failed call %zu", i);
+            sprintf(error_msg, "On failed call %lu", (unsigned long)i);
             ASSERT_IS_NULL(ws_url, error_msg);
         }
 

--- a/tests/x509_openssl_ut/x509_openssl_ut.c
+++ b/tests/x509_openssl_ut/x509_openssl_ut.c
@@ -479,7 +479,7 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
             umock_c_negative_tests_fail_call(index);
 
             char tmp_msg[128];
-            sprintf(tmp_msg, "x509_openssl_add_credentials failure in test %zu/%zu", index, count);
+            sprintf(tmp_msg, "x509_openssl_add_credentials failure in test %lu/%lu", (unsigned long)index, (unsigned long)count);
 
             g_replace_ctx.extra_certs = NULL;
 
@@ -613,7 +613,7 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
             umock_c_negative_tests_fail_call(index);
 
             char tmp_msg[128];
-            sprintf(tmp_msg, "x509_openssl_add_credentials failure in test %zu/%zu", index, count);
+            sprintf(tmp_msg, "x509_openssl_add_credentials failure in test %lu/%lu", (unsigned long)index, (unsigned long)count);
 
             //act
             result = x509_openssl_add_certificates(TEST_SSL_CTX, TEST_CERTIFICATE_1);

--- a/tests/x509_schannel_ut/x509_schannel_ut.c
+++ b/tests/x509_schannel_ut/x509_schannel_ut.c
@@ -701,7 +701,7 @@ TEST_FUNCTION(x509_schannel_negative_test_cases)
             umock_c_negative_tests_fail_call(i);
 
             ///act
-            (void)sprintf(temp_str, "On failed call %zu", i);
+            (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
             h = x509_schannel_create("certificate", "private key");
 
             ///assert

--- a/tests/xio_ut/xio_ut.c
+++ b/tests/xio_ut/xio_ut.c
@@ -974,7 +974,7 @@ TEST_FUNCTION(xio_retrieveoptions_unhappypaths)
         umock_c_negative_tests_fail_call(i);
 
         ///act
-        (void)sprintf(temp_str, "On failed call %zu", i);
+        (void)sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
         ///act
         h = xio_retrieveoptions(x);


### PR DESCRIPTION
As %zu cannot be shown correctly on mbed os5, I modified %zu to %lu in some mbed-os5-related files.

This is a Re-PR of https://github.com/Azure/azure-c-shared-utility/pull/182