### PR TITLE
Fix critical socketio_win32 bug where socketio_send() will drop packets if send() returns SOCKET_ERROR and WSAEWOULDBLOCK

### DIFF
--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -552,21 +552,22 @@ int socketio_send(CONCRETE_IO_HANDLE socket_io, const void* buffer, size_t size,
             }
             else
             {
-                /* TODO: we need to do more than a cast here to be 100% clean
-                The following bug was filed: [WarnL4] socketio_win32 does not account for already sent bytes and there is a truncation of size from size_t to int */
                 int send_result = send(socket_io_instance->socket, (const char*)buffer, (int)size, 0);
                 if (send_result != (int)size)
                 {
                     int last_error = WSAGetLastError();
-                    if (last_error != WSAEWOULDBLOCK)
+
+                    if (send_result == SOCKET_ERROR && last_error != WSAEWOULDBLOCK)
                     {
                         LogError("Failure: sending socket failed %d.", last_error);
                         result = MU_FAILURE;
                     }
                     else
                     {
+                        size_t bytes_sent = (send_result == SOCKET_ERROR ? 0 : send_result);
+
                         /* queue data */
-                        if (add_pending_io(socket_io_instance, (const unsigned char*)buffer, size, on_send_complete, callback_context) != 0)
+                        if (add_pending_io(socket_io_instance, ((const unsigned char*)buffer) + bytes_sent, size - bytes_sent, on_send_complete, callback_context) != 0)
                         {
                             LogError("Failure: add_pending_io failed.");
                             result = MU_FAILURE;


### PR DESCRIPTION
For reference:

https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send

"If no error occurs, send returns the total number of bytes sent, 
which can be less than the number requested to be sent in the len parameter. 
Otherwise, a value of SOCKET_ERROR is returned, and a specific error code can be retrieved by calling WSAGetLastError."

--------------------------

Investigation of socketio implementations for mbed:

[adapters\socketio_mbed.c](https://github.com/Azure/azure-c-shared-utility/blob/master/adapters/socketio_mbed.c)
[socketio_send(...)](https://github.com/Azure/azure-c-shared-utility/blob/master/adapters/socketio_mbed.c#L299):
It has the correct logic to handle failure (<0) or not all bytes send in one call to tcpsocketconnection_send.

[adapters\socketio_mbed_os5.c](https://github.com/Azure/azure-c-shared-utility/blob/master/adapters/socketio_mbed_os5.c)
[socketio_send()](https://github.com/Azure/azure-c-shared-utility/blob/master/adapters/socketio_mbed_os5.c#L429):
Always adds to the queue, does not try to send right away.
send_queued_data() has the correct logic to handle error (-1) or not sending all bytes in one call to tcpsocketconnection_send.


For reference:
https://os.mbed.com/users/mbed_official/code/Socket/docs/434906b5b977/TCPSocketConnection_8cpp_source.html

00048 int TCPSocketConnection::send(char* data, int length) {
    if ((_sock_fd < 0) || !_is_connected)
        return -1;
    
    if (!_blocking) {
        TimeInterval timeout(_timeout);
        if (wait_writable(timeout) != 0)
            return -1;
    }
    
    int n = lwip_send(_sock_fd, data, length, 0);
    _is_connected = (n != 0);
    
    return n;
}

http://api.tst-sistemas.es/apitsmart-1.2/group___l_w_i_p___exported___functions.html#ga7c670890d4d4e7729d152eece5ac89e0

"Returns
Number of bytes sent 
-1 - Failure"