### PR TITLE
Update tlsio options when creating TLSIO on MacOS

### DIFF
--- a/pal/ios-osx/tlsio_appleios.c
+++ b/pal/ios-osx/tlsio_appleios.c
@@ -258,7 +258,7 @@ static CONCRETE_IO_HANDLE tlsio_appleios_create(void* io_create_parameters)
                     result->sockWrite = NULL;
                     result->hostname = NULL;
                     result->pending_transmission_list = NULL;
-                    tlsio_options_initialize(&result->options, TLSIO_OPTION_BIT_NONE);
+                    tlsio_options_initialize(&result->options, TLSIO_OPTION_BIT_TRUSTED_CERTS);
                     /* Codes_SRS_TLSIO_30_016: [ tlsio_create shall make a copy of the hostname member of io_create_parameters to allow deletion of hostname immediately after the call. ]*/
                     if (NULL == (result->hostname = CFStringCreateWithCString(NULL, tls_io_config->hostname, kCFStringEncodingUTF8)))
                     {


### PR DESCRIPTION
Hi, I'm from the azure sdk python team, maintaining python messaging libraries. Our libraries depend on azure-c-shared-utility for fundamental network communication.

The problem I meet is:

When [uamqp library](https://github.com/Azure/azure-uamqp-python) (which utilizes azure-c-shared-utility library) wants to set certificate on MacOS, there is always an warning saying that "Trusted certs option not supported".

I debug the code in C and find on MacOS, the tls_options is set to `TLSIO_OPTION_BIT_NONE` in tlsio_appleios.c [(code here)](https://github.com/Azure/azure-c-shared-utility/blob/831c6b365599276cac17aa0d37960b44d21e0e00/pal/ios-osx/tlsio_appleios.c#L261):
```c
tlsio_options_initialize(&result->options, TLSIO_OPTION_BIT_NONE);
```
Meanwhile in tlsio_options.c, in function `tlsio_options_set`, the if-statement is checking [(coe here)](https://github.com/Azure/azure-c-shared-utility/blob/831c6b365599276cac17aa0d37960b44d21e0e00/pal/tlsio_options.c#L155-L159):
```c
if ((options->supported_options & TLSIO_OPTION_BIT_TRUSTED_CERTS) == 0
```

This leads to
```c
LogError("Trusted certs option not supported");
result = TLSIO_OPTIONS_RESULT_ERROR;
```

Related issue: https://github.com/Azure/azure-c-shared-utility/issues/426
or the comment here: https://github.com/Azure/azure-sdk-for-python/issues/7201#issuecomment-582271921.

--------------------

My questions are:

1) Is setting `TLSIO_OPTION_BIT_NONE` an intentional behavior on MacOS due to some known issues?
2) Can we safely update `TLSIO_OPTION_BIT_NONE` to `TLSIO_OPTION_BIT_TRUSTED_CERTS `?
3) If not, how to set certificate on MacOS
4) How are other platforms doing when setting certificate? I checked tlsio_schannel.c (windows) and tlsio_openssl.c (linux) but didn't find any setting related to the tls_options


Loop in @lmazuel  in the discussion.



