### PR TITLE
tickcounter_get_current_ms now returns ms resolution time ticks

### DIFF
--- a/adapters/linux_time.c
+++ b/adapters/linux_time.c
@@ -61,7 +61,7 @@ int get_time_ns(struct timespec* ts)
     return err;
 }
 
-time_t get_time_s()
+time_t get_time_ms()
 {
     struct timespec ts;
     if (get_time_ns(&ts) != 0)
@@ -70,6 +70,6 @@ time_t get_time_s()
         return INVALID_TIME_VALUE;
     }
 
-    return (time_t)ts.tv_sec;
+    return (time_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
 }
 

--- a/adapters/linux_time.h
+++ b/adapters/linux_time.h
@@ -13,7 +13,7 @@ extern clockid_t time_basis;
 
 extern void set_time_basis(void);
 extern int get_time_ns(struct timespec* ts);
-extern time_t get_time_s(void);
+extern time_t get_time_ms(void);
 
 #define INVALID_TIME_VALUE      (time_t)(-1)
 

--- a/adapters/tickcounter_linux.c
+++ b/adapters/tickcounter_linux.c
@@ -23,7 +23,7 @@ TICK_COUNTER_HANDLE tickcounter_create(void)
     {
         set_time_basis();
 
-        result->init_time_value = get_time_s();
+        result->init_time_value = get_time_ms();
         if (result->init_time_value == INVALID_TIME_VALUE)
         {
             LogError("tickcounter failed: time return INVALID_TIME.");
@@ -57,7 +57,7 @@ int tickcounter_get_current_ms(TICK_COUNTER_HANDLE tick_counter, tickcounter_ms_
     }
     else
     {
-        time_t time_value = get_time_s();
+        time_t time_value = get_time_ms();
         if (time_value == INVALID_TIME_VALUE)
         {
             result = MU_FAILURE;
@@ -65,7 +65,7 @@ int tickcounter_get_current_ms(TICK_COUNTER_HANDLE tick_counter, tickcounter_ms_
         else
         {
             TICK_COUNTER_INSTANCE* tick_counter_instance = (TICK_COUNTER_INSTANCE*)tick_counter;
-            tick_counter_instance->current_ms = (tickcounter_ms_t)(difftime(time_value, tick_counter_instance->init_time_value) * 1000);
+            tick_counter_instance->current_ms = (tickcounter_ms_t)(difftime(time_value, tick_counter_instance->init_time_value));
             *current_ms = tick_counter_instance->current_ms;
             result = 0;
         }


### PR DESCRIPTION
Fixes #190 prior to this fix the function only had a resolution of seconds, now it is really milliseconds.