### PR TITLE
fix printing data not in buffer

### DIFF
--- a/src/xlogging.c
+++ b/src/xlogging.c
@@ -90,6 +90,9 @@ void LogBinary(const char* comment, const void* data, size_t size)
     {
         /* Close the charBuf string. */
         charBuf[countbuf] = '\0';
+        hexBuf[countbuf * 3] = ' ';
+        hexBuf[countbuf * 3 + 1] = ' ';
+        hexBuf[countbuf * 3 + 2] = ' ';
 
         /* Fill the hexBuf with spaces to keep the charBuf alignment. */
         while ((countbuf++) < LINE_SIZE - 1)


### PR DESCRIPTION
closes #458 

Before:

```c
uint8_t data[] = {
        0x7d, 0xce, 0xb1, 0x62, 0x39, 0xf8, 0x3c, 0xd5, 0x9a, 0xad, 0x9e, 0x05,
        0xb1, 0x4f, 0x70, 0xa2, 0xfa, 0xd4, 0xfb, 0x04, 0xe5, 0x37, 0xd2, 0x63,
        0x9a, 0x46, 0x9e, 0xfd, 0xb0, 0x5b, 0x1e, 0xdf, 0xff };
```
Output:
```bash
33 bytes
0x55555580f020: 7D CE B1 62 39 F8 3C D5 9A AD 9E 05 B1 4F 70 A2     }..b9.<......Op.
0x55555580f030: FA D4 FB 04 E5 37 D2 63 9A 46 9E FD B0 5B 1E DF     .....7.c.F...[..
0x55555580f040: FF D4 
```

After:
```c
uint8_t data[] = {
        0x7d, 0xce, 0xb1, 0x62, 0x39, 0xf8, 0x3c, 0xd5, 0x9a, 0xad, 0x9e, 0x05,
        0xb1, 0x4f, 0x70, 0xa2, 0xfa, 0xd4, 0xfb, 0x04, 0xe5, 0x37, 0xd2, 0x63,
        0x9a, 0x46, 0x9e, 0xfd, 0xb0, 0x5b, 0x1e, 0xdf, 0xff };
```
Output:
```bash
33 bytes
0x55555580f020: 7D CE B1 62 39 F8 3C D5 9A AD 9E 05 B1 4F 70 A2     }..b9.<......Op.
0x55555580f030: FA D4 FB 04 E5 37 D2 63 9A 46 9E FD B0 5B 1E DF     .....7.c.F...[..
0x55555580f040: FF
```
