### PR TITLE
add proxy support for httpapi compact

### DIFF
--- a/adapters/httpapi_compact.c
+++ b/adapters/httpapi_compact.c
@@ -17,6 +17,7 @@
 #include "azure_c_shared_utility/tlsio.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/shared_util_options.h"
+#include "azure_c_shared_utility/http_proxy_io.h"
 
 #ifdef _MSC_VER
 #define snprintf _snprintf
@@ -45,6 +46,7 @@ MU_DEFINE_ENUM_STRINGS(HTTPAPI_RESULT, HTTPAPI_RESULT_VALUES)
 
 typedef struct HTTP_HANDLE_DATA_TAG
 {
+    char*           hostName;
     char*           certificate;
     char*           x509ClientCertificate;
     char*           x509ClientPrivateKey;
@@ -222,6 +224,7 @@ HTTP_HANDLE HTTPAPI_CreateConnection(const char* hostName)
         }
         else
         {
+            mallocAndStrcpy_s(&http_instance->hostName, hostName);
             tlsio_config.hostname = hostName;
             tlsio_config.port = 443;
             tlsio_config.underlying_io_interface = NULL;
@@ -330,6 +333,12 @@ void HTTPAPI_CloseConnection(HTTP_HANDLE handle)
         {
             free(http_instance->x509ClientPrivateKey);
         }
+
+        if (http_instance->hostName)
+        {
+            free(http_instance->hostName);
+        }
+
         free(http_instance);
     }
 }
@@ -1341,6 +1350,75 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
             result = HTTPAPI_OK;
         }
     }
+    else if (strcmp(OPTION_HTTP_PROXY, optionName) == 0)
+    {
+        TLSIO_CONFIG tlsio_config;
+        HTTP_PROXY_IO_CONFIG proxy_config;
+        HTTP_PROXY_OPTIONS* proxy_options = (HTTP_PROXY_OPTIONS*)value;
+
+        if (proxy_options->host_address == NULL)
+        {
+            LogError("NULL host_address in proxy options");
+            result = HTTPAPI_ERROR;
+        }
+        else if (((proxy_options->username == NULL) || (proxy_options->password == NULL)) &&
+                (proxy_options->username != proxy_options->password))
+        {
+            LogError("Only one of username and password for proxy settings was NULL");
+            result = HTTPAPI_ERROR;
+        }
+        else
+        {
+
+            /* Workaround: xio interface is already created when HTTPAPI_CreateConnection is call without proxy support
+             * need to destroy the interface and create a new one with proxy information
+             */
+            OPTIONHANDLER_HANDLE xio_options;
+            if ((xio_options = xio_retrieveoptions(http_instance->xio_handle)) == NULL)
+            {
+                LogError("failed saving underlying I/O transport options");
+                result = HTTPAPI_ERROR;
+            }
+            else
+            {
+                xio_destroy(http_instance->xio_handle);
+
+                proxy_config.hostname = http_instance->hostName;
+                proxy_config.proxy_hostname = proxy_options->host_address;
+                proxy_config.password = proxy_options->password;
+                proxy_config.username = proxy_options->username;
+                proxy_config.proxy_port = proxy_options->port;
+                proxy_config.port = 443;
+
+                tlsio_config.hostname = http_instance->hostName;
+                tlsio_config.port = 443;
+                tlsio_config.underlying_io_interface =  http_proxy_io_get_interface_description();
+                tlsio_config.underlying_io_parameters = &proxy_config;
+
+                http_instance->xio_handle = xio_create(platform_get_default_tlsio(), (void*)&tlsio_config);
+
+                if (http_instance->xio_handle == NULL)
+                {
+                    LogError("Fail to create xio handle with proxy configuration");
+                    result = HTTPAPI_ERROR;
+                }
+                else
+                {
+                    if (OptionHandler_FeedOptions(xio_options, http_instance->xio_handle) != OPTIONHANDLER_OK)
+                    {
+                        LogError("Failed feeding existing options to new xio instance.");
+                        result = HTTPAPI_ERROR;
+                    }
+                    else
+                    {
+                        result = HTTPAPI_OK;
+                    }
+                }
+
+                OptionHandler_Destroy(xio_options);
+            }
+        }
+    }
     else
     {
         /*Codes_SRS_HTTPAPI_COMPACT_21_063: [ If the HTTP do not support the optionName, the HTTPAPI_SetOption shall return HTTPAPI_INVALID_ARG. ]*/
@@ -1422,6 +1500,26 @@ HTTPAPI_RESULT HTTPAPI_CloneOption(const char* optionName, const void* value, co
             /*Codes_SRS_HTTPAPI_COMPACT_21_072: [ If the HTTPAPI_CloneOption get success setting the option, it shall return HTTPAPI_OK. ]*/
             (void)strcpy(tempCert, (const char*)value);
             *savedValue = tempCert;
+            result = HTTPAPI_OK;
+        }
+    }
+    else if (strcmp(OPTION_HTTP_PROXY, optionName) == 0)
+    {
+        HTTP_PROXY_OPTIONS* proxy_data = (HTTP_PROXY_OPTIONS*)value;
+
+        HTTP_PROXY_OPTIONS* new_proxy_info = malloc(sizeof(HTTP_PROXY_OPTIONS));
+        if (new_proxy_info == NULL)
+        {
+            LogError("unable to allocate proxy option information");
+            result = HTTPAPI_ERROR;
+        }
+        else
+        {
+            new_proxy_info->host_address = proxy_data->host_address;
+            new_proxy_info->port = proxy_data->port;
+            new_proxy_info->password = proxy_data->password;
+            new_proxy_info->username = proxy_data->username;
+            *savedValue = new_proxy_info;
             result = HTTPAPI_OK;
         }
     }


### PR DESCRIPTION
Hi,

This PR address the gap in HTTPAPI_compact implementation where proxy can not be used.

We had to introduce a small workaround  as the tlsio brick is created in the `HTTPAPI_CreateConnection` function, we destroy it and recreate one upon the call of `HTTPAPI_SetOption`

What do you think?
Best regards,