### PR TITLE
Comment that OPTION_TLS_VERSION is deprecated

### DIFF
--- a/inc/azure_c_shared_utility/shared_util_options.h
+++ b/inc/azure_c_shared_utility/shared_util_options.h
@@ -42,6 +42,8 @@ extern "C"
 
     static STATIC_VAR_UNUSED const char* const OPTION_NET_INT_MAC_ADDRESS = "net_interface_mac_address";
 
+    // DEPRECATED: The underlying security library for your platform will use a secure TLS version 
+    // that in general  should not be overridden with OPTION_TLS_VERSION.
     static STATIC_VAR_UNUSED const char* const OPTION_TLS_VERSION = "tls_version";
 
     static STATIC_VAR_UNUSED const char* const OPTION_ADDRESS_TYPE = "ADDRESS_TYPE";


### PR DESCRIPTION
Attempt to steer users from OPTION_TLS_VERSION.