### PR TITLE
Add SQM ID to platform info string

### DIFF
--- a/inc/azure_c_shared_utility/platform.h
+++ b/inc/azure_c_shared_utility/platform.h
@@ -16,6 +16,9 @@ extern "C" {
     MOCKABLE_FUNCTION(, void, platform_deinit);
     MOCKABLE_FUNCTION(, const IO_INTERFACE_DESCRIPTION*, platform_get_default_tlsio);
     MOCKABLE_FUNCTION(, STRING_HANDLE, platform_get_platform_info);
+#ifdef WIN32
+    MOCKABLE_FUNCTION(, STRING_HANDLE, platform_get_platform_info_with_id);
+#endif
 
 #ifdef __cplusplus
 }

--- a/samples/iot_c_utility/iot_c_utility.c
+++ b/samples/iot_c_utility/iot_c_utility.c
@@ -59,6 +59,15 @@ static void show_platform_info()
         (void)printf("%s\r\n", STRING_c_str(platform_info));
         STRING_delete(platform_info);
     }
+
+#ifdef WIN32
+    STRING_HANDLE platform_info_id = platform_get_platform_info_with_id();
+    if (platform_info_id != NULL)
+    {
+        (void)printf("%s\r\n", STRING_c_str(platform_info_id));
+        STRING_delete(platform_info_id);
+    }
+#endif
 }
 
 int main(int argc, char** argv)

--- a/tests/platform_win32_ut/platform_win32_ut.c
+++ b/tests/platform_win32_ut/platform_win32_ut.c
@@ -243,6 +243,21 @@ TEST_FUNCTION(platform_get_platform_info_success)
     STRING_delete(platform);
 }
 
+TEST_FUNCTION(platform_get_platform_info_with_id_success)
+{
+    //arrange
+
+    //act
+    STRING_HANDLE platform = platform_get_platform_info_with_id();
+
+    //assert
+    ASSERT_IS_NOT_NULL(platform);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    STRING_delete(platform);
+}
+
 TEST_FUNCTION(platform_deinit_success)
 {
     //arrange


### PR DESCRIPTION
Adding platform_get_platform_info_with_id to Win32 platform API so that SQM ID can be included in the product info.