### PR TITLE
Change constbuffer from CLONE to INC_REF/DEC_REF

### DIFF
--- a/devdoc/constbuffer_array_requirements.md
+++ b/devdoc/constbuffer_array_requirements.md
@@ -80,7 +80,7 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_ARRAY_HANDLE, constbuffer_array_create_from_arra
 
 **SRS_CONSTBUFFER_ARRAY_42_003: [** `constbuffer_array_create_from_array_array` shall allocate memory to hold all of the `CONSTBUFFER_HANDLES` from `buffer_arrays`. **]**
 
-**SRS_CONSTBUFFER_ARRAY_42_004: [** `constbuffer_array_create_from_array_array` shall copy all of the `CONSTBUFFER_HANDLES` from each const buffer array in `buffer_arrays` to the newly constructed array by calling `CONSTBUFFER_Clone`. **]**
+**SRS_CONSTBUFFER_ARRAY_42_004: [** `constbuffer_array_create_from_array_array` shall copy all of the `CONSTBUFFER_HANDLES` from each const buffer array in `buffer_arrays` to the newly constructed array by calling `CONSTBUFFER_IncRef`. **]**
 
 **SRS_CONSTBUFFER_ARRAY_42_007: [** `constbuffer_array_create_from_array_array` shall succeed and return a non-`NULL` value. **]**
 
@@ -191,8 +191,6 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, constbuffer_array_get_buffer, CONSTBUFFE
 **SRS_CONSTBUFFER_ARRAY_01_007: [** If `constbuffer_array_handle` is NULL, `constbuffer_array_get_buffer` shall fail and return NULL. **]**
 
 **SRS_CONSTBUFFER_ARRAY_01_008: [** If `buffer_index` is greater or equal to the number of buffers in the array, `constbuffer_array_get_buffer` shall fail and return NULL. **]**
-
-**SRS_CONSTBUFFER_ARRAY_01_015: [** If any error occurs, `constbuffer_array_get_buffer` shall fail and return NULL. **]**
 
 ### constbuffer_array_get_buffer_content
 

--- a/devdoc/constbuffer_requirements.md
+++ b/devdoc/constbuffer_requirements.md
@@ -36,11 +36,11 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, CONSTBUFFER_CreateWithMoveMemory, unsign
 
 MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, CONSTBUFFER_CreateWithCustomFree, const unsigned char*, source, size_t, size, CONSTBUFFER_CUSTOM_FREE_FUNC, customFreeFunc, void*, customFreeFuncContext);
 
-MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, CONSTBUFFER_Clone, CONSTBUFFER_HANDLE, constbufferHandle);
+MOCKABLE_FUNCTION(, void, CONSTBUFFER_IncRef, CONSTBUFFER_HANDLE, constbufferHandle);
+
+MOCKABLE_FUNCTION(, void, CONSTBUFFER_DecRef, CONSTBUFFER_HANDLE, constbufferHandle);
 
 MOCKABLE_FUNCTION(, const CONSTBUFFER*, CONSTBUFFER_GetContent, CONSTBUFFER_HANDLE, constbufferHandle);
-
-MOCKABLE_FUNCTION(, void, CONSTBUFFER_Destroy, CONSTBUFFER_HANDLE, constbufferHandle);
 ```
 
 ###  CONSTBUFFER_Create
@@ -114,13 +114,25 @@ The memory has to be free by calling the custom free function passed as argument
 
 **SRS_CONSTBUFFER_01_011: [** If any error occurs, `CONSTBUFFER_CreateWithMoveMemory` shall fail and return NULL. **]**
 
-### CONSTBUFFER_Clone
+### CONSTBUFFER_IncRef
 ```c
-MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, CONSTBUFFER_Clone, CONSTBUFFER_HANDLE, constbufferHandle);
+MOCKABLE_FUNCTION(, void, CONSTBUFFER_IncRef, CONSTBUFFER_HANDLE, constbufferHandle);
 ```
-**SRS_CONSTBUFFER_02_013: [** If `constbufferHandle` is NULL then CONSTBUFFER_Clone shall fail and return NULL. **]**
+**SRS_CONSTBUFFER_02_013: [** If `constbufferHandle` is NULL then `CONSTBUFFER_IncRef` shall return. **]**
 
-**SRS_CONSTBUFFER_02_014: [** Otherwise, `CONSTBUFFER_Clone` shall increment the reference count and return `constbufferHandle`. **]**
+**SRS_CONSTBUFFER_02_014: [** Otherwise, `CONSTBUFFER_IncRef` shall increment the reference count. **]**
+
+### CONSTBUFFER_DecRef
+```c
+MOCKABLE_FUNCTION(, void, CONSTBUFFER_DecRef, CONSTBUFFER_HANDLE, constbufferHandle);
+```
+**SRS_CONSTBUFFER_02_015: [** If `constbufferHandle` is NULL then `CONSTBUFFER_DecRef` shall do nothing. **]**
+
+**SRS_CONSTBUFFER_02_016: [** Otherwise, `CONSTBUFFER_DecRef` shall decrement the refcount on the `constbufferHandle` handle. **]**
+
+**SRS_CONSTBUFFER_02_017: [** If the refcount reaches zero, then `CONSTBUFFER_DecRef` shall deallocate all resources used by the CONSTBUFFER_HANDLE. **]**
+
+**SRS_CONSTBUFFER_01_012: [** If the buffer was created by calling `CONSTBUFFER_CreateWithCustomFree`, the `customFreeFunc` function shall be called to free the memory, while passed `customFreeFuncContext` as argument. **]**
 
 ### CONSTBUFFER_GetContent
 ```c
@@ -129,15 +141,3 @@ MOCKABLE_FUNCTION(, const CONSTBUFFER*, CONSTBUFFER_GetContent, CONSTBUFFER_HAND
 **SRS_CONSTBUFFER_02_011: [** If `constbufferHandle` is NULL then CONSTBUFFER_GetContent shall return NULL. **]**
 
 **SRS_CONSTBUFFER_02_012: [** Otherwise, `CONSTBUFFER_GetContent` shall return a `const CONSTBUFFER*` that matches byte by byte the original bytes used to created the const buffer and has the same length. **]**
-
-### CONSTBUFFER_Destroy
-```c
-MOCKABLE_FUNCTION(, void, CONSTBUFFER_Destroy, CONSTBUFFER_HANDLE, constbufferHandle);
-```
-**SRS_CONSTBUFFER_02_015: [** If `constbufferHandle` is NULL then `CONSTBUFFER_Destroy` shall do nothing. **]**
-
-**SRS_CONSTBUFFER_02_016: [** Otherwise, `CONSTBUFFER_Destroy` shall decrement the refcount on the `constbufferHandle` handle. **]**
-
-**SRS_CONSTBUFFER_02_017: [** If the refcount reaches zero, then `CONSTBUFFER_Destroy` shall deallocate all resources used by the CONSTBUFFER_HANDLE. **]**
-
-**SRS_CONSTBUFFER_01_012: [** If the buffer was created by calling `CONSTBUFFER_CreateWithCustomFree`, the `customFreeFunc` function shall be called to free the memory, while passed `customFreeFuncContext` as argument. **]**

--- a/inc/azure_c_shared_utility/constbuffer.h
+++ b/inc/azure_c_shared_utility/constbuffer.h
@@ -38,11 +38,11 @@ MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, CONSTBUFFER_CreateWithMoveMemory, unsign
 
 MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, CONSTBUFFER_CreateWithCustomFree, const unsigned char*, source, size_t, size, CONSTBUFFER_CUSTOM_FREE_FUNC, customFreeFunc, void*, customFreeFuncContext);
 
-MOCKABLE_FUNCTION(, CONSTBUFFER_HANDLE, CONSTBUFFER_Clone, CONSTBUFFER_HANDLE, constbufferHandle);
+MOCKABLE_FUNCTION(, void, CONSTBUFFER_IncRef, CONSTBUFFER_HANDLE, constbufferHandle);
+
+MOCKABLE_FUNCTION(, void, CONSTBUFFER_DecRef, CONSTBUFFER_HANDLE, constbufferHandle);
 
 MOCKABLE_FUNCTION(, const CONSTBUFFER*, CONSTBUFFER_GetContent, CONSTBUFFER_HANDLE, constbufferHandle);
