### PR TITLE
Suppress unused parameter warning

### DIFF
--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -865,6 +865,9 @@ void tlsio_wolfssl_dowork(CONCRETE_IO_HANDLE tls_io)
 static int process_option(char** destination, const char* name, const char* value)
 {
     int result;
+
+    UNUSED(name);
+
     if (*destination != NULL)
     {
         free(*destination);


### PR DESCRIPTION
This change addresses unused parameter warnings in process_option() by invoking the UNUSED macro.