### PR TITLE
Fix for C SDK Issue segfault when using wolfSSL and MQTT/WS

### DIFF
--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -429,11 +429,15 @@ static int on_io_recv(WOLFSSL *ssl, char *buf, int sz, void *context)
         }
         else if ( (result == 0) && (tls_io_instance->tlsio_state == TLSIO_STATE_OPEN))
         {
-            if ( wolfSSL_get_state(tls_io_instance->ssl) >= 8) // SERVER_HELLODONE_COMPLETE
+#ifdef HAVE_SECURE_RENEGOTIATION
+            if (wolfSSL_SSL_renegotiate_pending(tls_io_instance->ssl) == 0) // SERVER_HELLODONE_COMPLETE
             {
                 result = WOLFSSL_CBIO_ERR_WANT_READ;
             }
-            // Otherwise if Server Hello not complete during renegotiation, do not return error.
+            // If Server Hello not complete during renegotiation, do not return error.
+#else
+            result = WOLFSSL_CBIO_ERR_WANT_READ;
+#endif
         }
         else if ((result == 0) && (tls_io_instance->tlsio_state == TLSIO_STATE_CLOSING || tls_io_instance->tlsio_state == TLSIO_STATE_NOT_OPEN))
         {
@@ -933,7 +937,7 @@ static int process_option(char** destination, const char* name, const char* valu
 {
 
     (void) name;
-    
+
     int result;
     if (*destination != NULL)
     {

--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -567,7 +567,7 @@ static int create_wolfssl_instance(TLS_IO_INSTANCE* tls_io_instance)
         result = 0;
 
 #ifdef HAVE_SECURE_RENEGOTIATION
-        if(wolfSSL_UseSecureRenegotiation(tls_io_instance->ssl) != SSL_SUCCESS)
+        if (wolfSSL_UseSecureRenegotiation(tls_io_instance->ssl) != SSL_SUCCESS)
         {
             LogError("unable to enable secure renegotiation");
             result = MU_FAILURE;
@@ -903,8 +903,8 @@ int tlsio_wolfssl_send(CONCRETE_IO_HANDLE tls_io, const void* buffer, size_t siz
             }
 
             // remove on send complete and callback context
-            memset((void*)&tls_io_instance->on_send_complete, 0, sizeof(tls_io_instance->on_send_complete));
-            memset((void*)&tls_io_instance->on_send_complete_callback_context, 0, sizeof(tls_io_instance->on_send_complete_callback_context));
+            tls_io_instance->on_send_complete = NULL;
+            tls_io_instance->on_send_complete_callback_context = NULL;
         }
     }
 

--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -429,11 +429,11 @@ static int on_io_recv(WOLFSSL *ssl, char *buf, int sz, void *context)
         }
         else if ( (result == 0) && (tls_io_instance->tlsio_state == TLSIO_STATE_OPEN))
         {
-            // Othersie if Server Hello not complete during renegotiation, do not return error.
             if ( wolfSSL_get_state(tls_io_instance->ssl) >= 8) // SERVER_HELLODONE_COMPLETE
             {
                 result = WOLFSSL_CBIO_ERR_WANT_READ;
             }
+            // Otherwise if Server Hello not complete during renegotiation, do not return error.
         }
         else if ((result == 0) && (tls_io_instance->tlsio_state == TLSIO_STATE_CLOSING || tls_io_instance->tlsio_state == TLSIO_STATE_NOT_OPEN))
         {

--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -476,7 +476,7 @@ static int on_handshake_done(WOLFSSL* ssl, void* context)
     if (tls_io_instance->tlsio_state != TLSIO_STATE_IN_HANDSHAKE &&
         tls_io_instance->tlsio_state != TLSIO_STATE_OPEN) //Renegotiation
     {
-        LogInfo("on_handshake_done called when not in IN_HANDSHAKE state");
+        LogInfo("on_handshake_done called in wrong state: %d", tls_io_instance->tlsio_state);
     }
     else if (tls_io_instance->tlsio_state == TLSIO_STATE_IN_HANDSHAKE) // Do not do if in renegotiation
     {


### PR DESCRIPTION
This is a fix for C SDK Issue #1759 [https://github.com/Azure/azure-iot-sdk-c/issues/1759].

It involves two fixes:
1) Addresses the segfault using wolfSSL and MQTT/WS.  A callback was not reset to NULL and was mistakenly being called resulting in the segfault. (It should only be called on application data).
2) Updates logic to not return WANT_READ during renegotiation when waiting to receive CONNACK.

This change requires https://github.com/wolfSSL/wolfssl/pull/3594 to be merged, and the following wolfSSL release to be used. (v4.7.0 to be released mid-February)
Assuming this has occurred, wolfSSL must be configured with --enable-secure-renegotiation.

Enabling secure renegotiation does not obstruct using MQTT or AMQP.  It DOES enable MQTT/WS and AMQP/WS.
