### PR TITLE
OpenSSL IP Address SAN validation support

### DIFF
--- a/adapters/platform_linux.c
+++ b/adapters/platform_linux.c
@@ -42,6 +42,11 @@ int platform_init(void)
     {
         result = tlsio_openssl_init();
     }
+#elif USE_WOLFSSL
+    if (result == 0)
+    {
+        result = tlsio_wolfssl_init();
+    }
 #endif
     return result;
 }
@@ -91,5 +96,7 @@ void platform_deinit(void)
 #endif /* DONT_USE_UPLOADTOBLOB */
 #ifdef USE_OPENSSL
     tlsio_openssl_deinit();
+#elif USE_WOLFSSL
+    tlsio_wolfssl_deinit();
 #endif
 }

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -1022,8 +1022,8 @@ static int enable_domain_check(TLS_IO_INSTANCE* tlsInstance)
         X509_VERIFY_PARAM *param = SSL_get0_param(tlsInstance->ssl);
 
         X509_VERIFY_PARAM_set_hostflags(param, 0);
-        if ((!X509_VERIFY_PARAM_set1_ip_asc(param, tlsInstance->hostname) ||
-            (!X509_VERIFY_PARAM_set1_host(param, tlsInstance->hostname, strlen(tlsInstance->hostname)))))
+        if (!(X509_VERIFY_PARAM_set1_ip_asc(param, tlsInstance->hostname) ||
+              X509_VERIFY_PARAM_set1_host(param, tlsInstance->hostname, strlen(tlsInstance->hostname))))
         {
             result = MU_FAILURE;
         }

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -1022,8 +1022,8 @@ static int enable_domain_check(TLS_IO_INSTANCE* tlsInstance)
         X509_VERIFY_PARAM *param = SSL_get0_param(tlsInstance->ssl);
 
         X509_VERIFY_PARAM_set_hostflags(param, 0);
-        if (!(X509_VERIFY_PARAM_set1_ip_asc(param, tlsInstance->hostname) ||
-              X509_VERIFY_PARAM_set1_host(param, tlsInstance->hostname, strlen(tlsInstance->hostname))))
+        if ((!X509_VERIFY_PARAM_set1_ip_asc(param, tlsInstance->hostname) ||
+            (!X509_VERIFY_PARAM_set1_host(param, tlsInstance->hostname, strlen(tlsInstance->hostname)))))
         {
             result = MU_FAILURE;
         }

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -1022,7 +1022,8 @@ static int enable_domain_check(TLS_IO_INSTANCE* tlsInstance)
         X509_VERIFY_PARAM *param = SSL_get0_param(tlsInstance->ssl);
 
         X509_VERIFY_PARAM_set_hostflags(param, 0);
-        if (!X509_VERIFY_PARAM_set1_host(param, tlsInstance->hostname, strlen(tlsInstance->hostname)))
+        if (!(X509_VERIFY_PARAM_set1_ip_asc(param, tlsInstance->hostname) ||
+              X509_VERIFY_PARAM_set1_host(param, tlsInstance->hostname, strlen(tlsInstance->hostname))))
         {
             result = MU_FAILURE;
         }

--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -626,7 +626,6 @@ int tlsio_wolfssl_init(void)
 {
     (void)wolfSSL_library_init();
     wolfSSL_load_error_strings();
-
     return 0;
 }
 
@@ -946,6 +945,18 @@ static int process_option(char** destination, const char* name, const char* valu
     return result;
 }
 
