### PR TITLE
UUID_from_string: fix UUID_T overflow

### DIFF
--- a/src/uuid.c
+++ b/src/uuid.c
@@ -12,7 +12,13 @@
 #define UUID_STRING_LENGTH          36
 #define UUID_STRING_SIZE            (UUID_STRING_LENGTH + 1)
 #define __SUCCESS__                 0
-#define UUID_FORMAT_STRING          "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
+#define HEXA_DIGIT_VAL(c) \
+    ((((c) >= '0') && ((c) <= '9')) \
+        ? ((c) - '0') \
+        : (((c) >= 'a') && ((c) <= 'f')) \
+            ? ((c) - 'a' + 10) \
+            : (((c) >= 'A') && ((c) <= 'F')) ? ((c) - 'A' + 10) : -1)
+
 
 int UUID_from_string(const char* uuid_string, UUID_T* uuid)
 {
@@ -45,17 +51,26 @@ int UUID_from_string(const char* uuid_string, UUID_T* uuid)
 
             for (i = 0, j = 0; i < uuid_string_length; )
             {
+                bool mustBeDash = i == 8 || i == 13 || i == 18 || i == 23;
+
+                if ((uuid_string[i] == '-') != mustBeDash)
+                {
+                    // Codes_SRS_UUID_09_009: [ If uuid fails to be generated, UUID_from_string shall return a non-zero value ]
+                    LogError("Failed decoding UUID string (%lu)", (unsigned long)i);
+                    result = MU_FAILURE;
+                    break;
+                }
+
                 if (uuid_string[i] == '-')
                 {
                     i++;
                 }
                 else
                 {
-                    char double_hex_digit[3] = { 0, 0, 0 };
+                    int higherOrderDigit = HEXA_DIGIT_VAL(uuid_string[i]);
+                    int lowerOrderDigit = HEXA_DIGIT_VAL(uuid_string[i + 1]);
 
-                    (void)memcpy(double_hex_digit, uuid_string + i, 2);
-
-                    if (sscanf(double_hex_digit, "%02hhx", uuid_bytes + j) != 1)
+                    if (higherOrderDigit == -1 || lowerOrderDigit == -1)
                     {
                         // Codes_SRS_UUID_09_009: [ If uuid fails to be generated, UUID_from_string shall return a non-zero value ]
                         LogError("Failed decoding UUID string (%lu)", (unsigned long)i);
@@ -64,6 +79,7 @@ int UUID_from_string(const char* uuid_string, UUID_T* uuid)
                     }
                     else
                     {
+                        uuid_bytes[j] = (char)(higherOrderDigit * 16 + lowerOrderDigit);
                         i += 2;
                         j++;
                     }


### PR DESCRIPTION
- Too few dashes in UUID string could have caused to write beyond UUID_T.
- Check strictly for expected position with dashes.