### PR TITLE
Fix critical socketio_berkeley bug where socketio_send() will drop packets if send() returns -1 and errno=EAGAIN

### DIFF
--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -919,7 +919,7 @@ int socketio_send(CONCRETE_IO_HANDLE socket_io, const void* buffer, size_t size,
                     {
                         /*send says "come back later" with EAGAIN - likely the socket buffer cannot accept more data*/
                         /* queue data */
-                        size_t bytes_sent = (send_result < 0 ? 0: send_result);
+                        size_t bytes_sent = (send_result < 0 ? 0 : send_result);
 
                         if (add_pending_io(socket_io_instance, buffer + bytes_sent, size - bytes_sent, on_send_complete, callback_context) != 0)
                         {

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -910,32 +910,18 @@ int socketio_send(CONCRETE_IO_HANDLE socket_io, const void* buffer, size_t size,
                 ssize_t send_result = send(socket_io_instance->socket, buffer, size, 0);
                 if ((send_result < 0) || ((size_t)send_result != size))
                 {
-                    if (send_result == INVALID_SOCKET)
+                    if (errno != EAGAIN)
                     {
-                        if (errno == EAGAIN) /*send says "come back later" with EAGAIN - likely the socket buffer cannot accept more data*/
-                        {
-                            /* queue data */
-                            if (add_pending_io(socket_io_instance, buffer, size, on_send_complete, callback_context) != 0)
-                            {
-                                LogError("Failure: add_pending_io failed.");
-                                result = MU_FAILURE;
-                            }
-                            else
-                            {
-                                /*do nothing*/
-                                result = 0;
-                            }
-                        }
-                        else
-                        {
-                            LogError("Failure: sending socket failed. errno=%d (%s).", errno, strerror(errno));
-                            result = MU_FAILURE;
-                        }
+                        LogError("Failure: sending socket failed. errno=%d (%s).", errno, strerror(errno));
+                        result = MU_FAILURE;
                     }
                     else
                     {
+                        /*send says "come back later" with EAGAIN - likely the socket buffer cannot accept more data*/
                         /* queue data */
-                        if (add_pending_io(socket_io_instance, buffer + send_result, size - send_result, on_send_complete, callback_context) != 0)
+                        size_t bytes_sent = (send_result < 0 ? 0: send_result);
+
+                        if (add_pending_io(socket_io_instance, buffer + bytes_sent, size - bytes_sent, on_send_complete, callback_context) != 0)
                         {
                             LogError("Failure: add_pending_io failed.");
                             result = MU_FAILURE;


### PR DESCRIPTION
This is a fix for a bug in socketio_berkeley where packets may be lost by socketio_send().
In socketio_send, if send() returns -1 and errno is EAGAIN, the packet does not get added to the pending I/O queue and gets dropped.

This was caught by attempting to send huge amounts of data in a single shot to a remote endpoint which is applying throttling.
After a few calls to socketio_send where packets were lost, on the first call to send() that succeeds, the remote endpoint receives data out of order (since previous packets got dropped by socketio), cannot decrypt it and severs the connection.

The other socketio adapters are not affected by this bug (see [socketio_mbed.c](https://github.com/Azure/azure-c-shared-utility/blob/255cbc81a0f7bd2a34664503ce1f0276da5bb374/adapters/socketio_mbed.c#L333), [socketio_mbed_os5.c](https://github.com/Azure/azure-c-shared-utility/blob/255cbc81a0f7bd2a34664503ce1f0276da5bb374/adapters/socketio_mbed_os5.c#L201), [socketio_win32.c](https://github.com/Azure/azure-c-shared-utility/blob/255cbc81a0f7bd2a34664503ce1f0276da5bb374/adapters/socketio_win32.c#L485)).

Note: there are no tests for this module. E2E tests would need to be added to correctly verify the behavior of socketio (and other xio layers) on key conditions (network latency/delay, high-throughput, etc).

For reference: On non-blocking mode send() will return -1 and errno=EAGAIN if the socket is not ready to send (see https://linux.die.net/man/3/send).