-
-MOCKABLE_FUNCTION(, void, CONSTBUFFER_Destroy, CONSTBUFFER_HANDLE, constbufferHandle);
 
 #ifdef __cplusplus
 }

--- a/src/aziotsharedutil.def
+++ b/src/aziotsharedutil.def
@@ -28,11 +28,11 @@ EXPORTS
     COND_RESULTStringStorage
     COND_RESULTStrings
     COND_RESULT_FromString
-    CONSTBUFFER_Clone
     CONSTBUFFER_Create
     CONSTBUFFER_CreateFromBuffer
-    CONSTBUFFER_Destroy
+    CONSTBUFFER_DecRef
     CONSTBUFFER_GetContent
+    CONSTBUFFER_IncRef
     CONSTMAP_RESULTStringStorage
     CONSTMAP_RESULTStrings
     CONSTMAP_RESULT_FromString

--- a/src/constbuffer.c
+++ b/src/constbuffer.c
@@ -180,19 +180,18 @@ CONSTBUFFER_HANDLE CONSTBUFFER_CreateWithCustomFree(const unsigned char* source,
     return result;
 }
 
-CONSTBUFFER_HANDLE CONSTBUFFER_Clone(CONSTBUFFER_HANDLE constbufferHandle)
+void CONSTBUFFER_IncRef(CONSTBUFFER_HANDLE constbufferHandle)
 {
     if (constbufferHandle == NULL)
     {
-        /*Codes_SRS_CONSTBUFFER_02_013: [If constbufferHandle is NULL then CONSTBUFFER_Clone shall fail and return NULL.]*/
-        LogError("invalid arg");
+        /*Codes_SRS_CONSTBUFFER_02_013: [If constbufferHandle is NULL then CONSTBUFFER_IncRef shall return.]*/
+        LogError("Invalid arguments: CONSTBUFFER_HANDLE constbufferHandle=%p", constbufferHandle);
     }
     else
     {
-        /*Codes_SRS_CONSTBUFFER_02_014: [Otherwise, CONSTBUFFER_Clone shall increment the reference count and return constbufferHandle.]*/
+        /*Codes_SRS_CONSTBUFFER_02_014: [Otherwise, CONSTBUFFER_IncRef shall increment the reference count.]*/
         INC_REF_VAR(constbufferHandle->count);
     }
-    return constbufferHandle;
 }
 
 const CONSTBUFFER* CONSTBUFFER_GetContent(CONSTBUFFER_HANDLE constbufferHandle)
@@ -212,12 +211,16 @@ const CONSTBUFFER* CONSTBUFFER_GetContent(CONSTBUFFER_HANDLE constbufferHandle)
     return result;
 }
 
-void CONSTBUFFER_Destroy(CONSTBUFFER_HANDLE constbufferHandle)
+void CONSTBUFFER_DecRef(CONSTBUFFER_HANDLE constbufferHandle)
 {
-    /*Codes_SRS_CONSTBUFFER_02_015: [If constbufferHandle is NULL then CONSTBUFFER_Destroy shall do nothing.]*/
-    if (constbufferHandle != NULL)
+    if (constbufferHandle == NULL)
     {
-        /*Codes_SRS_CONSTBUFFER_02_016: [Otherwise, CONSTBUFFER_Destroy shall decrement the refcount on the constbufferHandle handle.]*/
+        /*Codes_SRS_CONSTBUFFER_02_015: [If constbufferHandle is NULL then CONSTBUFFER_DecRef shall do nothing.]*/
+        LogError("Invalid arguments: CONSTBUFFER_HANDLE constbufferHandle=%p", constbufferHandle);
+    }
+    else
+    {
+        /*Codes_SRS_CONSTBUFFER_02_016: [Otherwise, CONSTBUFFER_DecRef shall decrement the refcount on the constbufferHandle handle.]*/
         if (DEC_REF_VAR(constbufferHandle->count) == DEC_RETURN_ZERO)
         {
             if (constbufferHandle->buffer_type == CONSTBUFFER_TYPE_MEMORY_MOVED)
@@ -230,7 +233,7 @@ void CONSTBUFFER_Destroy(CONSTBUFFER_HANDLE constbufferHandle)
                 constbufferHandle->custom_free_func(constbufferHandle->custom_free_func_context);
             }
 
-            /*Codes_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_Destroy shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
+            /*Codes_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_DecRef shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
             free(constbufferHandle);
         }
     }

--- a/src/constbuffer_array.c
+++ b/src/constbuffer_array.c
@@ -51,34 +51,14 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create(const CONSTBUFFER_HANDLE* buff
             for (i = 0; i < buffer_count; i++)
             {
                 /* Codes_SRS_CONSTBUFFER_ARRAY_01_010: [ constbuffer_array_create shall clone the buffers in buffers and store them. ]*/
-                result->buffers[i] = CONSTBUFFER_Clone(buffers[i]);
-                if (result->buffers[i] == NULL)
-                {
-                    /* Codes_SRS_CONSTBUFFER_ARRAY_01_014: [ If any error occurs, constbuffer_array_create shall fail and return NULL. ]*/
-                    LogError("Failed cloning buffer at index %" PRIu32, i);
-                    break;
-                }
+                CONSTBUFFER_IncRef(buffers[i]);
+                result->buffers[i] = buffers[i];
             }
 
-            if (i < buffer_count)
-            {
-                uint32_t j;
-                LogError("Failed creating const buffer array");
+            result->nBuffers = buffer_count;
 
-                for (j = 0; j < i; j++)
-                {
-                    CONSTBUFFER_Destroy(result->buffers[j]);
-                }
-            }
-            else
-            {
-                result->nBuffers = buffer_count;
-
-                /* Codes_SRS_CONSTBUFFER_ARRAY_01_011: [ On success constbuffer_array_create shall return a non-NULL handle. ]*/
-                goto all_ok;
-            }
-
-            REFCOUNT_TYPE_DESTROY(CONSTBUFFER_ARRAY_HANDLE_DATA, result);
+            /* Codes_SRS_CONSTBUFFER_ARRAY_01_011: [ On success constbuffer_array_create shall return a non-NULL handle. ]*/
+            goto all_ok;
         }
     }
 
