### PR TITLE
Fix SEGFAULT errors introduced by dns_resolver in socketio (gh# 1275)

### DIFF
--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -708,6 +708,10 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                     if (result->dns_resolver == NULL)
                     {
                         LogError("Failure creating dns_resolver");
+                        if (result->hostname != NULL)
+                        {
+                            free(result->hostname);
+                        }
                         singlylinkedlist_destroy(result->pending_io_list);
                         free(result);
                         result = NULL;

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -660,15 +660,8 @@ static void destroy_socket_io_instance(SOCKET_IO_INSTANCE* instance)
         dns_resolver_destroy(instance->dns_resolver);
     }
 
-    if (instance->hostname != NULL)
-    {
-        free(instance->hostname);
-    }
-
-    if (instance->target_mac_address != NULL)
-    {
-        free(instance->target_mac_address);
-    }
+    free(instance->hostname);
+    free(instance->target_mac_address);
 
     if (instance->pending_io_list != NULL)
     {
@@ -727,7 +720,7 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                     destroy_socket_io_instance(result);
                     result = NULL;
                 }
-                else if ((result->dns_resolver = dns_resolver_create(result->hostname, result->port, NULL)) == NULL)
+                else if ((result->dns_resolver = dns_resolver_create(result->hostname, socket_io_config->port, NULL)) == NULL)
                 {
                     LogError("Failure creating dns_resolver");
                     destroy_socket_io_instance(result);

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -343,6 +343,10 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                     if (result->addrInfo == NULL)
                     {
                         LogError("Failure: addrInfo == NULL.");
+                        if (result->hostname != NULL)
+                        {
+                            free(result->hostname);
+                        }
                         singlylinkedlist_destroy(result->pending_io_list);
                         free(result);
                         result = NULL;
@@ -355,6 +359,10 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                         {
                             LogError("Failure allocating ai_addr");
                             free(result->addrInfo);
+                            if (result->hostname != NULL)
+                            {
+                                free(result->hostname);
+                            }
                             singlylinkedlist_destroy(result->pending_io_list);
                             free(result);
                             result = NULL;
@@ -368,6 +376,10 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                                 LogError("Failure creating dns_resolver");
                                 free(result->addrInfo->ai_addr);
                                 free(result->addrInfo);
+                                if (result->hostname != NULL)
+                                {
+                                    free(result->hostname);
+                                }
                                 singlylinkedlist_destroy(result->pending_io_list);
                                 free(result);
                                 result = NULL;

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -287,6 +287,35 @@ static int initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
     return result;
 }
 
+static void destroy_socket_io_instance(SOCKET_IO_INSTANCE* instance)
+{
+    if (instance->dns_resolver != NULL)
+    {
+        dns_resolver_destroy(instance->dns_resolver);
+    }
+
+    if (instance->hostname != NULL)
+    {
+        free(instance->hostname);
+    }
+
+    if (instance->addrInfo != NULL)
+    {
+        if (instance->addrInfo->ai_addr != NULL)
+        {
+            free(instance->addrInfo->ai_addr);
+        }
+        free(instance->addrInfo);
+    }
+
+    if (instance->pending_io_list != NULL)
+    {
+        singlylinkedlist_destroy(instance->pending_io_list);
+    }
+
+    free(instance);
+}
+
 CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
 {
     SOCKETIO_CONFIG* socket_io_config = (SOCKETIO_CONFIG*)io_create_parameters;
@@ -301,14 +330,17 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
     else
     {
         result = (SOCKET_IO_INSTANCE*)malloc(sizeof(SOCKET_IO_INSTANCE));
+
         if (result != NULL)
         {
+            (void)memset(result, 0, sizeof(SOCKET_IO_INSTANCE));
+
             result->address_type = ADDRESS_TYPE_IP;
             result->pending_io_list = singlylinkedlist_create();
             if (result->pending_io_list == NULL)
             {
                 LogError("Failure: singlylinkedlist_create unable to create pending list.");
-                free(result);
+                destroy_socket_io_instance(result);
                 result = NULL;
             }
             else
@@ -332,71 +364,37 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                 if ((result->hostname == NULL) && (result->socket == INVALID_SOCKET))
                 {
                     LogError("Failure: hostname == NULL and socket is invalid.");
-                    singlylinkedlist_destroy(result->pending_io_list);
-                    free(result);
+                    destroy_socket_io_instance(result);
+                    result = NULL;
+                }
+                else if ((result->addrInfo = calloc(1, sizeof(struct addrinfo))) == NULL)
+                {
+                    LogError("Failure: addrInfo == NULL.");
+                    destroy_socket_io_instance(result);
+                    result = NULL;
+                }
+                else if ((result->addrInfo->ai_addr = calloc(1, sizeof(struct sockaddr_in))) == NULL)
+                {
+                    LogError("Failure allocating ai_addr");
+                    destroy_socket_io_instance(result);
+                    result = NULL;
+                }
+                else if ((result->dns_resolver = dns_resolver_create(result->hostname, result->port, NULL)) == NULL)
+                {
+                    LogError("Failure creating dns_resolver");
+                    destroy_socket_io_instance(result);
                     result = NULL;
                 }
                 else
                 {
-                    result->addrInfo = calloc(1, sizeof(struct addrinfo));
-
-                    if (result->addrInfo == NULL)
-                    {
-                        LogError("Failure: addrInfo == NULL.");
-                        if (result->hostname != NULL)
-                        {
-                            free(result->hostname);
-                        }
-                        singlylinkedlist_destroy(result->pending_io_list);
-                        free(result);
-                        result = NULL;
-                    }
-                    else
-                    {
-                        result->addrInfo->ai_addr = calloc(1, sizeof(struct sockaddr_in));
-
-                        if (result->addrInfo->ai_addr == NULL)
-                        {
-                            LogError("Failure allocating ai_addr");
-                            free(result->addrInfo);
-                            if (result->hostname != NULL)
-                            {
-                                free(result->hostname);
-                            }
-                            singlylinkedlist_destroy(result->pending_io_list);
-                            free(result);
-                            result = NULL;
-                        }
-                        else
-                        {
-                            result->dns_resolver = dns_resolver_create(result->hostname, result->port, NULL);
-
-                            if (result->dns_resolver == NULL)
-                            {
-                                LogError("Failure creating dns_resolver");
-                                free(result->addrInfo->ai_addr);
-                                free(result->addrInfo);
-                                if (result->hostname != NULL)
-                                {
-                                    free(result->hostname);
-                                }
-                                singlylinkedlist_destroy(result->pending_io_list);
-                                free(result);
-                                result = NULL;
-                            }
-                            else
-                            {
-                                result->port = socket_io_config->port;
-                                result->on_io_open_complete = NULL;
-                                result->on_bytes_received = NULL;
-                                result->on_io_error = NULL;
-                                result->on_bytes_received_context = NULL;
-                                result->on_io_error_context = NULL;
-                                result->io_state = IO_STATE_CLOSED;
-                                result->keep_alive = tcp_keepalive;
-                            }
-                        }
-                    }
+                    result->port = socket_io_config->port;
+                    result->on_io_open_complete = NULL;
+                    result->on_bytes_received = NULL;
+                    result->on_io_error = NULL;
+                    result->on_bytes_received_context = NULL;
+                    result->on_io_error_context = NULL;
+                    result->io_state = IO_STATE_CLOSED;
+                    result->keep_alive = tcp_keepalive;
                 }
             }
         }
@@ -433,15 +431,7 @@ void socketio_destroy(CONCRETE_IO_HANDLE socket_io)
             singlylinkedlist_remove(socket_io_instance->pending_io_list, first_pending_io);
         }
 
-        singlylinkedlist_destroy(socket_io_instance->pending_io_list);
-        if (socket_io_instance->hostname != NULL)
-        {
-            free(socket_io_instance->hostname);
-        }
-
-        dns_resolver_destroy(socket_io_instance->dns_resolver);
-
-        free(socket_io);
+        destroy_socket_io_instance(socket_io);
     }
 }
 

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -294,19 +294,8 @@ static void destroy_socket_io_instance(SOCKET_IO_INSTANCE* instance)
         dns_resolver_destroy(instance->dns_resolver);
     }
 
