### PR TITLE
Removed length check

### DIFF
--- a/src/sha1.c
+++ b/src/sha1.c
@@ -130,10 +130,6 @@ int SHA1Input(SHA1Context *context, const uint8_t *message_array, unsigned int l
     {
         result = shaSuccess;
     }
-    else if (length > SHA1_Message_Block_Size)
-    {
-        result = shaInputTooLong;
-    }
     else if (!context || !message_array)
     {
         result = shaNull;

--- a/src/sha224.c
+++ b/src/sha224.c
@@ -225,10 +225,6 @@ int SHA256Input(SHA256Context *context, const uint8_t *message_array, unsigned i
     {
         result = shaSuccess;
     }
-    else if (length > SHA256_Message_Block_Size)
-    {
-        result = shaInputTooLong;
-    }
     else if (!context || !message_array)
     {
         result = shaNull;


### PR DESCRIPTION
Upon further testing in the e2e tests it seems this is not allowed and the function call in question resets the Message_Block_Index to 0 so this is actually not a bug - Revert to unmodified code