### PR TITLE
Improperly closed if statement in CMake functions.

### DIFF
--- a/configs/azure_c_shared_utilityFunctions.cmake
+++ b/configs/azure_c_shared_utilityFunctions.cmake
@@ -161,7 +161,7 @@ function(linux_unittests_add_exe whatIsBuilding)
             SET(PARSING_ADDITIONAL_LIBS OFF)
             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
             set(skip_to_next TRUE)
-        else()
+        endif()
 
         if(NOT skip_to_next)
             if(PARSING_ADDITIONAL_LIBS)


### PR DESCRIPTION
A warning about an improperly closed `if()` statement came up when I was attempting a build.