### PR TITLE
Logging fixes

### DIFF
--- a/adapters/tlsio_ssl_esp8266.c
+++ b/adapters/tlsio_ssl_esp8266.c
@@ -344,8 +344,9 @@ LOCAL int openssl_thread_LWIP_CONNECTION(TLS_IO_INSTANCE* p)
                                                         result = __LINE__;
                                                         LogInfo("error return : %d", lwip_net_errno(sock));
                                                         len = (unsigned int) sizeof( int );
-                                                        if (0 != getsockopt (sock, SOL_SOCKET, SO_ERROR, &ret, &len))
+                                                        if (0 != getsockopt (sock, SOL_SOCKET, SO_ERROR, &ret, &len)) {
                                                             LogInfo("SSL error ret : %d", ret);   // socket is in error state
+                                                        }
                                                         break;
                                                     }
 

--- a/inc/azure_c_shared_utility/xlogging.h
+++ b/inc/azure_c_shared_utility/xlogging.h
@@ -70,6 +70,7 @@ typedef void(*LOGGER_LOG_GETLASTERROR)(const char* file, const char* func, int l
 
 /*no logging is useful when time and fprintf are mocked*/
 #ifdef NO_LOGGING
+#define UNUSED(x) (void)(x)
 #define LOG(...)
 #define LogInfo(...)
 #define LogBinary(...)
@@ -78,16 +79,16 @@ typedef void(*LOGGER_LOG_GETLASTERROR)(const char* file, const char* func, int l
 #define xlogging_get_log_function() NULL
 #define xlogging_set_log_function(...)
 #define LogErrorWinHTTPWithGetLastErrorAsString(...)
-#define UNUSED(x) (void)(x)
 #elif (defined MINIMAL_LOGERROR)
+#define UNUSED(x) (void)(x)
 #define LOG(...)
 #define LogInfo(...)
 #define LogBinary(...)
 #define LogError(...) printf("error %s: line %d\n",__FILE__,__LINE__);
+#define LogLastError(...)
 #define xlogging_get_log_function() NULL
 #define xlogging_set_log_function(...)
 #define LogErrorWinHTTPWithGetLastErrorAsString(...)
-#define UNUSED(x) (void)(x)
 
 #elif defined(ESP8266_RTOS)
 #define LogInfo(FORMAT, ...) do {    \

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -325,7 +325,6 @@ extern int BUFFER_unbuild(BUFFER_HANDLE handle)
         BUFFER* b = (BUFFER*)handle;
         if (b->buffer != NULL)
         {
-            LogError("Failure buffer data is NULL");
             free(b->buffer);
             b->buffer = NULL;
             b->size = 0;


### PR DESCRIPTION
1. Fixing `NO_LOGGING` option build.
2. Removing unnecessary/incorrect buffer error message.