@@ -184,37 +164,14 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_create_from_array_array(const CONSTBU
                     {
                         for (source_idx = 0; source_idx < buffer_arrays[array_idx]->nBuffers; ++source_idx, ++dest_idx)
                         {
-                            /*Codes_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
-                            result->buffers[dest_idx] = CONSTBUFFER_Clone(buffer_arrays[array_idx]->buffers[source_idx]);
-                            if (result->buffers[dest_idx] == NULL)
-                            {
-                                /*Codes_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then constbuffer_array_create_from_array_array shall fail and return NULL. ]*/
-                                LogError("failure in CONSTBUFFER_Clone for buffer array %" PRIu32 ", buffer %" PRIu32, array_idx, source_idx);
-                                break;
-                            }
-                        }
-
-                        if (source_idx < buffer_arrays[array_idx]->nBuffers)
-                        {
-                            break;
+                            /*Codes_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
+                            CONSTBUFFER_IncRef(buffer_arrays[array_idx]->buffers[source_idx]);
+                            result->buffers[dest_idx] = buffer_arrays[array_idx]->buffers[source_idx];
                         }
                     }
 
-                    if (array_idx < buffer_array_count)
-                    {
-                        // Cleanup on partial copy
-                        for (i = 0; i < dest_idx; i++)
-                        {
-                            CONSTBUFFER_Destroy(result->buffers[i]);
-                        }
-                    }
-                    else
-                    {
-                        /*Codes_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
-                        goto allOk;
-                    }
-
-                    REFCOUNT_TYPE_DESTROY(CONSTBUFFER_ARRAY_HANDLE_DATA, result);
+                    /*Codes_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
+                    goto allOk;
                 }
             }
         }
@@ -248,45 +205,21 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_add_front(CONSTBUFFER_ARRAY_HANDLE co
         }
         else
         {
+            uint32_t i;
+
             /*Codes_SRS_CONSTBUFFER_ARRAY_02_043: [ constbuffer_array_add_front shall copy constbuffer_handle and all of constbuffer_array_handle existing CONSTBUFFER_HANDLE. ]*/
             /*Codes_SRS_CONSTBUFFER_ARRAY_02_044: [ constbuffer_array_add_front shall inc_ref all the CONSTBUFFER_HANDLE it had copied. ]*/
             result->nBuffers = constbuffer_array_handle->nBuffers + 1;
-            if ((result->buffers[0] = CONSTBUFFER_Clone(constbuffer_handle)) == NULL)
+            CONSTBUFFER_IncRef(constbuffer_handle);
+            result->buffers[0] = constbuffer_handle;
+            for (i = 1; i < result->nBuffers; i++)
             {
-                /*Codes_SRS_CONSTBUFFER_ARRAY_02_011: [ If there any failures constbuffer_array_add_front shall fail and return NULL. ]*/
-                LogError("failure in CONSTBUFFER_Clone");
-            }
-            else
-            {
-                uint32_t i;
-                for (i = 1; i < result->nBuffers; i++)
-                {
-                    result->buffers[i] = CONSTBUFFER_Clone(constbuffer_array_handle->buffers[i - 1]);
-                    if (result->buffers[i] == NULL)
-                    {
-                        /*Codes_SRS_CONSTBUFFER_ARRAY_02_011: [ If there any failures constbuffer_array_add_front shall fail and return NULL. ]*/
-                        LogError("failure in CONSTBUFFER_Clone");
-                        break;
-                    }
-                }
-
-                if (i != result->nBuffers)
-                {
-                    uint32_t j;
-                    for (j = 1; j < i; j++)
-                    {
-                        CONSTBUFFER_Destroy(result->buffers[j]);
-                    }
-                }
-                else
-                {
-                    /*Codes_SRS_CONSTBUFFER_ARRAY_02_010: [ constbuffer_array_add_front shall succeed and return a non-NULL value. ]*/
-                    goto allOk;
-                }
-                CONSTBUFFER_Destroy(result->buffers[0]);
+                CONSTBUFFER_IncRef(constbuffer_array_handle->buffers[i - 1]);
+                result->buffers[i] = constbuffer_array_handle->buffers[i - 1];
             }
 
-            REFCOUNT_TYPE_DESTROY(CONSTBUFFER_ARRAY_HANDLE_DATA, result);
+            /*Codes_SRS_CONSTBUFFER_ARRAY_02_010: [ constbuffer_array_add_front shall succeed and return a non-NULL value. ]*/
+            goto allOk;
         }
     }
     /*Codes_SRS_CONSTBUFFER_ARRAY_02_011: [ If there any failures constbuffer_array_add_front shall fail and return NULL. ]*/
@@ -329,50 +262,23 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_remove_front(CONSTBUFFER_ARRAY_HANDLE
             }
             else
             {
+                uint32_t i;
+
                 /* Codes_SRS_CONSTBUFFER_ARRAY_01_001: [ constbuffer_array_remove_front shall inc_ref the removed buffer. ]*/
-                CONSTBUFFER_HANDLE clonedFrontBuffer = CONSTBUFFER_Clone(constbuffer_array_handle->buffers[0]);
-                if (clonedFrontBuffer == NULL)
+                CONSTBUFFER_IncRef(constbuffer_array_handle->buffers[0]);
+                result->nBuffers = constbuffer_array_handle->nBuffers - 1;
+
+                /*Codes_SRS_CONSTBUFFER_ARRAY_02_047: [ constbuffer_array_remove_front shall copy all of constbuffer_array_handle CONSTBUFFER_HANDLEs except the front one. ]*/
+                /*Codes_SRS_CONSTBUFFER_ARRAY_02_048: [ constbuffer_array_remove_front shall inc_ref all the copied CONSTBUFFER_HANDLEs. ]*/
+                for (i = 1; i < constbuffer_array_handle->nBuffers; i++)
                 {
-                    /*Codes_SRS_CONSTBUFFER_ARRAY_02_036: [ If there are any failures then constbuffer_array_remove_front shall fail and return NULL. ]*/
-                    LogError("failure in CONSTBUFFER_Clone");
-                }
-                else
-                {
-                    uint32_t i;
-                    result->nBuffers = constbuffer_array_handle->nBuffers - 1;
-
-                    /*Codes_SRS_CONSTBUFFER_ARRAY_02_047: [ constbuffer_array_remove_front shall copy all of constbuffer_array_handle CONSTBUFFER_HANDLEs except the front one. ]*/
-                    /*Codes_SRS_CONSTBUFFER_ARRAY_02_048: [ constbuffer_array_remove_front shall inc_ref all the copied CONSTBUFFER_HANDLEs. ]*/
-                    for (i = 1; i < constbuffer_array_handle->nBuffers; i++)
-                    {
-                        if ((result->buffers[i - 1] = CONSTBUFFER_Clone(constbuffer_array_handle->buffers[i])) == NULL)
-                        {
-                            /*Codes_SRS_CONSTBUFFER_ARRAY_02_036: [ If there are any failures then constbuffer_array_remove_front shall fail and return NULL. ]*/
-                            LogError("failure in CONSTBUFFER_Clone");
-                            break;
-                        }
-                    }
-
-                    if (i != constbuffer_array_handle->nBuffers)
-                    {
-                        uint32_t j;
-
-                        for (j = 1; j < i; j++)
-                        {
-                            CONSTBUFFER_Destroy(result->buffers[j - 1]);
-                        }
-                    }
-                    else
-                    {
-                        /*Codes_SRS_CONSTBUFFER_ARRAY_02_049: [ constbuffer_array_remove_front shall succeed, write in constbuffer_handle the front handle and return a non-NULL value. ]*/
-                        *constbuffer_handle = clonedFrontBuffer;
-                        goto allOk;
-                    }
-
-                    CONSTBUFFER_Destroy(clonedFrontBuffer);
+                    CONSTBUFFER_IncRef(constbuffer_array_handle->buffers[i]);
+                    result->buffers[i - 1] = constbuffer_array_handle->buffers[i];
                 }
 
-                REFCOUNT_TYPE_DESTROY(CONSTBUFFER_ARRAY_HANDLE_DATA, result);
+                /*Codes_SRS_CONSTBUFFER_ARRAY_02_049: [ constbuffer_array_remove_front shall succeed, write in constbuffer_handle the front handle and return a non-NULL value. ]*/
+                *constbuffer_handle = constbuffer_array_handle->buffers[0];
+                goto allOk;
             }
         }
     }
@@ -425,17 +331,11 @@ CONSTBUFFER_HANDLE constbuffer_array_get_buffer(CONSTBUFFER_ARRAY_HANDLE constbu
     else
     {
         /* Codes_SRS_CONSTBUFFER_ARRAY_01_006: [ The returned handle shall have its reference count incremented. ]*/
-        result = CONSTBUFFER_Clone(constbuffer_array_handle->buffers[buffer_index]);
-        if (result == NULL)
-        {
-            /* Codes_SRS_CONSTBUFFER_ARRAY_01_015: [ If any error occurs, constbuffer_array_get_buffer shall fail and return NULL. ]*/
-            LogError("Cloning CONST buffer failed");
-        }
-        else
-        {
-            /* Codes_SRS_CONSTBUFFER_ARRAY_01_005: [ On success, constbuffer_array_get_buffer shall return a non-NULL handle to the buffer_index-th const buffer in the array. ]*/
-            goto all_ok;
-        }
+        CONSTBUFFER_IncRef(constbuffer_array_handle->buffers[buffer_index]);
+        result = constbuffer_array_handle->buffers[buffer_index];
+
+        /* Codes_SRS_CONSTBUFFER_ARRAY_01_005: [ On success, constbuffer_array_get_buffer shall return a non-NULL handle to the buffer_index-th const buffer in the array. ]*/
+        goto all_ok;
     }
 
     result = NULL;
@@ -498,7 +398,7 @@ void constbuffer_array_dec_ref(CONSTBUFFER_ARRAY_HANDLE constbuffer_array_handle
             /*Codes_SRS_CONSTBUFFER_ARRAY_02_038: [ If the reference count reaches 0, constbuffer_array_dec_ref shall free all used resources. ]*/
             for (i = 0; i < constbuffer_array_handle->nBuffers; i++)
             {
-                CONSTBUFFER_Destroy(constbuffer_array_handle->buffers[i]);
+                CONSTBUFFER_DecRef(constbuffer_array_handle->buffers[i]);
             }
 
             REFCOUNT_TYPE_DESTROY(CONSTBUFFER_ARRAY_HANDLE_DATA, constbuffer_array_handle);

--- a/tests/constbuffer_array_ut/constbuffer_array_ut.c
+++ b/tests/constbuffer_array_ut/constbuffer_array_ut.c
@@ -86,7 +86,6 @@ TEST_SUITE_INITIALIZE(suite_init)
 
     REGISTER_UMOCK_ALIAS_TYPE(CONSTBUFFER_HANDLE, void*);
 
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(CONSTBUFFER_Clone, NULL);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(CONSTBUFFER_GetContent, NULL);
 
     REGISTER_GLOBAL_MOCK_HOOK(gballoc_malloc, my_gballoc_malloc);
@@ -133,12 +132,12 @@ TEST_FUNCTION_INITIALIZE(method_init)
 
 TEST_FUNCTION_CLEANUP(method_cleanup)
 {
-    CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_6);
-    CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_5);
-    CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_4);
-    CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_3);
-    CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_2);
-    CONSTBUFFER_Destroy(TEST_CONSTBUFFER_HANDLE_1);
+    CONSTBUFFER_DecRef(TEST_CONSTBUFFER_HANDLE_6);
+    CONSTBUFFER_DecRef(TEST_CONSTBUFFER_HANDLE_5);
+    CONSTBUFFER_DecRef(TEST_CONSTBUFFER_HANDLE_4);
+    CONSTBUFFER_DecRef(TEST_CONSTBUFFER_HANDLE_3);
+    CONSTBUFFER_DecRef(TEST_CONSTBUFFER_HANDLE_2);
+    CONSTBUFFER_DecRef(TEST_CONSTBUFFER_HANDLE_1);
     umock_c_negative_tests_deinit();
     TEST_MUTEX_RELEASE(test_serialize_mutex);
 }