+static void logging_callback(const int logLevel, const char *const logMessage)
+{
+    if (logLevel == ERROR_LOG)
+    {
+        LogError("tlsio_wolfssl: %s", logMessage);
+    }
+    else
+    {
+        LogInfo("tlsio_wolfssl: %s", logMessage);
+    }
+}
+
 int tlsio_wolfssl_setoption(CONCRETE_IO_HANDLE tls_io, const char* optionName, const void* value)
 {
     int result;
@@ -997,6 +1008,12 @@ int tlsio_wolfssl_setoption(CONCRETE_IO_HANDLE tls_io, const char* optionName, c
         {
             bool* server_name_check = (bool*)value;
             tls_io_instance->ignore_host_name_check = *server_name_check;
+            result = 0;
+        }
+        else if (strcmp("debugLog", optionName) == 0)
+        {
+            (void)wolfSSL_Debugging_ON();
+            (void)wolfSSL_SetLoggingCb(&logging_callback);
             result = 0;
         }
         else

--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -1018,21 +1018,20 @@ int tlsio_wolfssl_setoption(CONCRETE_IO_HANDLE tls_io, const char* optionName, c
             bool* enable_debug_logging = (bool*)value;
             if (enable_debug_logging)
             {
-
-            }
-            if (!wolfSSL_Debugging_ON())
-            {
-                LogError("wolfSSL_Debugging_ON failed.");
-                result = MU_FAILURE;
-            }
-            else if (!wolfSSL_SetLoggingCb(&logging_callback))
-            {
-                LogError("wolfSSL_SetLoggingCb failed.");
-                result = MU_FAILURE;
-            }
-            else
-            {
-                result = 0;
+                if (!wolfSSL_Debugging_ON())
+                {
+                    LogError("wolfSSL_Debugging_ON failed.");
+                    result = MU_FAILURE;
+                }
+                else if (!wolfSSL_SetLoggingCb(&logging_callback))
+                {
+                    LogError("wolfSSL_SetLoggingCb failed.");
+                    result = MU_FAILURE;
+                }
+                else
+                {
+                    result = 0;
+                }
             }
         }
 #endif // LIBWOLFSSL_VERSION_HEX >= 0x04000000

--- a/inc/azure_c_shared_utility/tlsio_wolfssl.h
+++ b/inc/azure_c_shared_utility/tlsio_wolfssl.h
@@ -18,6 +18,9 @@ extern "C" {
 
 extern const char* const OPTION_WOLFSSL_SET_DEVICE_ID;
 
+MOCKABLE_FUNCTION(, int, tlsio_wolfssl_init);
+MOCKABLE_FUNCTION(, void, tlsio_wolfssl_deinit);
+
 MOCKABLE_FUNCTION(, CONCRETE_IO_HANDLE, tlsio_wolfssl_create, void*, io_create_parameters);
 MOCKABLE_FUNCTION(, void, tlsio_wolfssl_destroy, CONCRETE_IO_HANDLE, tls_io);
 MOCKABLE_FUNCTION(, int, tlsio_wolfssl_open, CONCRETE_IO_HANDLE, tls_io, ON_IO_OPEN_COMPLETE, on_io_open_complete, void*, on_io_open_complete_context, ON_BYTES_RECEIVED, on_bytes_received, void*, on_bytes_received_context, ON_IO_ERROR, on_io_error, void*, on_io_error_context);

--- a/tests/tlsio_wolfssl_ut/tlsio_wolfssl_ut.c
+++ b/tests/tlsio_wolfssl_ut/tlsio_wolfssl_ut.c
@@ -135,11 +135,13 @@ MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_get_error, WOLFSSL*, ssl, int,
 MOCK_FUNCTION_END(SSL_SUCCESS)
 MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_check_domain_name, WOLFSSL*, ssl, const char*, dn)
 MOCK_FUNCTION_END(SSL_SUCCESS)
+
+#if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX >= 0x04000000
 MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_Debugging_ON)
 MOCK_FUNCTION_END(SSL_SUCCESS)
 MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_SetLoggingCb, wolfSSL_Logging_cb, log_function)
 MOCK_FUNCTION_END(SSL_SUCCESS)
-
+#endif
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
@@ -202,7 +204,9 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_UMOCK_ALIAS_TYPE(CONCRETE_IO_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(XIO_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(CallbackIORecv, void*);
+#if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX >= 0x04000000
     REGISTER_UMOCK_ALIAS_TYPE(wolfSSL_Logging_cb, void*);
+#endif
     REGISTER_UMOCK_ALIAS_TYPE(HandShakeDoneCb, void*);
     REGISTER_UMOCK_ALIAS_TYPE(ON_IO_OPEN_COMPLETE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(ON_BYTES_RECEIVED, void*);
@@ -812,6 +816,7 @@ TEST_FUNCTION(tlsio_wolfssl_setoption_device_id_fail)
 }
 #endif
 
+#if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX >= 0x04000000
 TEST_FUNCTION(tlsio_wolfssl_setoption_debug_log_succeed)
 {
     //arrange
@@ -834,6 +839,7 @@ TEST_FUNCTION(tlsio_wolfssl_setoption_debug_log_succeed)
     //clean
     tlsio_wolfssl_destroy(io_handle);
 }
+#endif
 
 TEST_FUNCTION(tlsio_wolfssl_on_underlying_io_bytes_received_ctx_NULL_succeess)
 {

--- a/tests/tlsio_wolfssl_ut/tlsio_wolfssl_ut.c
+++ b/tests/tlsio_wolfssl_ut/tlsio_wolfssl_ut.c
@@ -135,6 +135,15 @@ MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_get_error, WOLFSSL*, ssl, int,
 MOCK_FUNCTION_END(SSL_SUCCESS)
 MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_check_domain_name, WOLFSSL*, ssl, const char*, dn)
 MOCK_FUNCTION_END(SSL_SUCCESS)
+MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_Debugging_ON)
+MOCK_FUNCTION_END(SSL_SUCCESS)
+
+typedef void (*wolfSSL_Logging_cb)(const int logLevel,
+                                   const char *const logMessage);
+
+MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_SetLoggingCb, wolfSSL_Logging_cb, log_function)
+MOCK_FUNCTION_END(SSL_SUCCESS)
+
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 


### PR DESCRIPTION
- Adding IP Address SAN list support.
- Properly initializing WolfSSL.
- Adding WolfSSL debug logging set-option (requires WolfSSL `--enable-debug` configured binary)
