### PR TITLE
Add support for private keys in crypto devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,7 @@ set(source_h_files
     ./inc/azure_c_shared_utility/string_tokenizer_types.h
     ./inc/azure_c_shared_utility/string_utils.h
     ./inc/azure_c_shared_utility/tlsio_options.h
+    ./inc/azure_c_shared_utility/tlsio_cryptodev.h
     ./inc/azure_c_shared_utility/tickcounter.h
     ./inc/azure_c_shared_utility/threadapi.h
     ./inc/azure_c_shared_utility/xio.h

--- a/devdoc/x509_openssl.md
+++ b/devdoc/x509_openssl.md
@@ -42,7 +42,6 @@ x509_openssl_add_credentials loads a x509 certificate and a x509 private key int
 
 **SRS_X509_OPENSSL_02_009: [** Otherwise x509_openssl_add_credentials shall fail and return a non-zero number. **]**
 
-
 ###  x509_openssl_add_certificates
 ```c
 int x509_openssl_add_certificates(SSL_CTX* ssl_ctx, const char* certificates);
@@ -69,6 +68,31 @@ int x509_openssl_add_certificates(SSL_CTX* ssl_ctx, const char* certificates);
 **SRS_X509_OPENSSL_02_018: [** In case of any failure `x509_openssl_add_certificates` shall fail and return a non-zero value. **]**
 
 **SRS_X509_OPENSSL_02_019: [** Otherwise, `x509_openssl_add_certificates` shall succeed and return 0. **]**
+
+###   x509_openssl_add_credentials_cryptodev
+```c
+int x509_openssl_add_credentials_cryptodev(SSL_CTX* ssl_ctx, const char* x509certificate, TLS_CRYPTODEV_PKEY* x509cryptodevprivatekey);
+```
+
+x509_openssl_add_credentials_cryptodev loads a x509 certificate and an x509 private key from a crypto device into a SSL context. 
+
+**SRS_X509_OPENSSL_02_020: [** If any argument is NULL then x509_openssl_add_credentials_cryptodev shall fail and return a non-zero value. **]**
+
+**SRS_X509_OPENSSL_02_021: [** x509_openssl_add_credentials_cryptodev shall use BIO_new_mem_buf to create a memory BIO from the x509 certificate. **]** 
+
+**SRS_X509_OPENSSL_02_022: [** x509_openssl_add_credentials_cryptodev shall use PEM_read_bio_X509 to read the x509 certificate. **]**
+
+**SRS_X509_OPENSSL_02_023: [** x509_openssl_add_credentials_cryptodev shall use RSA_set_method to set method on an RSA private key **]**
+
+**SRS_X509_OPENSSL_02_024: [** x509_openssl_add_credentials_cryptodev shall use EVP_PKEY_set1_RSA to create an RSA private key. **]**
+
+**SRS_X509_OPENSSL_02_025: [** x509_openssl_add_credentials_cryptodev shall use SSL_CTX_use_certificate to load the certicate into the SSL context. **]**
+
+**SRS_X509_OPENSSL_02_026: [** x509_openssl_add_credentials_cryptodev shall use SSL_CTX_use_RSAPrivateKey to load the private key into the SSL context. **]**
+
+**SRS_X509_OPENSSL_02_027: [** If no error occurs, then x509_openssl_add_credentials_cryptodev shall succeed and return 0. **]**
+
+**SRS_X509_OPENSSL_02_028: [** Otherwise x509_openssl_add_credentials_cryptodev shall fail and return a non-zero number. **]**
 
 ###  x509_openssl_add_ecc_credentials
 

--- a/inc/azure_c_shared_utility/shared_util_options.h
+++ b/inc/azure_c_shared_utility/shared_util_options.h
@@ -27,6 +27,7 @@ extern "C"
     // Clients should not use OPTION_OPENSSL_CIPHER_SUITE except for very specialized scenarios.
     // They instead should rely on the underlying client TLS stack and service to negotiate an appropriate cipher.
     static STATIC_VAR_UNUSED const char* const OPTION_OPENSSL_CIPHER_SUITE = "CipherSuite";
+    static STATIC_VAR_UNUSED const char* const OPTION_OPENSSL_SIGALGS = "Sigalgs";
 
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_CERT = "x509certificate";
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_PRIVATE_KEY = "x509privatekey";

--- a/inc/azure_c_shared_utility/shared_util_options.h
+++ b/inc/azure_c_shared_utility/shared_util_options.h
@@ -30,6 +30,8 @@ extern "C"
 
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_CERT = "x509certificate";
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_PRIVATE_KEY = "x509privatekey";
+    static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_CRYPTODEV_PRIVATE_KEY = "x509cryptodevprivatekey";
+
 
     static STATIC_VAR_UNUSED const char* const OPTION_X509_ECC_CERT = "x509EccCertificate";
     static STATIC_VAR_UNUSED const char* const OPTION_X509_ECC_KEY = "x509EccAliasKey";

--- a/inc/azure_c_shared_utility/tlsio_cryptodev.h
+++ b/inc/azure_c_shared_utility/tlsio_cryptodev.h
@@ -1,0 +1,46 @@
+#ifndef TLSIO_CRYPTODEV_H
+#define TLSIO_CRYPTODEV_H
+
+#include <stdint.h>
+
+/* @brief sign data
+ * @param data - data to sign
+ * @param datalen - size of the data in bytes
+ * @param signature - output buffer for the signature
+ * @param signature_len - size of the signature in bytes
+ * @param priv - private data passed to every call
+ * @return - 1 on success, 0 on error
+ */
+typedef int (*tlsio_cryptodev_pkey_sign_t)(const uint8_t* data, int datalen, uint8_t* signature, int *signature_len, void* priv);
+
+/* @brief decrypt data
+ * @param cipher - data to decrypt
+ * @param cipherlen - size of the data in bytes or a negative number to use the algorithm's default
+ * @param plain - output buffer for the plaintext
+ * @param plain_len - size of the plaintext in bytes
+ * @param priv - private data passed to every call
+ * @return - 1 on success, 0 on error
+ */
+typedef int (*tlsio_cryptodev_pkey_decrypt_t)(const uint8_t* cipher, int cipherlen, uint8_t* plain, int *plain_len, void* priv);
+
+/* @brief destroy private data
+ * @param priv data to destroy
+ * @return - 1 on success, 0 on error
+ */
+typedef int (*tlsio_cryptodev_pkey_destroy_t)(void* priv);
+
+typedef enum TLSIO_CRYPTODEV_PKEY_TYPE_TAG {
+  TLSIO_CRYPTODEV_PKEY_TYPE_ECC = 0,
+  TLSIO_CRYPTODEV_PKEY_TYPE_RSA = 1,
+} TLSIO_CRYPTODEV_PKEY_TYPE;
+
+typedef struct TLSIO_CRYPTODEV_PKEY_TAG
+{
+    tlsio_cryptodev_pkey_sign_t sign;
+    tlsio_cryptodev_pkey_decrypt_t decrypt;
+    tlsio_cryptodev_pkey_destroy_t destroy;
+    TLSIO_CRYPTODEV_PKEY_TYPE type;
+    void* private_data;
+} TLSIO_CRYPTODEV_PKEY;
+
+#endif /* TLSIO_CRYPTODEV_H */

--- a/inc/azure_c_shared_utility/x509_openssl.h
+++ b/inc/azure_c_shared_utility/x509_openssl.h
@@ -11,9 +11,11 @@ extern "C" {
 #endif
 
 #include "umock_c/umock_c_prod.h"
+#include "tlsio_cryptodev.h"
 
 MOCKABLE_FUNCTION(,int, x509_openssl_add_certificates, SSL_CTX*, ssl_ctx, const char*, certificates);
 MOCKABLE_FUNCTION(,int, x509_openssl_add_credentials, SSL_CTX*, ssl_ctx, const char*, x509certificate, const char*, x509privatekey);
+MOCKABLE_FUNCTION(,int, x509_openssl_add_credentials_cryptodev, SSL_CTX*, ssl_ctx, const char*, x509certificate, TLSIO_CRYPTODEV_PKEY*, x509cryptodevprivatekey);
 
 #ifdef __cplusplus
 }

--- a/tests/x509_openssl_ut/x509_openssl_ut.c
+++ b/tests/x509_openssl_ut/x509_openssl_ut.c
@@ -17,6 +17,8 @@ static void my_gballoc_free(void* s)
     free(s);
 }
 
+extern void x509_openssl_test_reset(void);
+
 #ifdef __cplusplus
 #include <cstddef>
 #else
@@ -81,11 +83,46 @@ MOCKABLE_FUNCTION(,BIO *,BIO_new_mem_buf, const void *,buf, int, len);
 MOCKABLE_FUNCTION(, BIO *, BIO_new_mem_buf, void *, buf, int, len);
 #endif
 
+/*from openssl/bn.h*/
+MOCKABLE_FUNCTION(, BIGNUM*, BN_dup, const BIGNUM*, a);
+
+/*from openssl/crypto.h*/
+MOCKABLE_FUNCTION(, int, CRYPTO_get_ex_new_index, int, class_index, long, argl, void*, argp, CRYPTO_EX_new*, new_func, CRYPTO_EX_dup*, dup_func, CRYPTO_EX_free*, free_func);
+
+/*from openssl/evp.h*/
+MOCKABLE_FUNCTION(, EVP_PKEY*, EVP_PKEY_new);
+MOCKABLE_FUNCTION(, int, EVP_PKEY_set1_RSA, EVP_PKEY*, pkey, struct rsa_st*, key);
+MOCKABLE_FUNCTION(, struct rsa_st*, EVP_PKEY_get0_RSA, EVP_PKEY*, pkey);
+
 /*from openssl/rsa.h*/
 MOCKABLE_FUNCTION(, void, RSA_free, RSA *,rsa);
+MOCKABLE_FUNCTION(, void*, RSA_get_ex_data, const RSA *,r, int, idx);
+MOCKABLE_FUNCTION(, int, RSA_set_ex_data, RSA *, r, int, idx, void*, arg);
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+MOCKABLE_FUNCTION(, int, RSA_set0_key, RSA *,r, BIGNUM*, n, BIGNUM*, e, BIGNUM*, d);
+MOCKABLE_FUNCTION(, void, RSA_get0_key, const RSA *,r, const BIGNUM**, n, const BIGNUM**, e, const BIGNUM**, d);
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+MOCKABLE_FUNCTION(, RSA_METHOD*, RSA_meth_dup, const RSA_METHOD *, meth);
+MOCKABLE_FUNCTION(, int, RSA_meth_set1_name, RSA_METHOD *, meth, const char*, name);
+MOCKABLE_FUNCTION(, int, RSA_meth_set_flags, RSA_METHOD *, meth, int, flags);
+MOCKABLE_FUNCTION(, RSA*, RSA_new);
+MOCKABLE_FUNCTION(, const RSA_METHOD*, RSA_get_default_method);
+MOCKABLE_FUNCTION(, int, RSA_set_method, RSA*, rsa, const RSA_METHOD*, meth);
+
+typedef int (*openssl_rsa_priv_dec_t) (int, const unsigned char*, unsigned char*, RSA*, int);
+MOCKABLE_FUNCTION(, int, RSA_meth_set_priv_dec, RSA_METHOD *, meth, openssl_rsa_priv_dec_t, priv_dec);
+
+typedef int (*openssl_rsa_sign_t) (int, const unsigned char*, unsigned int, unsigned char*, unsigned int*, const RSA*);
+MOCKABLE_FUNCTION(, int, RSA_meth_set_sign, RSA_METHOD *, rsa, openssl_rsa_sign_t, sign);
+
+typedef int (*openssl_rsa_finish_t) (RSA*);
+MOCKABLE_FUNCTION(, int, RSA_meth_set_finish, RSA_METHOD *, rsa, openssl_rsa_finish_t, finish);
+#endif
 
 /*from openssl/x509.h*/
 MOCKABLE_FUNCTION(, void, X509_free, X509 *, a);
+MOCKABLE_FUNCTION(, EVP_PKEY*, X509_get_pubkey, X509 *, x);
 
 /*from  openssl/pem.h*/
 MOCKABLE_FUNCTION(, X509 *, PEM_read_bio_X509, BIO *, bp, X509 **, x, pem_password_cb *, cb, void *, u);
@@ -139,6 +176,26 @@ static int my_BIO_free(BIO * a)
     return 0;
 }
 
+static void my_RSA_get0_key(const RSA * r, const BIGNUM** n, const BIGNUM** e, const BIGNUM** d) {
+    (void) r;
+    if (n) {
+        *n =  (BIGNUM*)my_gballoc_malloc(1);
+    }
+
+    if (e) {
+        *e =  (BIGNUM*)my_gballoc_malloc(1);
+    }
+
+    if (d) {
+        *d =  (BIGNUM*)my_gballoc_malloc(1);
+    }
+}
+
+static const RSA_METHOD* my_RSA_get_default_method(void) {
+    return (RSA_METHOD*)my_gballoc_malloc(1);
+}
+
+
 #if OPENSSL_VERSION_NUMBER >= 0x1010007fL
 static BIO *my_BIO_new(const BIO_METHOD *type)
 #else
@@ -180,6 +237,12 @@ static RSA* my_EVP_PKEY_get1_RSA(EVP_PKEY* pkey)
     return (RSA*)my_gballoc_malloc(1);
 }
 
+static struct rsa_st* my_EVP_PKEY_get0_RSA(EVP_PKEY* pkey)
+{
+    (void)pkey;
+    return (struct rsa_st*)my_gballoc_malloc(1);
+}
+
 static X509 * my_PEM_read_bio_X509(BIO * bp, X509 ** x, pem_password_cb * cb, void * u)
 {
     (void)u, (void)cb, (void)x, (void)bp;
@@ -192,6 +255,88 @@ static RSA * my_PEM_read_bio_RSAPrivateKey(BIO * bp, RSA ** x, pem_password_cb *
     return (RSA*)my_gballoc_malloc(1);
 }
 
+static RSA * my_RSA_new()
+{
+    return (RSA*)my_gballoc_malloc(1);
+}
+
+static EVP_PKEY * my_EVP_PKEY_new()
+{
+    return (EVP_PKEY*)my_gballoc_malloc(1);
+}
+
+static RSA_METHOD* my_RSA_meth_dup(const RSA_METHOD* meth)
+{
+    (void)meth;
+    return (RSA_METHOD*)my_gballoc_malloc(1);
+}
+
+static int my_RSA_meth_set1_name(RSA_METHOD* meth, const char* name)
+{
+    (void)meth;
+    (void)name;
+    return 1;
+}
+
+static int my_RSA_meth_set_flags(RSA_METHOD* meth, int flags)
+{
+    (void)meth;
+    (void)flags;
+    return 1;
+}
+
+static int my_RSA_meth_set_sign(RSA_METHOD* meth, openssl_rsa_sign_t sign)
+{
+    (void)meth;
+    (void)sign;
+    return 1;
+}
+
+static int my_RSA_meth_set_priv_dec(RSA_METHOD* meth, openssl_rsa_priv_dec_t priv_dec)
+{
+    (void)meth;
+    (void)priv_dec;
+    return 1;
+}
+
+static int my_RSA_meth_set_finish(RSA_METHOD* meth, openssl_rsa_finish_t finish)
+{
+    (void)meth;
+    (void)finish;
+    return 1;
+}
+
+static int my_RSA_set_method(RSA* rsa, const RSA_METHOD* meth)
+{
+    (void)rsa;
+    (void)meth;
+    return 1;
+}
+
+static int my_RSA_set_ex_data(RSA* rsa, int idx, void* arg)
+{
+    (void)rsa;
+    (void)idx;
+    (void)arg;
+    return 1;
+}
+
+static int my_CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
+                                      CRYPTO_EX_new *new_func, CRYPTO_EX_dup *dup_func,
+                                      CRYPTO_EX_free *free_func) {
+    (void) class_index;
+    (void) argl;
+    (void) argp;
+    (void) new_func;
+    (void) dup_func;
+    (void) free_func;
+
+    return 1;
+}
+static EVP_PKEY* my_X509_get_pubkey(X509* x) {
+    (void) x;
+    return (EVP_PKEY*)my_gballoc_malloc(1);
+}
 static TEST_MUTEX_HANDLE g_testByTest;
 static TEST_MUTEX_HANDLE g_dllByDll;
 
@@ -226,6 +371,25 @@ static SSL_TEST_CTX g_replace_ctx;
 static EVP_PKEY* g_evp_pkey;
 static replace_evp_pkey_st g_replace_evp_key;
 
+static void func_ptr_free(void* ptr) {
+    (void) ptr;
+}
+
+static int func_ptr_copy(void* dest, const void* source) {
+    *((void**)dest) = *((void**)source);
+    return 0;
+}
+
+static int func_ptr_equal(const void* left, const void* right) {
+    return *((void**)left) == *((void**)right);
+}
+
+static char* func_ptr_stringify(const void* value) {
+    char *buf = (char*) my_gballoc_malloc(32);
+    snprintf(buf, 32, "%p", *((void**)value));
+    return buf;
+}
+
 BEGIN_TEST_SUITE(x509_openssl_unittests)
 
     TEST_SUITE_INITIALIZE(a)
@@ -238,6 +402,9 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
         (void)umock_c_init(on_umock_c_error);
 
         (void)umocktypes_charptr_register_types();
+        umocktypes_register_type("openssl_rsa_sign_t", func_ptr_stringify, func_ptr_equal, func_ptr_copy, func_ptr_free);
+        umocktypes_register_type("openssl_rsa_priv_dec_t", func_ptr_stringify, func_ptr_equal, func_ptr_copy, func_ptr_free);
+        umocktypes_register_type("openssl_rsa_finish_t", func_ptr_stringify, func_ptr_equal, func_ptr_copy, func_ptr_free);
 
         REGISTER_GLOBAL_MOCK_HOOK(gballoc_malloc, my_gballoc_malloc);
         REGISTER_GLOBAL_MOCK_FAIL_RETURN(gballoc_malloc, NULL);
@@ -269,13 +436,37 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
         REGISTER_GLOBAL_MOCK_HOOK(X509_free, my_X509_free);
         REGISTER_GLOBAL_MOCK_HOOK(EVP_PKEY_get1_RSA, my_EVP_PKEY_get1_RSA);
         REGISTER_GLOBAL_MOCK_FAIL_RETURN(EVP_PKEY_get1_RSA, NULL);
+        REGISTER_GLOBAL_MOCK_HOOK(EVP_PKEY_get0_RSA, my_EVP_PKEY_get0_RSA);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(EVP_PKEY_get0_RSA, NULL);
 
         REGISTER_GLOBAL_MOCK_RETURNS(PEM_read_bio_PrivateKey, g_evp_pkey, NULL);
 
         REGISTER_GLOBAL_MOCK_RETURNS(BIO_new_mem_buf, TEST_BIO_CERT, NULL);
         REGISTER_GLOBAL_MOCK_HOOK(PEM_read_bio_X509_AUX, my_PEM_read_bio_X509_AUX);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(PEM_read_bio_X509_AUX, NULL);
         REGISTER_GLOBAL_MOCK_RETURNS(SSL_CTX_use_PrivateKey, 1, 0);
         REGISTER_GLOBAL_MOCK_HOOK(SSL_CTX_ctrl, my_SSL_CTX_ctrl);
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_meth_dup, my_RSA_meth_dup);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(RSA_meth_dup, NULL);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_meth_set1_name, my_RSA_meth_set1_name);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_meth_set_flags, my_RSA_meth_set_flags);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_meth_set_sign, my_RSA_meth_set_sign);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_meth_set_priv_dec, my_RSA_meth_set_priv_dec);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_meth_set_finish, my_RSA_meth_set_finish);
+#endif
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_get_default_method, my_RSA_get_default_method);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_new, my_RSA_new);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(RSA_new, NULL);
+        REGISTER_GLOBAL_MOCK_HOOK(EVP_PKEY_new, my_EVP_PKEY_new);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(EVP_PKEY_new, NULL);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_set_method, my_RSA_set_method);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_set_ex_data, my_RSA_set_ex_data);
+        REGISTER_GLOBAL_MOCK_HOOK(CRYPTO_get_ex_new_index, my_CRYPTO_get_ex_new_index);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(CRYPTO_get_ex_new_index, -1);
+        REGISTER_GLOBAL_MOCK_HOOK(X509_get_pubkey, my_X509_get_pubkey);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(X509_get_pubkey, NULL);
+        REGISTER_GLOBAL_MOCK_HOOK(RSA_get0_key, my_RSA_get0_key);
     }
 
     TEST_SUITE_CLEANUP(TestClassCleanup)
@@ -314,19 +505,33 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
         return result;
     }
 
-    static void setup_load_alias_key_cert_mocks(bool is_rsa_cert)
+    static void setup_load_alias_key_cert_mocks(bool is_rsa_cert, bool is_cryptodev)
     {
         if (is_rsa_cert)
         {
             g_replace_evp_key.type = EVP_PKEY_RSA;
-            STRICT_EXPECTED_CALL(EVP_PKEY_get1_RSA(g_evp_pkey));
+            if (is_cryptodev)
+            {
+                STRICT_EXPECTED_CALL(EVP_PKEY_get1_RSA(IGNORED_PTR_ARG));
+            }
+            else
+            {
+                STRICT_EXPECTED_CALL(EVP_PKEY_get1_RSA(g_evp_pkey));
+            }
             STRICT_EXPECTED_CALL(SSL_CTX_use_RSAPrivateKey(TEST_SSL_CTX_STRUCTURE, IGNORED_PTR_ARG));
             STRICT_EXPECTED_CALL(RSA_free(IGNORED_PTR_ARG) );
         }
         else
         {
             g_replace_evp_key.type = EVP_PKEY_EC;
-            STRICT_EXPECTED_CALL(SSL_CTX_use_PrivateKey(TEST_SSL_CTX_STRUCTURE, g_evp_pkey));
+            if (is_cryptodev)
+            {
+                STRICT_EXPECTED_CALL(SSL_CTX_use_PrivateKey(TEST_SSL_CTX_STRUCTURE, IGNORED_PTR_ARG));
+            }
+            else
+            {
+                STRICT_EXPECTED_CALL(SSL_CTX_use_PrivateKey(TEST_SSL_CTX_STRUCTURE, g_evp_pkey));
+            }
         }
     }
 
@@ -347,17 +552,60 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
         STRICT_EXPECTED_CALL(BIO_free(IGNORED_PTR_ARG));
     }
 
-    static void setup_add_credentials(bool is_rsa_cert)
+    static void setup_add_credentials(bool is_rsa_cert, bool is_cryptodev)
     {
-        STRICT_EXPECTED_CALL(BIO_new_mem_buf((char*)TEST_PRIVATE_CERTIFICATE, -1));
-        STRICT_EXPECTED_CALL(PEM_read_bio_PrivateKey(IGNORED_PTR_ARG, NULL, NULL, NULL));
+        if (is_cryptodev)
+        {
+            STRICT_EXPECTED_CALL(RSA_get_default_method());
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+            STRICT_EXPECTED_CALL(RSA_meth_dup(IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(RSA_meth_set1_name(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(RSA_meth_set_flags(IGNORED_PTR_ARG, 0));
+            STRICT_EXPECTED_CALL(RSA_meth_set_sign(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(RSA_meth_set_priv_dec(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(RSA_meth_set_finish(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+#endif
+            STRICT_EXPECTED_CALL(RSA_new());
+            STRICT_EXPECTED_CALL(RSA_set_method(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_RSA, 0, NULL, NULL, NULL, NULL));
+            STRICT_EXPECTED_CALL(RSA_set_ex_data(IGNORED_PTR_ARG, 1, IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(BIO_new_mem_buf((char*)TEST_PUBLIC_CERTIFICATE, -1));
+            STRICT_EXPECTED_CALL(PEM_read_bio_X509_AUX(IGNORED_PTR_ARG, NULL, NULL, NULL));
+            STRICT_EXPECTED_CALL(BIO_free(IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(X509_get_pubkey(IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(X509_free(IGNORED_PTR_ARG));
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+            STRICT_EXPECTED_CALL(EVP_PKEY_get0_RSA(IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(RSA_get0_key(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL));
+#endif
+            STRICT_EXPECTED_CALL(BN_dup(IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(BN_dup(IGNORED_PTR_ARG));
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+            STRICT_EXPECTED_CALL(RSA_set0_key(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL));
+#endif
+
+            STRICT_EXPECTED_CALL(EVP_PKEY_new());
+            STRICT_EXPECTED_CALL(EVP_PKEY_set1_RSA(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        }
+        else
+        {
+            STRICT_EXPECTED_CALL(BIO_new_mem_buf((char*)TEST_PRIVATE_CERTIFICATE, -1));
+            STRICT_EXPECTED_CALL(PEM_read_bio_PrivateKey(IGNORED_PTR_ARG, NULL, NULL, NULL));
+            STRICT_EXPECTED_CALL(BIO_free(IGNORED_PTR_ARG));
+        }
 #ifndef __APPLE__
         STRICT_EXPECTED_CALL(EVP_PKEY_id(IGNORED_PTR_ARG)).SetReturn(is_rsa_cert ? EVP_PKEY_RSA : EVP_PKEY_EC);
 #endif
-        setup_load_alias_key_cert_mocks(is_rsa_cert);
+        setup_load_alias_key_cert_mocks(is_rsa_cert, is_cryptodev);
+        if (is_cryptodev)
+        {
+            STRICT_EXPECTED_CALL(EVP_PKEY_free(IGNORED_PTR_ARG));
+        }
+        else
+        {
+            STRICT_EXPECTED_CALL(EVP_PKEY_free(g_evp_pkey));
+        }
         setup_load_certificate_chain_mocks();
-        STRICT_EXPECTED_CALL(EVP_PKEY_free(g_evp_pkey));
-        STRICT_EXPECTED_CALL(BIO_free(IGNORED_PTR_ARG));
     }
 
     /*Tests_SRS_X509_OPENSSL_02_001: [ If any argument is NULL then x509_openssl_add_credentials shall fail and return a non-zero value. ]*/
@@ -411,7 +659,7 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
     /*Tests_SRS_X509_OPENSSL_02_008: [ If no error occurs, then x509_openssl_add_credentials shall succeed and return 0. ] */
     TEST_FUNCTION(x509_openssl_add_credentials_happy_path)
     {
-        setup_add_credentials(true);
+        setup_add_credentials(true, false);
 
         //act
         int result = x509_openssl_add_credentials(TEST_SSL_CTX_STRUCTURE, TEST_PUBLIC_CERTIFICATE, TEST_PRIVATE_CERTIFICATE);
@@ -425,7 +673,7 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
 
     TEST_FUNCTION(x509_openssl_add_credentials_ecc_happy_path)
     {
-        setup_add_credentials(false);
+        setup_add_credentials(false, false);
 
         //act
         int result = x509_openssl_add_credentials(TEST_SSL_CTX_STRUCTURE, TEST_PUBLIC_CERTIFICATE, TEST_PRIVATE_CERTIFICATE);
@@ -446,21 +694,21 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
         int negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-        setup_add_credentials(true);
+        setup_add_credentials(true, false);
 
         umock_c_negative_tests_snapshot();
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
     #ifdef __APPLE__
-            size_t calls_cannot_fail[] = { 4, 8, 9, 10, 11, 12, 13, 14, 15 };
+            size_t calls_cannot_fail[] = { 2, 5, 6, 10, 11, 12, 13, 14, 15 };
     #else
-            size_t calls_cannot_fail[] = { 2, 5, 9, 10, 11, 12, 13, 14, 15, 16 };
+            size_t calls_cannot_fail[] = { 2, 3, 6, 7, 11, 12, 13, 14, 15, 16 };
     #endif
 #else
     #ifdef __APPLE__
-            size_t calls_cannot_fail[] = { 4, 8, 9, 10, 11, 12, 13, 14 };
+            size_t calls_cannot_fail[] = { 2, 5, 6, 11, 12, 13, 14, 15 };
     #else
-            size_t calls_cannot_fail[] = { 2, 5, 9, 10, 11, 12, 13, 14, 15 };
+            size_t calls_cannot_fail[] = { 2, 3, 6, 7, 11, 12, 13, 14, 15 };
     #endif
 #endif
         //act
@@ -624,4 +872,139 @@ BEGIN_TEST_SUITE(x509_openssl_unittests)
         umock_c_negative_tests_deinit();
     }
 
+    /*Tests_SRS_X509_OPENSSL_02_020: [ If any argument is NULL then x509_openssl_add_credentials_cryptodev shall fail and return a non-zero value. ]*/
+    TEST_FUNCTION(x509_openssl_add_credentials_cryptodev_with_NULL_SSL_CTX_fails)
+    {
+        //arrange
+
+        //act
+        TLSIO_CRYPTODEV_PKEY pkey = {NULL, NULL, NULL, TLSIO_CRYPTODEV_PKEY_TYPE_RSA, NULL};
+        int result = x509_openssl_add_credentials_cryptodev(NULL, "certificate", &pkey);
+
+        //assert
+        ASSERT_ARE_NOT_EQUAL(int, 0, result);
+
+        //cleanup
+    }
+
+    /*Tests_SRS_X509_OPENSSL_02_020: [ If any argument is NULL then x509_openssl_add_credentials_cryptodev shall fail and return a non-zero value. ]*/
+    TEST_FUNCTION(x509_openssl_add_credentials_cryptodev_with_NULL_certificate_fails)
+    {
+        //arrange
+
+        //act
+        TLSIO_CRYPTODEV_PKEY pkey = {NULL, NULL, NULL, TLSIO_CRYPTODEV_PKEY_TYPE_RSA, NULL};
+        int result = x509_openssl_add_credentials_cryptodev(TEST_SSL_CTX, NULL, &pkey);
+
+        //assert
+        ASSERT_ARE_NOT_EQUAL(int, 0, result);
+
+        //cleanup
+    }
+
+    /*Tests_SRS_X509_OPENSSL_02_020: [ If any argument is NULL then x509_openssl_add_credentials_cryptodev shall fail and return a non-zero value. ]*/
+    TEST_FUNCTION(x509_openssl_add_credentials_cryptodev_with_NULL_privatekey_fails)
+    {
+        //arrange
+
+        //act
+        int result = x509_openssl_add_credentials_cryptodev(TEST_SSL_CTX, "certificate", NULL);
+
+        //assert
+        ASSERT_ARE_NOT_EQUAL(int, 0, result);
+
+        //cleanup
+    }
+
+    /*Tests_SRS_X509_OPENSSL_02_021: [ x509_openssl_add_credentials_cryptodev shall use BIO_new_mem_buf to create a memory BIO from the x509 certificate. ] */
+    /*Tests_SRS_X509_OPENSSL_02_022: [ x509_openssl_add_credentials_cryptodev shall use PEM_read_bio_X509 to read the x509 certificate. ] */
+    /*Tests_SRS_X509_OPENSSL_02_023: [ x509_openssl_add_credentials_cryptodev shall use RSA_set_method to set method on an RSA private key. ] */
+    /*Tests_SRS_X509_OPENSSL_02_024: [ x509_openssl_add_credentials_cryptodev shall use EVP_PKEY_set1_RSA to create an RSA private key.  ] */
+    /*Tests_SRS_X509_OPENSSL_02_025: [ x509_openssl_add_credentials_cryptodev shall use SSL_CTX_use_certificate to load the certicate into the SSL context. ] */
+    /*Tests_SRS_X509_OPENSSL_02_026: [ x509_openssl_add_credentials_cryptodev shall use SSL_CTX_use_RSAPrivateKey to load the private key into the SSL context. ]*/
+    /*Tests_SRS_X509_OPENSSL_02_027: [ If no error occurs, then x509_openssl_add_credentials_cryptodev shall succeed and return 0. ] */
+    TEST_FUNCTION(x509_openssl_add_credentials_cryptodev_happy_path)
+    {
+        setup_add_credentials(true, true);
+
+        //act
+        x509_openssl_test_reset();
+        TLSIO_CRYPTODEV_PKEY pkey = {NULL, NULL, NULL, TLSIO_CRYPTODEV_PKEY_TYPE_RSA, NULL};
+        int result = x509_openssl_add_credentials_cryptodev(TEST_SSL_CTX_STRUCTURE, TEST_PUBLIC_CERTIFICATE, &pkey);
+
+        //assert
+        ASSERT_ARE_EQUAL(int, 0, result);
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+        //cleanup
+    }
+
+    /*Tests_SRS_X509_OPENSSL_02_028: [ Otherwise x509_openssl_add_credentials_cryptodev shall fail and return a non-zero number. ]*/
+    TEST_FUNCTION(x509_openssl_add_credentials_cryptodev_fails)
+    {
+        //arrange
+        umock_c_reset_all_calls();
+
+        int negativeTestsInitResult = umock_c_negative_tests_init();
+        ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
+
+        setup_add_credentials(true, true);
+
+        umock_c_negative_tests_snapshot();
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x10100003L)
+    #ifdef __APPLE__
+            size_t calls_cannot_fail[] = { 0, 2, 4, 7, 9, 10, 11, 13, 16, 17, 21, 22, 23, 24, 25, 26};
+    #else
+            size_t calls_cannot_fail[] = { 0, 2, 4, 7, 9, 10, 11, 13, 14, 17, 18, 22, 23, 24, 25, 26, 27};
+    #endif
+#elif(OPENSSL_VERSION_NUMBER >= 0x10100003L) && (OPENSSL_VERSION_NUMBER < 0x10100005L)
+    #ifdef __APPLE__
+            size_t calls_cannot_fail[] = { 0, 2, 4, 7, 9, 11, 12, 13, 14, 16, 19, 20, 24, 25, 26, 27, 28, 29};
+    #else
+            size_t calls_cannot_fail[] = { 0, 2, 4, 7, 9, 11, 12, 13, 14, 16, 17, 20, 21, 25, 26, 27, 28, 29, 30};
+    #endif
+#elif(OPENSSL_VERSION_NUMBER >= 0x10100005L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
+    #ifdef __APPLE__
+            size_t calls_cannot_fail[] = { 0, 2, 3, 4, 5, 6, 8, 10, 13, 15, 17, 18, 19, 20, 22, 25, 26, 30, 31, 32, 33, 34, 35};
+    #else
+            size_t calls_cannot_fail[] = { 0, 2, 3, 4, 5, 6, 8, 10, 13, 15, 17, 18, 19, 20, 22, 23, 26, 27, 31, 32, 33, 34, 35, 36};
+    #endif
+#else
+    #ifdef __APPLE__
+            size_t calls_cannot_fail[] = { 0, 2, 3, 4, 5, 6, 8, 10, 13, 15, 17, 18, 19, 20, 22, 25, 26, 30, 31, 32, 33, 34};
+    #else
+            size_t calls_cannot_fail[] = { 0, 2, 3, 4, 5, 6, 8, 10, 13, 15, 17, 18, 19, 20, 22, 23, 26, 27, 31, 32, 33, 34, 35};
+    #endif
+#endif
+
+        //act
+        int result;
+        size_t count = umock_c_negative_tests_call_count();
+        for (size_t index = 0; index < count; index++)
+        {
+            if (should_skip_index(index, calls_cannot_fail, sizeof(calls_cannot_fail) / sizeof(calls_cannot_fail[0])) != 0)
+            {
+                continue;
+            }
+
+            umock_c_negative_tests_reset();
+            umock_c_negative_tests_fail_call(index);
+
+            char tmp_msg[128];
+            sprintf(tmp_msg, "x509_openssl_add_credentials_cryptodev failure in test %lu/%lu", (unsigned long)index, (unsigned long)count);
+
+            g_replace_ctx.extra_certs = NULL;
+
+            x509_openssl_test_reset();
+            TLSIO_CRYPTODEV_PKEY pkey = {NULL, NULL, NULL, TLSIO_CRYPTODEV_PKEY_TYPE_RSA, NULL};
+            result = x509_openssl_add_credentials_cryptodev(TEST_SSL_CTX_STRUCTURE, TEST_PUBLIC_CERTIFICATE, &pkey);
+
+            //assert
+            ASSERT_ARE_NOT_EQUAL(int, 0, result, tmp_msg);
+        }
+
+        //cleanup
+        umock_c_negative_tests_deinit();
+    }
 END_TEST_SUITE(x509_openssl_unittests)


### PR DESCRIPTION
The PR is related to this issue: https://github.com/Azure/azure-iot-sdk-c/issues/1022

I tried to make changes to the API minimal, therefore the old option to add plain text private key is still there. Nevertheless, some changes to the API were necessary, so probably some projects depending on the c-utility can fail to build. If you approve the idea behind this PR, I can make fixes to the other ones.

Only OpenSSL is supported so far, but nothing prevents supporting other libraries.

No tests are included in this PR, I will definitely need maintainers' help here.

A PR to uhttp utilizing this will be made shortly.