@@ -163,8 +162,8 @@ TEST_FUNCTION(constbuffer_array_create_succeeds)
     test_buffers[1] = TEST_CONSTBUFFER_HANDLE_2;
 
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(TEST_CONSTBUFFER_HANDLE_1));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(TEST_CONSTBUFFER_HANDLE_2));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(TEST_CONSTBUFFER_HANDLE_1));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(TEST_CONSTBUFFER_HANDLE_2));
 
     ///act
     constbuffer_array = constbuffer_array_create(test_buffers, sizeof(test_buffers) / sizeof(test_buffers[0]));
@@ -230,22 +229,25 @@ TEST_FUNCTION(when_underlying_calls_fail_constbuffer_array_create_fails)
     test_buffers[1] = TEST_CONSTBUFFER_HANDLE_2;
 
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(TEST_CONSTBUFFER_HANDLE_1));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(TEST_CONSTBUFFER_HANDLE_2));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(TEST_CONSTBUFFER_HANDLE_1));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(TEST_CONSTBUFFER_HANDLE_2));
 
     umock_c_negative_tests_snapshot();
     for (i = 0; i < umock_c_negative_tests_call_count(); i++)
     {
-        CONSTBUFFER_ARRAY_HANDLE constbuffer_array;
+        if (umock_c_negative_tests_can_call_fail(i))
+        {
+            CONSTBUFFER_ARRAY_HANDLE constbuffer_array;
 
-        umock_c_negative_tests_reset();
-        umock_c_negative_tests_fail_call(i);
+            umock_c_negative_tests_reset();
+            umock_c_negative_tests_fail_call(i);
 
-        ///act
-        constbuffer_array = constbuffer_array_create(test_buffers, sizeof(test_buffers) / sizeof(test_buffers[0]));
+            ///act
+            constbuffer_array = constbuffer_array_create(test_buffers, sizeof(test_buffers) / sizeof(test_buffers[0]));
 
-        ///assert
-        ASSERT_IS_NULL(constbuffer_array);
+            ///assert
+            ASSERT_IS_NULL(constbuffer_array);
+        }
     }
 }
 
@@ -330,7 +332,7 @@ static CONSTBUFFER_ARRAY_HANDLE TEST_constbuffer_array_add_front(CONSTBUFFER_ARR
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     for (i = 0; i < nExistingBuffers; i++)
     {
-        STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(constbuffer_handle));
+        STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(constbuffer_handle));
     }
 
     result = constbuffer_array_add_front(constbuffer_array, constbuffer_handle);
@@ -348,7 +350,7 @@ static CONSTBUFFER_ARRAY_HANDLE TEST_constbuffer_array_remove_front(CONSTBUFFER_
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     for (i = 0; i < nExistingBuffers-1; i++)
     {
-        STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(IGNORED_PTR_ARG));
     }
 
     result = constbuffer_array_remove_front(constbuffer_array, constbuffer_handle);
@@ -362,7 +364,7 @@ static void TEST_constbuffer_array_dec_ref(CONSTBUFFER_ARRAY_HANDLE constbuffer_
     uint32_t i;
     for (i = 0; i < nExistingBuffers; i++)
     {
-        STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(CONSTBUFFER_DecRef(IGNORED_PTR_ARG));
     }
 
     STRICT_EXPECTED_CALL(gballoc_free(constbuffer_array));
@@ -377,7 +379,7 @@ static void constbuffer_array_create_from_array_array_inert_path(uint32_t existi
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     for (uint32_t i = 0; i < existing_item_count; i++)
     {
-        STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(IGNORED_PTR_ARG));
     }
 }
 
@@ -404,7 +406,7 @@ static void validate_sorted_constbuffer_array(CONSTBUFFER_ARRAY_HANDLE constbuff
     {
         CONSTBUFFER_HANDLE temp = constbuffer_array_get_buffer(constbuffer_array, i);
         ASSERT_ARE_EQUAL(void_ptr, all_buffers[i], temp, "Validate result[%" PRIu32 "]", i);
-        CONSTBUFFER_Destroy(temp);
+        CONSTBUFFER_DecRef(temp);
     }
 }
 
@@ -561,7 +563,7 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_three_empty_arrays_
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ constbuffer_array_create_from_array_array shall allocate memory to hold all of the CONSTBUFFER_HANDLES from buffer_arrays. ]*/
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
 TEST_FUNCTION(constbuffer_array_create_from_array_array_with_empty_array_and_1_element_array_succeeds)
 {
@@ -592,7 +594,7 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_empty_array_and_1_e
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ constbuffer_array_create_from_array_array shall allocate memory to hold all of the CONSTBUFFER_HANDLES from buffer_arrays. ]*/
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
 TEST_FUNCTION(constbuffer_array_create_from_array_array_with_1_element_array_and_empty_array_succeeds)
 {
@@ -623,7 +625,7 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_1_element_array_and
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ constbuffer_array_create_from_array_array shall allocate memory to hold all of the CONSTBUFFER_HANDLES from buffer_arrays. ]*/
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
 TEST_FUNCTION(constbuffer_array_create_from_array_array_with_2_1_element_arrays_succeeds)
 {
@@ -654,7 +656,7 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_2_1_element_arrays_
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ constbuffer_array_create_from_array_array shall allocate memory to hold all of the CONSTBUFFER_HANDLES from buffer_arrays. ]*/
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
 TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_1_element_arrays_succeeds)
 {
@@ -686,7 +688,7 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_1_element_arrays_
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ constbuffer_array_create_from_array_array shall allocate memory to hold all of the CONSTBUFFER_HANDLES from buffer_arrays. ]*/
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
 TEST_FUNCTION(constbuffer_array_create_from_array_array_with_2_2_element_arrays_succeeds)
 {
@@ -717,7 +719,7 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_2_2_element_arrays_
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ constbuffer_array_create_from_array_array shall allocate memory to hold all of the CONSTBUFFER_HANDLES from buffer_arrays. ]*/
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
 TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_2_element_arrays_succeeds)
 {
@@ -749,7 +751,7 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_2_element_arrays_
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ constbuffer_array_create_from_array_array shall allocate memory to hold all of the CONSTBUFFER_HANDLES from buffer_arrays. ]*/
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
 TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_arrays_of_size_1_2_3_succeeds)
 {
@@ -781,7 +783,7 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_arrays_of_size_1_
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_003: [ constbuffer_array_create_from_array_array shall allocate memory to hold all of the CONSTBUFFER_HANDLES from buffer_arrays. ]*/
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_Clone. ]*/
+/*Tests_SRS_CONSTBUFFER_ARRAY_42_004: [ constbuffer_array_create_from_array_array shall copy all of the CONSTBUFFER_HANDLES from each const buffer array in buffer_arrays to the newly constructed array by calling CONSTBUFFER_IncRef. ]*/
 /*Tests_SRS_CONSTBUFFER_ARRAY_42_007: [ constbuffer_array_create_from_array_array shall succeed and return a non-NULL value. ]*/
 TEST_FUNCTION(constbuffer_array_create_from_array_array_with_2_2_element_arrays_same_pointer_succeeds)
 {
@@ -811,16 +813,16 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_with_2_2_element_arrays_
 
     temp_buffer = constbuffer_array_get_buffer(result, 0);
     ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_1, temp_buffer, "Validate result[0]");
