### PR TITLE
Fix for bug-7579476

### DIFF
--- a/src/http_proxy_io.c
+++ b/src/http_proxy_io.c
@@ -631,7 +631,7 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
         case HTTP_PROXY_IO_STATE_WAITING_FOR_CONNECT_RESPONSE:
         {
             /* Codes_SRS_HTTP_PROXY_IO_01_065: [ When bytes are received and the response to the CONNECT request was not yet received, the bytes shall be accumulated until a double new-line is detected. ]*/
-            unsigned char* new_receive_buffer = (unsigned char*)realloc(http_proxy_io_instance->receive_buffer, http_proxy_io_instance->receive_buffer_size + size + 1);
+            unsigned char* new_receive_buffer = (unsigned char*)realloc(http_proxy_io_instance->receive_buffer, http_proxy_io_instance->receive_buffer_size + size);
             if (new_receive_buffer == NULL)
             {
                 /* Codes_SRS_HTTP_PROXY_IO_01_067: [ If allocating memory for the buffered bytes fails, the on_open_complete callback shall be triggered with IO_OPEN_ERROR, passing also the on_open_complete_context argument as context. ]*/
@@ -649,11 +649,8 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
             {
                 const char* request_end_ptr;
 
-                http_proxy_io_instance->receive_buffer[http_proxy_io_instance->receive_buffer_size] = 0;
-
                 /* Codes_SRS_HTTP_PROXY_IO_01_066: [ When a double new-line is detected the response shall be parsed in order to extract the status code. ]*/
-                if ((http_proxy_io_instance->receive_buffer_size >= 4) &&
-                    ((request_end_ptr = strstr((const char*)http_proxy_io_instance->receive_buffer, "\r\n\r\n")) != NULL))
+                if ((request_end_ptr = strstr((const char*)http_proxy_io_instance->receive_buffer, "\r\n\r\n")) != NULL)
                 {
                     int status_code;
 


### PR DESCRIPTION
While memory was allocated for buffer_size + size + 1, memcpy only copied up to buffer_size + size.

I would think writing 0 to the last position of the reallocated memory would be fine, but based on the reported details of the bug there was still a complaint:
"Buffer overrun while writing to 'http_proxy_io_instance->receive_buffer': **the writable size is 'http_proxy_io_instance->receive_buffer_size+size+1' bytes**, but 'http_proxy_io_instance->receive_buffer_size' bytes might be written."
