### PR TITLE
Update call to get private key for compatibility with OpenSSL@1.1

### DIFF
--- a/adapters/x509_openssl.c
+++ b/adapters/x509_openssl.c
@@ -13,7 +13,7 @@
 
 #ifdef __APPLE__
     #ifndef EVP_PKEY_id
-        #define EVP_PKEY_id(evp_key) evp_key->type
+	#define EVP_PKEY_ID(evp_key) EVP_PKEY_get1_EC_KEY(evp_key)
     #endif // EVP_PKEY_id
 #endif // __APPLE__
 


### PR DESCRIPTION
This changes updates the method used to get the PK ID to make it compatible with OpenSSL@1.1