-    CONSTBUFFER_Destroy(temp_buffer);
+    CONSTBUFFER_DecRef(temp_buffer);
     temp_buffer = constbuffer_array_get_buffer(result, 1);
     ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_2, temp_buffer, "Validate result[1]");
-    CONSTBUFFER_Destroy(temp_buffer);
+    CONSTBUFFER_DecRef(temp_buffer);
     temp_buffer = constbuffer_array_get_buffer(result, 2);
     ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_1, temp_buffer, "Validate result[2]");
-    CONSTBUFFER_Destroy(temp_buffer);
+    CONSTBUFFER_DecRef(temp_buffer);
     temp_buffer = constbuffer_array_get_buffer(result, 3);
     ASSERT_ARE_EQUAL(void_ptr, TEST_CONSTBUFFER_HANDLE_2, temp_buffer, "Validate result[3]");
-    CONSTBUFFER_Destroy(temp_buffer);
+    CONSTBUFFER_DecRef(temp_buffer);
 
     ///clean
     constbuffer_array_dec_ref(result);
@@ -848,268 +850,6 @@ TEST_FUNCTION(constbuffer_array_create_from_array_array_fails_if_malloc_fails)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     ///clean
-    for (uint32_t i = 0; i < array_count; ++i)
-    {
-        constbuffer_array_dec_ref(buffer_array[i]);
-    }
-}
-
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
-TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_2_element_arrays_fails_if_first_clone_fails)
-{
-    ///arrange
-    CONSTBUFFER_ARRAY_HANDLE result;
-    const uint32_t array_count = 3;
-    CONSTBUFFER_ARRAY_HANDLE buffer_array[3];
-    buffer_array[0] = TEST_constbuffer_array_create(2, 0);
-    buffer_array[1] = TEST_constbuffer_array_create(2, 2);
-    buffer_array[2] = TEST_constbuffer_array_create(2, 4);
-
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .SetReturn(NULL);
-
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-
-    ///act
-    result = constbuffer_array_create_from_array_array(buffer_array, array_count);
-
-    ///assert
-    ASSERT_IS_NULL(result);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    ///clean
-    constbuffer_array_dec_ref(result);
-    for (uint32_t i = 0; i < array_count; ++i)
-    {
-        constbuffer_array_dec_ref(buffer_array[i]);
-    }
-}
-
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
-TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_2_element_arrays_fails_if_second_clone_fails)
-{
-    ///arrange
-    CONSTBUFFER_ARRAY_HANDLE result;
-    const uint32_t array_count = 3;
-    CONSTBUFFER_ARRAY_HANDLE buffer_array[3];
-    CONSTBUFFER_HANDLE clone;
-    buffer_array[0] = TEST_constbuffer_array_create(2, 0);
-    buffer_array[1] = TEST_constbuffer_array_create(2, 2);
-    buffer_array[2] = TEST_constbuffer_array_create(2, 4);
-
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clone);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .SetReturn(NULL);
-
-    // All cloned buffers are destroyed
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clone);
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-
-    ///act
-    result = constbuffer_array_create_from_array_array(buffer_array, array_count);
-
-    ///assert
-    ASSERT_IS_NULL(result);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    ///clean
-    constbuffer_array_dec_ref(result);
-    for (uint32_t i = 0; i < array_count; ++i)
-    {
-        constbuffer_array_dec_ref(buffer_array[i]);
-    }
-}
-
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
-TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_2_element_arrays_fails_if_third_clone_fails)
-{
-    ///arrange
-    CONSTBUFFER_ARRAY_HANDLE result;
-    const uint32_t array_count = 3;
-    CONSTBUFFER_ARRAY_HANDLE buffer_array[3];
-    CONSTBUFFER_HANDLE clones[2];
-    buffer_array[0] = TEST_constbuffer_array_create(2, 0);
-    buffer_array[1] = TEST_constbuffer_array_create(2, 2);
-    buffer_array[2] = TEST_constbuffer_array_create(2, 4);
-
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[0]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[1]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .SetReturn(NULL);
-
-    // All cloned buffers are destroyed
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[0]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[1]);
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-
-    ///act
-    result = constbuffer_array_create_from_array_array(buffer_array, array_count);
-
-    ///assert
-    ASSERT_IS_NULL(result);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    ///clean
-    constbuffer_array_dec_ref(result);
-    for (uint32_t i = 0; i < array_count; ++i)
-    {
-        constbuffer_array_dec_ref(buffer_array[i]);
-    }
-}
-
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
-TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_2_element_arrays_fails_if_fourth_clone_fails)
-{
-    ///arrange
-    CONSTBUFFER_ARRAY_HANDLE result;
-    const uint32_t array_count = 3;
-    CONSTBUFFER_ARRAY_HANDLE buffer_array[3];
-    CONSTBUFFER_HANDLE clones[3];
-    buffer_array[0] = TEST_constbuffer_array_create(2, 0);
-    buffer_array[1] = TEST_constbuffer_array_create(2, 2);
-    buffer_array[2] = TEST_constbuffer_array_create(2, 4);
-
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[0]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[1]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[2]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .SetReturn(NULL);
-
-    // All cloned buffers are destroyed
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[0]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[1]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[2]);
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-
-    ///act
-    result = constbuffer_array_create_from_array_array(buffer_array, array_count);
-
-    ///assert
-    ASSERT_IS_NULL(result);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    ///clean
-    constbuffer_array_dec_ref(result);
-    for (uint32_t i = 0; i < array_count; ++i)
-    {
-        constbuffer_array_dec_ref(buffer_array[i]);
-    }
-}
-
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
-TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_2_element_arrays_fails_if_fifth_clone_fails)
-{
-    ///arrange
-    CONSTBUFFER_ARRAY_HANDLE result;
-    const uint32_t array_count = 3;
-    CONSTBUFFER_ARRAY_HANDLE buffer_array[3];
-    CONSTBUFFER_HANDLE clones[4];
-    buffer_array[0] = TEST_constbuffer_array_create(2, 0);
-    buffer_array[1] = TEST_constbuffer_array_create(2, 2);
-    buffer_array[2] = TEST_constbuffer_array_create(2, 4);
-
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[0]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[1]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[2]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[3]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .SetReturn(NULL);
-
-    // All cloned buffers are destroyed
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[0]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[1]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[2]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[3]);
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-
-    ///act
-    result = constbuffer_array_create_from_array_array(buffer_array, array_count);
-
-    ///assert
-    ASSERT_IS_NULL(result);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    ///clean
-    constbuffer_array_dec_ref(result);
-    for (uint32_t i = 0; i < array_count; ++i)
-    {
-        constbuffer_array_dec_ref(buffer_array[i]);
-    }
-}
-
-/*Tests_SRS_CONSTBUFFER_ARRAY_42_008: [ If there are any failures then appended_constbuffer_array_handle shall fail and return NULL. ]*/
-TEST_FUNCTION(constbuffer_array_create_from_array_array_with_3_2_element_arrays_fails_if_sixth_clone_fails)
-{
-    ///arrange
-    CONSTBUFFER_ARRAY_HANDLE result;
-    const uint32_t array_count = 3;
-    CONSTBUFFER_ARRAY_HANDLE buffer_array[3];
-    CONSTBUFFER_HANDLE clones[5];
-    buffer_array[0] = TEST_constbuffer_array_create(2, 0);
-    buffer_array[1] = TEST_constbuffer_array_create(2, 2);
-    buffer_array[2] = TEST_constbuffer_array_create(2, 4);
-
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[0]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[1]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[2]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[3]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .CaptureReturn(&clones[4]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .SetReturn(NULL);
-
-    // All cloned buffers are destroyed
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[0]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[1]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[2]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[3]);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG))
-        .ValidateArgumentValue_constbufferHandle(&clones[4]);
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-
-    ///act
-    result = constbuffer_array_create_from_array_array(buffer_array, array_count);
-
-    ///assert
-    ASSERT_IS_NULL(result);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    ///clean
-    constbuffer_array_dec_ref(result);
     for (uint32_t i = 0; i < array_count; ++i)
     {
         constbuffer_array_dec_ref(buffer_array[i]);
@@ -1150,7 +890,7 @@ TEST_FUNCTION(constbuffer_array_add_front_with_constbuffer_handle_NULL_fails)
 static void constbuffer_array_add_front_inert_path(void)
 {
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(TEST_CONSTBUFFER_HANDLE_1));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(TEST_CONSTBUFFER_HANDLE_1));
 }
 
 /*Tests_SRS_CONSTBUFFER_ARRAY_02_042: [ constbuffer_array_add_front shall allocate enough memory to hold all of constbuffer_array_handle existing CONSTBUFFER_HANDLE and constbuffer_handle. ]*/
