### PR TITLE
Revert change of dns_resolver_create in socketio

### DIFF
--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -720,16 +720,11 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                     destroy_socket_io_instance(result);
                     result = NULL;
                 }
-                else if ((result->dns_resolver = dns_resolver_create(result->hostname, socket_io_config->port, NULL)) == NULL)
-                {
-                    LogError("Failure creating dns_resolver");
-                    destroy_socket_io_instance(result);
-                    result = NULL;
-                }
                 else
                 {
                     result->port = socket_io_config->port;
                     result->on_io_open_complete = NULL;
+                    result->dns_resolver = dns_resolver_create(result->hostname, socket_io_config->port, NULL);
                     result->target_mac_address = NULL;
                     result->on_bytes_received = NULL;
                     result->on_io_error = NULL;

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -368,16 +368,11 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                     destroy_socket_io_instance(result);
                     result = NULL;
                 }
-                else if ((result->dns_resolver = dns_resolver_create(result->hostname, socket_io_config->port, NULL)) == NULL)
-                {
-                    LogError("Failure creating dns_resolver");
-                    destroy_socket_io_instance(result);
-                    result = NULL;
-                }
                 else
                 {
                     result->port = socket_io_config->port;
                     result->on_io_open_complete = NULL;
+                    result->dns_resolver = dns_resolver_create(result->hostname, socket_io_config->port, NULL);
                     result->on_bytes_received = NULL;
                     result->on_io_error = NULL;
                     result->on_bytes_received_context = NULL;


### PR DESCRIPTION
The additonal change related to dns_resolver_create in socketio_* unveiled another set of issues related to the
handling of hostname in the socketio structure. To provide proper fixes, the changes will be split into
separate commits, first to address github #1275 and a subsequent one to address the remaining issues.
Thus reverting part of the recent changes to align with the strategy of having separate fixes.