### PR TITLE
Define USE_OPENSSL macro if it's enabled in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ if(${use_custom_heap})
     add_definitions(-DGB_USE_CUSTOM_HEAP)
 endif()
 
+if(${use_openssl})
+    add_definitions(-DUSE_OPENSSL)
+endif()
+
 if(WIN32)
     option(use_schannel "set use_schannel to ON if schannel is to be used, set to OFF to not use schannel" ON)
     option(use_openssl "set use_openssl to ON if openssl is to be used, set to OFF to not use openssl" OFF)
@@ -673,4 +677,3 @@ DESTINATION
 )
 
 compileTargetAsC99(aziotsharedutil)
-


### PR DESCRIPTION
In `platform_linux.c`, `USE_OPENSSL` is not defined if it's enabled in cmake via the `use_openssl` option. Because of this, the header never gets included:

```cpp
#ifdef USE_OPENSSL
#include "azure_c_shared_utility/tlsio_openssl.h"
#endif
```

This is slightly related to https://github.com/Azure/azure-iot-sdk-c/issues/999