@@ -1189,57 +929,22 @@ TEST_FUNCTION(constbuffer_array_add_front_unhappy_paths)
     umock_c_negative_tests_snapshot();
     for (i = 0; i < umock_c_negative_tests_call_count(); i++)
     {
-        CONSTBUFFER_ARRAY_HANDLE result;
+        if (umock_c_negative_tests_can_call_fail(i))
+        {
+            CONSTBUFFER_ARRAY_HANDLE result;
 
-        umock_c_negative_tests_reset();
-        umock_c_negative_tests_fail_call(i);
+            umock_c_negative_tests_reset();
+            umock_c_negative_tests_fail_call(i);
 
-        ///act
-        result = constbuffer_array_add_front(TEST_CONSTBUFFER_ARRAY_HANDLE, TEST_CONSTBUFFER_HANDLE_1);
+            ///act
+            result = constbuffer_array_add_front(TEST_CONSTBUFFER_ARRAY_HANDLE, TEST_CONSTBUFFER_HANDLE_1);
 
-        ///assert
-        ASSERT_IS_NULL(result);
+            ///assert
+            ASSERT_IS_NULL(result);
+        }
     }
 
     ///clean
-    constbuffer_array_dec_ref(TEST_CONSTBUFFER_ARRAY_HANDLE);
-}
-
-/*Tests_SRS_CONSTBUFFER_ARRAY_02_011: [ If there any failures constbuffer_array_add_front shall fail and return NULL. ]*/
-TEST_FUNCTION(when_cloning_the_2nd_buffer_fails_constbuffer_array_remove_front_fails_and_destroys_the_clones)
-{
-    ///arrange
-    CONSTBUFFER_ARRAY_HANDLE TEST_CONSTBUFFER_ARRAY_HANDLE = TEST_constbuffer_array_create_empty();
-    CONSTBUFFER_ARRAY_HANDLE afterAdd1 = TEST_constbuffer_array_add_front(TEST_CONSTBUFFER_ARRAY_HANDLE, 0, TEST_CONSTBUFFER_HANDLE_1);
-    CONSTBUFFER_ARRAY_HANDLE afterAdd2 = TEST_constbuffer_array_add_front(afterAdd1, 1, TEST_CONSTBUFFER_HANDLE_2);
-    CONSTBUFFER_ARRAY_HANDLE afterAdd3 = TEST_constbuffer_array_add_front(afterAdd2, 2, TEST_CONSTBUFFER_HANDLE_3);
-    CONSTBUFFER_HANDLE removed = NULL;
-    CONSTBUFFER_ARRAY_HANDLE afterRemove1;
-
-    umock_c_reset_all_calls();
-
-    // new array
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-
-    // clone index 1
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG));
-    // clone index 2 fails
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG))
-        .SetReturn(NULL);
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-
-    ///act
-    afterRemove1 = constbuffer_array_remove_front(afterAdd3, &removed);
-
-    ///assert
-    ASSERT_IS_NULL(afterRemove1);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    ///cleanup
-    constbuffer_array_dec_ref(afterAdd3);
-    constbuffer_array_dec_ref(afterAdd2);
-    constbuffer_array_dec_ref(afterAdd1);
     constbuffer_array_dec_ref(TEST_CONSTBUFFER_ARRAY_HANDLE);
 }
 
@@ -1302,7 +1007,7 @@ TEST_FUNCTION(constbuffer_array_remove_front_with_constbuffer_array_handle_empty
     CONSTBUFFER_ARRAY_HANDLE afterRemove = TEST_constbuffer_array_remove_front(afterAdd, 1, &removed); /*maybe this is a different kind of empty*/ /*shrugs*/
     CONSTBUFFER_HANDLE removed2;
     CONSTBUFFER_ARRAY_HANDLE result;
-    CONSTBUFFER_Destroy(removed);
+    CONSTBUFFER_DecRef(removed);
     TEST_constbuffer_array_dec_ref(afterAdd, 1);
     umock_c_reset_all_calls();
 
@@ -1322,13 +1027,13 @@ static void constbuffer_array_remove_front_inert_path(uint32_t nExistingItems)
 {
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     // clone front buffer
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(IGNORED_PTR_ARG));
     if (nExistingItems > 0)
     {
         uint32_t i;
         for (i = 0; i < nExistingItems-1; i++)
         {
-            STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(IGNORED_PTR_ARG));
         }
     }
 }
@@ -1362,7 +1067,7 @@ TEST_FUNCTION(constbuffer_array_remove_front_with_1_item_succeeds)
     ///cleanup
     constbuffer_array_dec_ref(afterRemove);
     constbuffer_array_dec_ref(afterAdd);
-    CONSTBUFFER_Destroy(removed);
+    CONSTBUFFER_DecRef(removed);
     constbuffer_array_dec_ref(TEST_CONSTBUFFER_ARRAY_HANDLE);
 }
 
@@ -1394,7 +1099,7 @@ TEST_FUNCTION(constbuffer_array_remove_front_with_2_items_succeeds)
 
     ///cleanup
     constbuffer_array_dec_ref(afterRemove1);
-    CONSTBUFFER_Destroy(removed);
+    CONSTBUFFER_DecRef(removed);
     constbuffer_array_dec_ref(afterAdd2);
     constbuffer_array_dec_ref(afterAdd1);
     constbuffer_array_dec_ref(TEST_CONSTBUFFER_ARRAY_HANDLE);
@@ -1414,17 +1119,20 @@ TEST_FUNCTION(constbuffer_array_remove_front_unhappy_paths)
     umock_c_negative_tests_snapshot();
     for (i = 0; i < umock_c_negative_tests_call_count(); i++)
     {
-        CONSTBUFFER_HANDLE removed;
-        CONSTBUFFER_ARRAY_HANDLE afterRemove;
+        if (umock_c_negative_tests_can_call_fail(i))
+        {
+            CONSTBUFFER_HANDLE removed;
+            CONSTBUFFER_ARRAY_HANDLE afterRemove;
 
-        umock_c_negative_tests_reset();
-        umock_c_negative_tests_fail_call(i);
+            umock_c_negative_tests_reset();
+            umock_c_negative_tests_fail_call(i);
 
-        ///act
-        afterRemove = constbuffer_array_remove_front(afterAdd, &removed);
+            ///act
+            afterRemove = constbuffer_array_remove_front(afterAdd, &removed);
 
-        ///assert
-        ASSERT_IS_NULL(afterRemove);
+            ///assert
+            ASSERT_IS_NULL(afterRemove);
+        }
     }
 
     ///clean
@@ -1575,7 +1283,7 @@ TEST_FUNCTION(constbuffer_array_get_buffer_succeeds)
     constbuffer_array = constbuffer_array_create(test_buffers, sizeof(test_buffers) / sizeof(test_buffers[0]));
     umock_c_reset_all_calls();
 
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(TEST_CONSTBUFFER_HANDLE_1));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(TEST_CONSTBUFFER_HANDLE_1));
 
     // act
     result = constbuffer_array_get_buffer(constbuffer_array, 0);
@@ -1586,7 +1294,7 @@ TEST_FUNCTION(constbuffer_array_get_buffer_succeeds)
 
     // cleanup
     constbuffer_array_dec_ref(constbuffer_array);
-    CONSTBUFFER_Destroy(result);
+    CONSTBUFFER_DecRef(result);
 }
 
 /* Tests_SRS_CONSTBUFFER_ARRAY_01_005: [ On success, constbuffer_array_get_buffer shall return a non-NULL handle to the buffer_index-th const buffer in the array. ]*/
