### PR TITLE
update dec ref for loop max value

### DIFF
--- a/adapters/tlsio_schannel.c
+++ b/adapters/tlsio_schannel.c
@@ -810,7 +810,7 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                     {
                         LPVOID srcText = NULL;
                         if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
-                            status, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)srcText, 0, NULL) > 0)
+                            status, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&srcText, 0, NULL) > 0)
                         {
                             LogError("[%#x] %s", status, (LPTSTR)srcText);
                             LocalFree(srcText);
@@ -972,7 +972,7 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                     {
                         LPVOID srcText = NULL;
                         if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
-                            status, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)srcText, 0, NULL) > 0)
+                            status, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&srcText, 0, NULL) > 0)
                         {
                             LogError("[%#x] %s", status, (LPTSTR)srcText);
                             LocalFree(srcText);

--- a/src/constbuffer_array_batcher.c
+++ b/src/constbuffer_array_batcher.c
@@ -72,7 +72,8 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_batcher_batch(CONSTBUFFER_ARRAY_HANDL
                 }
 
                 /* Codes_SRS_CONSTBUFFER_ARRAY_BATCHER_01_007: [ constbuffer_array_batcher_batch shall allocate enough memory for all the buffer handles in all the arrays + one extra header buffer handle. ]*/
-                all_buffers = malloc(sizeof(CONSTBUFFER_HANDLE) * (total_buffer_count + 1));
+                size_t all_buffers_array_size = total_buffer_count + 1;
+                all_buffers = malloc(sizeof(CONSTBUFFER_HANDLE) * (all_buffers_array_size));
                 if (all_buffers == NULL)
                 {
                     /* Codes_SRS_CONSTBUFFER_ARRAY_BATCHER_01_010: [ If any error occurrs, constbuffer_array_batcher_batch shall fail and return NULL. ]*/
@@ -109,8 +110,8 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_batcher_batch(CONSTBUFFER_ARRAY_HANDL
                             }
                         }
 
-                        result = constbuffer_array_create(all_buffers, total_buffer_count + 1);
-                        for (i = 0; i < total_buffer_count + 1; i++)
+                        result = constbuffer_array_create(all_buffers, all_buffers_array_size);
+                        for (i = 0; i < all_buffers_array_size; i++)
                         {
                             CONSTBUFFER_DecRef(all_buffers[i]);
                         }

--- a/src/constbuffer_array_batcher.c
+++ b/src/constbuffer_array_batcher.c
@@ -72,8 +72,8 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_batcher_batch(CONSTBUFFER_ARRAY_HANDL
                 }
 
                 /* Codes_SRS_CONSTBUFFER_ARRAY_BATCHER_01_007: [ constbuffer_array_batcher_batch shall allocate enough memory for all the buffer handles in all the arrays + one extra header buffer handle. ]*/
-                size_t all_buffers_array_size = total_buffer_count + 1;
-                all_buffers = malloc(sizeof(CONSTBUFFER_HANDLE) * (all_buffers_array_size));
+                uint32_t all_buffers_array_size = total_buffer_count + 1;
+                all_buffers = malloc(sizeof(CONSTBUFFER_HANDLE) * ((size_t)all_buffers_array_size));
                 if (all_buffers == NULL)
                 {
                     /* Codes_SRS_CONSTBUFFER_ARRAY_BATCHER_01_010: [ If any error occurrs, constbuffer_array_batcher_batch shall fail and return NULL. ]*/

--- a/src/constbuffer_array_batcher.c
+++ b/src/constbuffer_array_batcher.c
@@ -110,7 +110,7 @@ CONSTBUFFER_ARRAY_HANDLE constbuffer_array_batcher_batch(CONSTBUFFER_ARRAY_HANDL
                         }
 
                         result = constbuffer_array_create(all_buffers, total_buffer_count + 1);
-                        for (i = 0; i < current_index; i++)
+                        for (i = 0; i < total_buffer_count + 1; i++)
                         {
                             CONSTBUFFER_DecRef(all_buffers[i]);
                         }


### PR DESCRIPTION
Updates the loop over which `all_buffers` is `dec_ref`'d to the size which originally allocated `all_buffers` instead of an indirectly-the-same value.