### PR TITLE
Proxy use-case fixed for wolfSSL

### DIFF
--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -768,7 +768,7 @@ void tlsio_wolfssl_destroy(CONCRETE_IO_HANDLE tls_io)
 
 int tlsio_wolfssl_open(CONCRETE_IO_HANDLE tls_io, ON_IO_OPEN_COMPLETE on_io_open_complete, void* on_io_open_complete_context, ON_BYTES_RECEIVED on_bytes_received, void* on_bytes_received_context, ON_IO_ERROR on_io_error, void* on_io_error_context)
 {
-    int result = 0;
+    int result;
 
     if (tls_io == NULL)
     {
@@ -808,6 +808,10 @@ int tlsio_wolfssl_open(CONCRETE_IO_HANDLE tls_io, ON_IO_OPEN_COMPLETE on_io_open
                 LogError("Cannot open the underlying IO.");
                 tls_io_instance->tlsio_state = TLSIO_STATE_NOT_OPEN;
                 result = MU_FAILURE;
+            }
+            else
+            {
+                result = 0;
             }
         }
     }

--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -911,16 +911,14 @@ void tlsio_wolfssl_dowork(CONCRETE_IO_HANDLE tls_io)
     else
     {
         TLS_IO_INSTANCE* tls_io_instance = (TLS_IO_INSTANCE*)tls_io;
-
-        if ((tls_io_instance->tlsio_state != TLSIO_STATE_NOT_OPEN) &&
-            (tls_io_instance->tlsio_state != TLSIO_STATE_ERROR))
+        if (tls_io_instance->tlsio_state == TLSIO_STATE_IN_HANDSHAKE ||
+            tls_io_instance->tlsio_state == TLSIO_STATE_OPEN ||
+            tls_io_instance->tlsio_state == TLSIO_STATE_CLOSING)
         {
-            if (tls_io_instance->tlsio_state != TLSIO_STATE_OPENING_UNDERLYING_IO) //Proxy used
-            {
-                decode_ssl_received_bytes(tls_io_instance);
-            }
-            xio_dowork(tls_io_instance->socket_io);
+            decode_ssl_received_bytes(tls_io_instance);
         }
+
+        xio_dowork(tls_io_instance->socket_io);
     }
 }
 


### PR DESCRIPTION
This fixes the issue reported in https://github.com/Azure/azure-iot-sdk-c/issues/1842

I have tested this with and without a proxy, for all 4 working protocols. MQTT, MQTT/WS, AMQP, AMQP/WS.  HTTP is not working currently and already has an issue filed for it.