### PR TITLE
Fix for wolfssl failure to reconnect

### DIFF
--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -422,7 +422,7 @@ static int on_io_send(WOLFSSL *ssl, char *buf, int sz, void *context)
         LogError("Failed sending bytes through underlying IO");
         tls_io_instance->tlsio_state = TLSIO_STATE_ERROR;
         indicate_error(tls_io_instance);
-        result = 0;
+        result = -1;
     }
     else
     {

--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -422,7 +422,7 @@ static int on_io_send(WOLFSSL *ssl, char *buf, int sz, void *context)
         LogError("Failed sending bytes through underlying IO");
         tls_io_instance->tlsio_state = TLSIO_STATE_ERROR;
         indicate_error(tls_io_instance);
-        result = -1;
+        result = WOLFSSL_CBIO_ERR_WANT_WRITE;
     }
     else
     {

--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -422,7 +422,7 @@ static int on_io_send(WOLFSSL *ssl, char *buf, int sz, void *context)
         LogError("Failed sending bytes through underlying IO");
         tls_io_instance->tlsio_state = TLSIO_STATE_ERROR;
         indicate_error(tls_io_instance);
-        result = WOLFSSL_CBIO_ERR_WANT_WRITE;
+        result = WOLFSSL_CBIO_ERR_GENERAL;
     }
     else
     {


### PR DESCRIPTION
Address Issue [#1704](https://github.com/Azure/azure-iot-sdk-c/issues/1704) of the azure-iot-sdk-c.

`on_io_send` is registered to be the function called for `wolfssl_write()`. (See `tlsio_wolfssl.c`, `tlsio_wolfssl_create()`: `wolfSSL_SetIOSend(result->ssl_context, on_io_send);`)

From the wolfssl [sample](https://github.com/wolfSSL/wolfssl-examples/blob/master/embedded/tls-client-server.c) implementing a similar pattern, the correct return value is `WOLFSSL_CBIO_ERR_GENERAL` (which is -1); From this [sample](https://github.com/wolfSSL/wolfssl-examples/blob/master/custom-io-callbacks/file-server/file-server.c), we see the return value is based on the result of `write`, so on error the value returned needs to be negative, and not 0.  A return of 0 means nothing was written, and not that an actual error occurred. 

Please see issue [#1704](https://github.com/Azure/azure-iot-sdk-c/issues/1704) for instructions on how to reproduce the bug and test this fix.