-    if (instance->hostname != NULL)
-    {
-        free(instance->hostname);
-    }
-
-    if (instance->addrInfo != NULL)
-    {
-        if (instance->addrInfo->ai_addr != NULL)
-        {
-            free(instance->addrInfo->ai_addr);
-        }
-        free(instance->addrInfo);
-    }
+    free(instance->hostname);
+    free(instance->addrInfo);
 
     if (instance->pending_io_list != NULL)
     {
@@ -379,7 +368,7 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                     destroy_socket_io_instance(result);
                     result = NULL;
                 }
-                else if ((result->dns_resolver = dns_resolver_create(result->hostname, result->port, NULL)) == NULL)
+                else if ((result->dns_resolver = dns_resolver_create(result->hostname, socket_io_config->port, NULL)) == NULL)
                 {
                     LogError("Failure creating dns_resolver");
                     destroy_socket_io_instance(result);

--- a/pal/ios-osx/socket_async_os.h
+++ b/pal/ios-osx/socket_async_os.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//This file pulls in OS-specific header files to allow compilation of socket_async.c under
+// most OS's except for Windows.
+
+// For Linux systems
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <netdb.h>

--- a/tests/socketio_win32_ut/socketio_win32_ut.c
+++ b/tests/socketio_win32_ut/socketio_win32_ut.c
@@ -463,6 +463,8 @@ TEST_FUNCTION(socketio_create_singlylinkedlist_create_fails)
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     EXPECTED_CALL(singlylinkedlist_create()).SetReturn((SINGLYLINKEDLIST_HANDLE)NULL);
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
     // act
     ioHandle = socketio_create(&socketConfig);
@@ -532,11 +534,12 @@ TEST_FUNCTION(socketio_destroy_socket_succeeds)
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     EXPECTED_CALL(singlylinkedlist_remove(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     EXPECTED_CALL(singlylinkedlist_get_head_item(IGNORED_PTR_ARG));
-    EXPECTED_CALL(singlylinkedlist_destroy(IGNORED_PTR_ARG));
-    EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     EXPECTED_CALL(freeaddrinfo(&TEST_ADDR_INFO));
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    EXPECTED_CALL(singlylinkedlist_destroy(IGNORED_PTR_ARG));
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
     // act


### PR DESCRIPTION
Relates to: https://github.com/Azure/azure-iot-sdk-c/issues/1275

There were two instances of possible failures not properly handled on socketio related to dns_resolver:
- The result of dns_resolver_create() was not being checked for NULL (which could be caused by memory allocation failure);
- The result of dns_resolver_get_addrInfo() was not being checked for NULL, which could happen even if dns_resolver_is_lookup_complete returned true.

These failures affected socketio_berkeley.c and socketio_win32.c.
The currently remaining socketio implementations were not affected, since they do not use dns_resolver (socketio_mbed.c, socketio_mbed_os5.c).

Thanks @mlilien for the initial PR to fix this issue.