@@ -1604,7 +1312,7 @@ TEST_FUNCTION(constbuffer_array_get_buffer_for_2nd_buffer_succeeds)
     constbuffer_array = constbuffer_array_create(test_buffers, sizeof(test_buffers) / sizeof(test_buffers[0]));
     umock_c_reset_all_calls();
 
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(TEST_CONSTBUFFER_HANDLE_2));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_IncRef(TEST_CONSTBUFFER_HANDLE_2));
 
     // act
     result = constbuffer_array_get_buffer(constbuffer_array, 1);
@@ -1615,7 +1323,7 @@ TEST_FUNCTION(constbuffer_array_get_buffer_for_2nd_buffer_succeeds)
 
     // cleanup
     constbuffer_array_dec_ref(constbuffer_array);
-    CONSTBUFFER_Destroy(result);
+    CONSTBUFFER_DecRef(result);
 }
 
 /* Tests_SRS_CONSTBUFFER_ARRAY_01_007: [ If constbuffer_array_handle is NULL, constbuffer_array_get_buffer shall fail and return NULL. ]*/
@@ -1690,33 +1398,6 @@ TEST_FUNCTION(constbuffer_array_get_buffer_with_index_0_on_empty_array_fails)
     CONSTBUFFER_HANDLE result;
 
     constbuffer_array = TEST_constbuffer_array_create_empty();
-
-    // act
-    result = constbuffer_array_get_buffer(constbuffer_array, 0);
-
-    // assert
-    ASSERT_IS_NULL(result);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-    // cleanup
-    constbuffer_array_dec_ref(constbuffer_array);
-}
-
-/* Tests_SRS_CONSTBUFFER_ARRAY_01_015: [ If any error occurs, constbuffer_array_get_buffer shall fail and return NULL. ]*/
-TEST_FUNCTION(when_CONSTBUFFER_Clone_fails_constbuffer_array_get_buffer_also_fails)
-{
-    // arrange
-    CONSTBUFFER_HANDLE test_buffers[1];
-    CONSTBUFFER_ARRAY_HANDLE constbuffer_array;
-    CONSTBUFFER_HANDLE result;
-
-    test_buffers[0] = TEST_CONSTBUFFER_HANDLE_1;
-
-    constbuffer_array = constbuffer_array_create(test_buffers, sizeof(test_buffers) / sizeof(test_buffers[0]));
-    umock_c_reset_all_calls();
-
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Clone(TEST_CONSTBUFFER_HANDLE_1))
-        .SetReturn(NULL);
 
     // act
     result = constbuffer_array_get_buffer(constbuffer_array, 0);
