### PR TITLE
fix library ref and casts in tlsio_mbedtls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,10 +535,10 @@ endif()
 
 if(${use_mbedtls})
     if (WIN32)
-        set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} 
-            $ENV{mbedtlsLibDir}/mbedtls 
-            $ENV{mbedtlsLibDir}/mbedx509 
-            $ENV{mbedtlsLibDir}/mbedcrypto
+        set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} ws2_32
+            $ENV{mbedtlsLibDir}/mbedtls.lib 
+            $ENV{mbedtlsLibDir}/mbedx509.lib 
+            $ENV{mbedtlsLibDir}/mbedcrypto.lib
         )
         include_directories("$ENV{mbedtlsDir}/include")
     else()

--- a/adapters/platform_win32.c
+++ b/adapters/platform_win32.c
@@ -20,6 +20,9 @@
 #if USE_WOLFSSL
 #include "azure_c_shared_utility/tlsio_wolfssl.h"
 #endif
+#if USE_MBEDTLS
+#include "azure_c_shared_utility/tlsio_mbedtls.h"
+#endif
 #if USE_BEARSSL
 #include "azure_c_shared_utility/tlsio_bearssl.h"
 #endif
@@ -67,6 +70,8 @@ const IO_INTERFACE_DESCRIPTION* platform_get_default_tlsio(void)
     return tlsio_wolfssl_get_interface_description();
 #elif USE_BEARSSL
     return tlsio_bearssl_get_interface_description();
+#elif USE_MBEDTLS
+    return tlsio_mbedtls_get_interface_description();
 #else
     return tlsio_schannel_get_interface_description();
 #endif

--- a/adapters/tlsio_mbedtls.c
+++ b/adapters/tlsio_mbedtls.c
@@ -325,10 +325,10 @@ static int on_io_recv(void *context, unsigned char *buf, size_t sz)
             }
         }
 
-        result = tls_io_instance->socket_io_read_byte_count;
+        result = (int) tls_io_instance->socket_io_read_byte_count;
         if (result > (int)sz)
         {
-            result = sz;
+            result = (int)sz;
         }
 
         if (result > 0)
@@ -399,7 +399,7 @@ static int on_io_send(void *context, const unsigned char *buf, size_t sz)
     {
         TLS_IO_INSTANCE *tls_io_instance = (TLS_IO_INSTANCE *)context;
         ON_SEND_COMPLETE on_complete_callback = NULL;
-        void *context = NULL;
+        context = NULL;
 
         // Only allow Application data type message to send on_send_complete callback.
         if (tls_io_instance->ssl.out_msgtype == MBEDTLS_SSL_MSG_APPLICATION_DATA)
@@ -415,7 +415,7 @@ static int on_io_send(void *context, const unsigned char *buf, size_t sz)
         }
         else
         {
-            result = sz;
+            result = (int)sz;
         }
     }
     return result;
@@ -732,7 +732,7 @@ int tlsio_mbedtls_send(CONCRETE_IO_HANDLE tls_io, const void *buffer, size_t siz
             tls_io_instance->send_complete_info.on_send_complete = on_send_complete;
             tls_io_instance->send_complete_info.on_send_complete_callback_context = callback_context;
             tls_io_instance->send_complete_info.last_fragmented_req_status = IO_SEND_OK;
-            int out_left = size;
+            int out_left = (int)size;
             result = 0;
 
             do


### PR DESCRIPTION
Hi,

Small fixes to use mbedtls library on windows,

it fix cast errors and libraries missing `.lib` extention in cmakefile

Regards,