### PR TITLE
add dummy implementation for 'xlogging_LogErrorWinHTTPWithGetLastErrorAsStringFormatter'

### DIFF
--- a/src/etwxlogging.c
+++ b/src/etwxlogging.c
@@ -39,4 +39,9 @@ LOGGER_LOG_GETLASTERROR xlogging_get_log_function_GetLastError(void)
 {
     return global_log_function_GetLastError;
 }
+
+void xlogging_LogErrorWinHTTPWithGetLastErrorAsStringFormatter(int errorMessageID)
+{
+    (void)errorMessageID;
+}
 #endif


### PR DESCRIPTION
add dummy implementation for 'xlogging_LogErrorWinHTTPWithGetLastErrorAsStringFormatter'
We have an ETW ‘writer’ for xlogging which can be enabled by building with the switch ‘use_etw’ in CMAKE. Turns out the current implementation was broken because the method ‘xlogging_LogErrorWinHTTPWithGetLastErrorAsStringFormatter’ was added to xlogging.h and was not implemented by the ETW writer.  I’ve fixed that by adding a dummy method in the ETW Xlogging implementation. 