@@ -1927,8 +1608,8 @@ TEST_FUNCTION(constbuffer_array_dec_ref_frees)
     CONSTBUFFER_ARRAY_HANDLE afterAdd2 = TEST_constbuffer_array_add_front(afterAdd1, 1, TEST_CONSTBUFFER_HANDLE_2);
     umock_c_reset_all_calls();
 
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(CONSTBUFFER_Destroy(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_DecRef(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(CONSTBUFFER_DecRef(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
     ///act

--- a/tests/constbuffer_ut/constbuffer_ut.c
+++ b/tests/constbuffer_ut/constbuffer_ut.c
@@ -166,7 +166,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /* CONSTBUFFER_CreateFromBuffer */
@@ -197,7 +197,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /*Tests_SRS_CONSTBUFFER_02_008: [If copying the content fails, then CONSTBUFFER_CreateFromBuffer shall fail and return NULL.]*/
@@ -221,7 +221,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /*Tests_SRS_CONSTBUFFER_02_006: [If buffer is NULL then CONSTBUFFER_CreateFromBuffer shall fail and return NULL.]*/
@@ -237,7 +237,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /*Tests_SRS_CONSTBUFFER_02_003: [If creating the copy fails then CONSTBUFFER_Create shall return NULL.]*/
@@ -260,7 +260,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     }
 
     /*Tests_SRS_CONSTBUFFER_02_005: [The non-NULL handle returned by CONSTBUFFER_Create shall have its ref count set to "1".]*/
-    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_Destroy shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
+    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_DecRef shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
     TEST_FUNCTION(CONSTBUFFER_Create_is_ref_counted_1)
     {
         ///arrange
@@ -270,7 +270,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
 
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -299,7 +299,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /*Tests_SRS_CONSTBUFFER_02_002: [Otherwise, CONSTBUFFER_Create shall create a copy of the memory area pointed to by source having size bytes.]*/
@@ -324,7 +324,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /* CONSTBUFFER_CreateWithMoveMemory */
@@ -367,7 +367,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /* Tests_SRS_CONSTBUFFER_01_002: [ CONSTBUFFER_CreateWithMoveMemory shall store the source and size and return a non-NULL handle to the newly created const buffer. ]*/
@@ -394,7 +394,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /* Tests_SRS_CONSTBUFFER_01_002: [ CONSTBUFFER_CreateWithMoveMemory shall store the source and size and return a non-NULL handle to the newly created const buffer. ]*/
@@ -417,7 +417,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /* Tests_SRS_CONSTBUFFER_01_005: [ If any error occurs, CONSTBUFFER_CreateWithMoveMemory shall fail and return NULL. ]*/
@@ -500,7 +500,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /* Tests_SRS_CONSTBUFFER_01_014: [ customFreeFuncContext shall be allowed to be NULL. ]*/
@@ -527,7 +527,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
         my_gballoc_free(test_buffer);
     }
 
@@ -555,7 +555,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /* Tests_SRS_CONSTBUFFER_01_008: [ CONSTBUFFER_CreateWithCustomFree shall store the source and size and return a non-NULL handle to the newly created const buffer. ]*/
@@ -578,7 +578,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /* Tests_SRS_CONSTBUFFER_01_011: [ If any error occurs, CONSTBUFFER_CreateWithMoveMemory shall fail and return NULL. ]*/
@@ -644,7 +644,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
     /*Tests_SRS_CONSTBUFFER_02_012: [Otherwise, CONSTBUFFER_GetContent shall return a const CONSTBUFFER* that matches byte by byte the original bytes used to created the const buffer and has the same length.]*/
@@ -666,79 +666,74 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
-    /* CONSTBUFFER_Clone */
+    /* CONSTBUFFER_IncRef */
 
-    /*Tests_SRS_CONSTBUFFER_02_013: [If constbufferHandle is NULL then CONSTBUFFER_Clone shall fail and return NULL.]*/
-    TEST_FUNCTION(CONSTBUFFER_Clone_with_NULL_returns_NULL)
+    /*Tests_SRS_CONSTBUFFER_02_013: [If constbufferHandle is NULL then CONSTBUFFER_IncRef shall return.]*/
+    TEST_FUNCTION(CONSTBUFFER_IncRef_with_NULL_returns_NULL)
     {
         ///arrange
 
         ///act
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Clone(NULL);
+        CONSTBUFFER_IncRef(NULL);
 
         ///assert
-        ASSERT_IS_NULL(handle);
-
-        ///cleanup
     }
 
-    /*Tests_SRS_CONSTBUFFER_02_014: [Otherwise, CONSTBUFFER_Clone shall increment the reference count and return constbufferHandle.]*/
-    TEST_FUNCTION(CONSTBUFFER_Clone_increments_ref_count_1)
+    /*Tests_SRS_CONSTBUFFER_02_014: [Otherwise, CONSTBUFFER_IncRef shall increment the reference count.]*/
+    TEST_FUNCTION(CONSTBUFFER_IncRef_increments_ref_count_1)
     {
         ///arrange
-        CONSTBUFFER_HANDLE clone;
         CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
         umock_c_reset_all_calls();
 
         ///act
-        clone = CONSTBUFFER_Clone(handle);
-
-        ///assert
-        ASSERT_ARE_EQUAL(void_ptr, handle, clone);
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-
-        ///cleanup
-        CONSTBUFFER_Destroy(handle);
-        CONSTBUFFER_Destroy(clone);
-    }
-
-    /*Tests_SRS_CONSTBUFFER_02_014: [Otherwise, CONSTBUFFER_Clone shall increment the reference count and return constbufferHandle.]*/
-    /*Tests_SRS_CONSTBUFFER_02_016: [Otherwise, CONSTBUFFER_Destroy shall decrement the refcount on the constbufferHandle handle.]*/
-    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_Destroy shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
-    TEST_FUNCTION(CONSTBUFFER_Clone_increments_ref_count_2)
-    {
-        ///arrange
-        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
-        CONSTBUFFER_HANDLE clone = CONSTBUFFER_Clone(handle);
-        umock_c_reset_all_calls();
-
-        ///act
-        CONSTBUFFER_Destroy(clone); /*only a dec_Ref is expected here, so no effects*/
+        CONSTBUFFER_IncRef(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         ///cleanup
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
+        CONSTBUFFER_DecRef(handle);
     }
 
-    /*Tests_SRS_CONSTBUFFER_02_014: [Otherwise, CONSTBUFFER_Clone shall increment the reference count and return constbufferHandle.]*/
-    /*Tests_SRS_CONSTBUFFER_02_016: [Otherwise, CONSTBUFFER_Destroy shall decrement the refcount on the constbufferHandle handle.]*/
-    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_Destroy shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
-    TEST_FUNCTION(CONSTBUFFER_Clone_increments_ref_count_3)
+    /*Tests_SRS_CONSTBUFFER_02_014: [Otherwise, CONSTBUFFER_IncRef shall increment the reference count and return constbufferHandle.]*/
+    /*Tests_SRS_CONSTBUFFER_02_016: [Otherwise, CONSTBUFFER_DecRef shall decrement the refcount on the constbufferHandle handle.]*/
+    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_DecRef shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
+    TEST_FUNCTION(CONSTBUFFER_IncRef_increments_ref_count_2)
     {
         ///arrange
         CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
-        CONSTBUFFER_HANDLE clone = CONSTBUFFER_Clone(handle);
-        CONSTBUFFER_Destroy(handle); /*only a dec_Ref is expected here, so no effects*/
+        CONSTBUFFER_IncRef(handle);
+        umock_c_reset_all_calls();
+
+        ///act
+        CONSTBUFFER_DecRef(handle); /*only a dec_Ref is expected here, so no effects*/
+
+        ///assert
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+        ///cleanup
+        CONSTBUFFER_DecRef(handle);
+    }
+
+    /*Tests_SRS_CONSTBUFFER_02_014: [Otherwise, CONSTBUFFER_IncRef shall increment the reference count and return constbufferHandle.]*/
+    /*Tests_SRS_CONSTBUFFER_02_016: [Otherwise, CONSTBUFFER_DecRef shall decrement the refcount on the constbufferHandle handle.]*/
+    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_DecRef shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
+    TEST_FUNCTION(CONSTBUFFER_IncRef_increments_ref_count_3)
+    {
+        ///arrange
+        CONSTBUFFER_HANDLE handle = CONSTBUFFER_Create(BUFFER1_u_char, BUFFER1_length);
+        CONSTBUFFER_IncRef(handle);
+        CONSTBUFFER_DecRef(handle); /*only a dec_Ref is expected here, so no effects*/
         umock_c_reset_all_calls();
 
         ///act
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-        CONSTBUFFER_Destroy(clone);
+        CONSTBUFFER_DecRef(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -746,15 +741,15 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         ///cleanup
     }
 
-    /* CONSTBUFFER_Destroy */
+    /* CONSTBUFFER_DecRef */
 
-    /*Tests_SRS_CONSTBUFFER_02_015: [If constbufferHandle is NULL then CONSTBUFFER_Destroy shall do nothing.]*/
-    TEST_FUNCTION(CONSTBUFFER_Destroy_with_NULL_argument_does_nothing)
+    /*Tests_SRS_CONSTBUFFER_02_015: [If constbufferHandle is NULL then CONSTBUFFER_DecRef shall do nothing.]*/
+    TEST_FUNCTION(CONSTBUFFER_DecRef_with_NULL_argument_does_nothing)
     {
         ///arrange
 
         ///act
-        CONSTBUFFER_Destroy(NULL);
+        CONSTBUFFER_DecRef(NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -764,7 +759,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
 
     /*Tests_SRS_CONSTBUFFER_02_010: [The non-NULL handle returned by CONSTBUFFER_CreateFromBuffer shall have its ref count set to "1".]*/
     /*Tests_SRS_CONSTBUFFER_02_005: [The non-NULL handle returned by CONSTBUFFER_Create shall have its ref count set to "1".]*/
-    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_Destroy shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
+    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_DecRef shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
     TEST_FUNCTION(CONSTBUFFER_CreateFromBuffer_is_ref_counted_1)
     {
         ///arrange
@@ -774,7 +769,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
 
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -796,7 +791,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -817,7 +812,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         STRICT_EXPECTED_CALL(test_free_func((void*)0x4242));
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -827,7 +822,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
     }
 
     /* Tests_SRS_CONSTBUFFER_01_003: [ The non-NULL handle returned by CONSTBUFFER_CreateWithMoveMemory shall have its ref count set to "1". ]*/
-    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_Destroy shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
+    /*Tests_SRS_CONSTBUFFER_02_017: [If the refcount reaches zero, then CONSTBUFFER_DecRef shall deallocate all resources used by the CONSTBUFFER_HANDLE.]*/
     TEST_FUNCTION(CONSTBUFFER_CreateWithMoveMemory_is_ref_counted_1)
     {
         ///arrange
@@ -842,7 +837,7 @@ BEGIN_TEST_SUITE(constbuffer_unittests)
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
         ///act
-        CONSTBUFFER_Destroy(handle);
+        CONSTBUFFER_DecRef(handle);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/tests/real_test_files/real_constbuffer.c
+++ b/tests/real_test_files/real_constbuffer.c
@@ -5,9 +5,9 @@
 #define CONSTBUFFER_CreateFromBuffer real_CONSTBUFFER_CreateFromBuffer
 #define CONSTBUFFER_CreateWithMoveMemory real_CONSTBUFFER_CreateWithMoveMemory
 #define CONSTBUFFER_CreateWithCustomFree real_CONSTBUFFER_CreateWithCustomFree
-#define CONSTBUFFER_Clone real_CONSTBUFFER_Clone
+#define CONSTBUFFER_IncRef real_CONSTBUFFER_IncRef
+#define CONSTBUFFER_DecRef real_CONSTBUFFER_DecRef
 #define CONSTBUFFER_GetContent real_CONSTBUFFER_GetContent
-#define CONSTBUFFER_Destroy real_CONSTBUFFER_Destroy
 
 #define GBALLOC_H
 

--- a/tests/real_test_files/real_constbuffer.h
+++ b/tests/real_test_files/real_constbuffer.h
@@ -13,9 +13,9 @@
         CONSTBUFFER_CreateFromBuffer, \
         CONSTBUFFER_CreateWithMoveMemory, \
         CONSTBUFFER_CreateWithCustomFree, \
-        CONSTBUFFER_Clone, \
+        CONSTBUFFER_IncRef, \
         CONSTBUFFER_GetContent, \
-        CONSTBUFFER_Destroy \
+        CONSTBUFFER_DecRef \
 )
 
 #ifdef __cplusplus
@@ -34,12 +34,11 @@ CONSTBUFFER_HANDLE real_CONSTBUFFER_CreateWithMoveMemory(unsigned char* source, 
 
 CONSTBUFFER_HANDLE real_CONSTBUFFER_CreateWithCustomFree(const unsigned char* source, size_t size, CONSTBUFFER_CUSTOM_FREE_FUNC custom_free_func, void* custom_free_func_context);
 
-CONSTBUFFER_HANDLE real_CONSTBUFFER_Clone(CONSTBUFFER_HANDLE constbufferHandle);
+void real_CONSTBUFFER_IncRef(CONSTBUFFER_HANDLE constbufferHandle);
+
+void real_CONSTBUFFER_DecRef(CONSTBUFFER_HANDLE constbufferHandle);
 
 const CONSTBUFFER* real_CONSTBUFFER_GetContent(CONSTBUFFER_HANDLE constbufferHandle);
-
-void real_CONSTBUFFER_Destroy(CONSTBUFFER_HANDLE constbufferHandle);
-
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Change constbuffer from CLONE to INC_REF/DEC_REF.

The motivation is that CONSTBUFFER does not allocate new resources for a clone, but in fact by the module contract does an inc_ref. And thus it is lighter on the user module to have an inc_ref/dec_ref API (less error checking and there is no need to treat the result as a potentially completely different handle.