### PR TITLE
Upgrading the Raspberry PI image to use OpenSSL>1.0.2

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -50,15 +50,13 @@ jobs:
     condition: always()
 - job: raspberrypi
   variables:
-    _PREVIEW_VSTS_DOCKER_IMAGE: "aziotbld/raspberrypi-c"
+    _PREVIEW_VSTS_DOCKER_IMAGE: "aziotbld/raspberrypi-c-buster:brown"
   pool: aziotbld-lin01
   displayName: raspberrypi
   steps:
   - script: |
-     if [ -f "jenkins/raspberrypi_c.sh" ]
-     then
-      sudo ./jenkins/raspberrypi_c.sh
-     fi
+     chmod +x jenkins/raspberrypi_c_buster.sh
+     ./jenkins/raspberrypi_c_buster.sh
     displayName: 'build'
   - script: sudo rm -rf $(Agent.BuildDirectory)/*
     displayName: 'cleanup'

--- a/jenkins/raspberrypi_c_buster.sh
+++ b/jenkins/raspberrypi_c_buster.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# assume directory is root of downloaded repo
+mkdir cmake
+cd cmake
+ls -al
+
+# Create a cmake toolchain file on the fly
+echo "SET(CMAKE_SYSTEM_NAME Linux)     # this one is important" > toolchain.cmake
+echo "SET(CMAKE_SYSTEM_VERSION 1)      # this one not so much" >> toolchain.cmake
+
+echo "SET(CMAKE_C_COMPILER ${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-gcc)" >> toolchain.cmake
+echo "SET(CMAKE_CXX_COMPILER ${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-g++)" >> toolchain.cmake
+echo "SET(CMAKE_FIND_ROOT_PATH ${TOOLCHAIN_SYSROOT})" >> toolchain.cmake
+echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
+echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake
+echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> toolchain.cmake
+ls -al
+
+# Build the SDK. This will use the OpenSSL, cURL and uuid binaries that we built before
+cmake -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake -Duse_prov_client=OFF -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN_PREFIX} -Drun_e2e_tests=ON -Drun_unittests=ON ..
+make -j 2
+ls -al


### PR DESCRIPTION
Current RPI image is using OpenSSL 1.0.1. Minimum allowed for this LTS is now 1.0.2.