### PR TITLE
Fix for crash in case AddOptionInternal fails adding xio CONCRETE_OPTIONS

### DIFF
--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -106,6 +106,7 @@ static void* tlsio_openssl_CloneOption(const char* name, const void* value)
     {
         if (strcmp(name, OPTION_UNDERLYING_IO_OPTIONS) == 0)
         {
+            //result = (void*)OptionHandler_Clone((OPTIONHANDLER_HANDLE)value);
             result = (void*)value;
         }
         else if (strcmp(name, OPTION_TRUSTED_CERT) == 0)

--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -38,9 +38,9 @@ typedef enum TLSIO_STATE_TAG
 
 typedef enum TLSIO_VERSION_TAG
 {
-    VERSION_1_0,
-    VERSION_1_1,
-    VERSION_1_2,
+    VERSION_1_0 = 10,
+    VERSION_1_1 = 11,
+    VERSION_1_2 = 12,
 } TLSIO_VERSION;
 
 static bool is_an_opening_state(TLSIO_STATE state)
@@ -106,8 +106,7 @@ static void* tlsio_openssl_CloneOption(const char* name, const void* value)
     {
         if (strcmp(name, OPTION_UNDERLYING_IO_OPTIONS) == 0)
         {
-            //result = (void*)OptionHandler_Clone((OPTIONHANDLER_HANDLE)value);
-            result = (void*)value;
+            result = (void*)OptionHandler_Clone((OPTIONHANDLER_HANDLE)value);
         }
         else if (strcmp(name, OPTION_TRUSTED_CERT) == 0)
         {
@@ -333,96 +332,106 @@ static OPTIONHANDLER_HANDLE tlsio_openssl_retrieveoptions(CONCRETE_IO_HANDLE han
             TLS_IO_INSTANCE* tls_io_instance = (TLS_IO_INSTANCE*)handle;
             OPTIONHANDLER_HANDLE underlying_io_options;
 
-            if ((underlying_io_options = xio_retrieveoptions(tls_io_instance->underlying_io)) == NULL ||
-                OptionHandler_AddOption(result, OPTION_UNDERLYING_IO_OPTIONS, underlying_io_options) != OPTIONHANDLER_OK)
+            if ((underlying_io_options = xio_retrieveoptions(tls_io_instance->underlying_io)) == NULL)
             {
-                LogError("unable to save underlying_io options");
-                OptionHandler_Destroy(underlying_io_options);
+                LogError("unable to retrieve underlying_io options");
                 OptionHandler_Destroy(result);
                 result = NULL;
             }
-            else if (
-                (tls_io_instance->certificate != NULL) &&
-                (OptionHandler_AddOption(result, OPTION_TRUSTED_CERT, tls_io_instance->certificate) != OPTIONHANDLER_OK)
-                )
+            else
             {
-                LogError("unable to save TrustedCerts option");
-                OptionHandler_Destroy(result);
-                result = NULL;
-            }
-            else if (
-                (tls_io_instance->cipher_list != NULL) &&
-                (OptionHandler_AddOption(result, OPTION_OPENSSL_CIPHER_SUITE, tls_io_instance->cipher_list) != OPTIONHANDLER_OK)
-                )
-            {
-                LogError("unable to save CipherSuite option");
-                OptionHandler_Destroy(result);
-                result = NULL;
-            }
-            else if (tls_io_instance->x509_certificate != NULL && (OptionHandler_AddOption(result, SU_OPTION_X509_CERT, tls_io_instance->x509_certificate) != OPTIONHANDLER_OK) )
-            {
-                LogError("unable to save x509 certificate option");
-                OptionHandler_Destroy(result);
-                result = NULL;
-            }
-            else if (tls_io_instance->x509_private_key != NULL && (OptionHandler_AddOption(result, SU_OPTION_X509_PRIVATE_KEY, tls_io_instance->x509_private_key) != OPTIONHANDLER_OK) )
-            {
-                LogError("unable to save x509 privatekey option");
-                OptionHandler_Destroy(result);
-                result = NULL;
-            }
-            else if (tls_io_instance->tls_version != 0 && (OptionHandler_AddOption(result, OPTION_TLS_VERSION, &tls_io_instance->tls_version) != OPTIONHANDLER_OK) )
-            {
-                LogError("unable to save tls_version option");
-                OptionHandler_Destroy(result);
-                result = NULL;
-            }
-            else if (
-                (tls_io_instance->engine_id != NULL) &&
-                (OptionHandler_AddOption(result, OPTION_OPENSSL_ENGINE, tls_io_instance->engine_id) != OPTIONHANDLER_OK)
-                )
-            {
-                LogError("unable to save Engine option");
-                OptionHandler_Destroy(result);
-                result = NULL;
-            }
-            else if (
-                (tls_io_instance->x509_private_key_type != KEY_TYPE_DEFAULT) &&
-                (OptionHandler_AddOption(result, OPTION_OPENSSL_PRIVATE_KEY_TYPE, &tls_io_instance->x509_private_key_type))
-                )
-            {
-                LogError("unable to save x509PrivatekeyType option");
-                OptionHandler_Destroy(result);
-                result = NULL;
-            }
-            else if (tls_io_instance->tls_validation_callback != NULL)
-            {
+                if (OptionHandler_AddOption(result, OPTION_UNDERLYING_IO_OPTIONS, underlying_io_options) != OPTIONHANDLER_OK)
+                {
+                    LogError("unable to save underlying_io options");
+                    OptionHandler_Destroy(result);
+                    result = NULL;
+                }
+                else if (
+                    (tls_io_instance->certificate != NULL) &&
+                    (OptionHandler_AddOption(result, OPTION_TRUSTED_CERT, tls_io_instance->certificate) != OPTIONHANDLER_OK)
+                    )
+                {
+                    LogError("unable to save TrustedCerts option");
+                    OptionHandler_Destroy(result);
+                    result = NULL;
+                }
+                else if (
+                    (tls_io_instance->cipher_list != NULL) &&
+                    (OptionHandler_AddOption(result, OPTION_OPENSSL_CIPHER_SUITE, tls_io_instance->cipher_list) != OPTIONHANDLER_OK)
+                    )
+                {
+                    LogError("unable to save CipherSuite option");
+                    OptionHandler_Destroy(result);
+                    result = NULL;
+                }
+                else if (tls_io_instance->x509_certificate != NULL && (OptionHandler_AddOption(result, SU_OPTION_X509_CERT, tls_io_instance->x509_certificate) != OPTIONHANDLER_OK) )
+                {
+                    LogError("unable to save x509 certificate option");
+                    OptionHandler_Destroy(result);
+                    result = NULL;
+                }
+                else if (tls_io_instance->x509_private_key != NULL && (OptionHandler_AddOption(result, SU_OPTION_X509_PRIVATE_KEY, tls_io_instance->x509_private_key) != OPTIONHANDLER_OK) )
+                {
+                    LogError("unable to save x509 privatekey option");
+                    OptionHandler_Destroy(result);
+                    result = NULL;
+                }
+                else if (tls_io_instance->tls_version != 0 && (OptionHandler_AddOption(result, OPTION_TLS_VERSION, &tls_io_instance->tls_version) != OPTIONHANDLER_OK) )
+                {
+                    LogError("unable to save tls_version option");
+                    OptionHandler_Destroy(result);
+                    result = NULL;
+                }
+                else if (
+                    (tls_io_instance->engine_id != NULL) &&
+                    (OptionHandler_AddOption(result, OPTION_OPENSSL_ENGINE, tls_io_instance->engine_id) != OPTIONHANDLER_OK)
+                    )
+                {
+                    LogError("unable to save Engine option");
+                    OptionHandler_Destroy(result);
+                    result = NULL;
+                }
+                else if (
+                    (tls_io_instance->x509_private_key_type != KEY_TYPE_DEFAULT) &&
+                    (OptionHandler_AddOption(result, OPTION_OPENSSL_PRIVATE_KEY_TYPE, &tls_io_instance->x509_private_key_type))
+                    )
+                {
+                    LogError("unable to save x509PrivatekeyType option");
+                    OptionHandler_Destroy(result);
+                    result = NULL;
+                }
+                else if (tls_io_instance->tls_validation_callback != NULL)
+                {
 #ifdef WIN32
 #pragma warning(push)
 #pragma warning(disable:4152)
 #endif
-                void* ptr = tls_io_instance->tls_validation_callback;
+                    void* ptr = tls_io_instance->tls_validation_callback;
 #ifdef WIN32
 #pragma warning(pop)
 #endif
-                if (OptionHandler_AddOption(result, "tls_validation_callback", (const char*)ptr) != OPTIONHANDLER_OK)
+                    if (OptionHandler_AddOption(result, "tls_validation_callback", (const char*)ptr) != OPTIONHANDLER_OK)
+                    {
+                        LogError("unable to save tls_validation_callback option");
+                        OptionHandler_Destroy(result);
+                        result = NULL;
+                    }
+
+                    if (OptionHandler_AddOption(result, "tls_validation_callback_data", (const char*)tls_io_instance->tls_validation_callback_data) != OPTIONHANDLER_OK)
+                    {
+                        LogError("unable to save tls_validation_callback_data option");
+                        OptionHandler_Destroy(result);
+                        result = NULL;
+                    }
+                }
+                else
                 {
-                    LogError("unable to save tls_validation_callback option");
-                    OptionHandler_Destroy(result);
-                    result = NULL;
+                    /*all is fine, all interesting options have been saved*/
+                    /*return as is*/
                 }
 
-                if (OptionHandler_AddOption(result, "tls_validation_callback_data", (const char*)tls_io_instance->tls_validation_callback_data) != OPTIONHANDLER_OK)
-                {
-                    LogError("unable to save tls_validation_callback_data option");
-                    OptionHandler_Destroy(result);
-                    result = NULL;
-                }
-            }
-            else
-            {
-                /*all is fine, all interesting options have been saved*/
-                /*return as is*/
+                // Must destroy since OptionHandler_AddOption creates a copy of it. 
+                OptionHandler_Destroy(underlying_io_options); 
             }
         }
     }

--- a/src/xio.c
+++ b/src/xio.c
@@ -285,7 +285,6 @@ OPTIONHANDLER_HANDLE xio_retrieveoptions(XIO_HANDLE xio)
                 if (OptionHandler_AddOption(result, CONCRETE_OPTIONS, concreteOptions) != OPTIONHANDLER_OK)
                 {
                     LogError("unable to OptionHandler_AddOption");
-                    OptionHandler_Destroy(concreteOptions);
                     OptionHandler_Destroy(result);
                     result = NULL;
                 }
@@ -293,6 +292,9 @@ OPTIONHANDLER_HANDLE xio_retrieveoptions(XIO_HANDLE xio)
                 {
                     /*all is fine*/
                 }
+                
+                // Must destroy since OptionHandler_AddOption creates a copy of it.
+                OptionHandler_Destroy(concreteOptions);
             }
         }
     }

--- a/src/xio.c
+++ b/src/xio.c
@@ -218,7 +218,7 @@ static void* xio_CloneOption(const char* name, const void* value)
     {
         if (strcmp(name, CONCRETE_OPTIONS) == 0)
         {
-            result = (void*)value;
+            result = (void*)OptionHandler_Clone((OPTIONHANDLER_HANDLE)value);
         }
         else
         {


### PR DESCRIPTION
This crash occurs for the following callstack:

==31911== Invalid read of size 8
==31911==    at 0x144C04: DestroyInternal (optionhandler.c:111)
==31911==    by 0x14517F: OptionHandler_Destroy (optionhandler.c:278)
==31911==    by 0x144958: xio_retrieveoptions (xio.c:288)
==31911==    by 0x140395: tlsio_openssl_retrieveoptions (tlsio_openssl.c:335)
==31911==    by 0x14488B: xio_retrieveoptions (xio.c:276)
==31911==    by 0x14F12C: ResetConnectionIfNecessary (iothubtransport_mqtt_common.c:1977)
==31911==    by 0x15074B: UpdateMqttConnectionStateIfNeeded (iothubtransport_mqtt_common.c:2585)
==31911==    by 0x15290C: IoTHubTransport_MQTT_Common_DoWork (iothubtransport_mqtt_common.c:3474)
==31911==    by 0x14AD63: IoTHubTransportMqtt_DoWork (iothubtransportmqtt.c:121)
==31911==    by 0x11DD46: IoTHubClientCore_LL_DoWork (iothub_client_core_ll.c:2123)
==31911==    by 0x128F92: ScheduleWork_Thread (iothub_client_core.c:813)
==31911==    by 0x1397D0: ThreadWrapper (threadapi_pthreads.c:35)
==31911==  Address 0x6097008 is 24 bytes inside a block of size 32 free'd
==31911==    at 0x48369AB: free (vg_replace_malloc.c:530)
==31911==    by 0x144C98: DestroyInternal (optionhandler.c:123)
==31911==    by 0x14517F: OptionHandler_Destroy (optionhandler.c:278)
==31911==    by 0x14473A: xio_DestroyOption (xio.c:246)
==31911==    by 0x144BD0: AddOptionInternal (optionhandler.c:91)
==31911==    by 0x144FA6: OptionHandler_AddOption (optionhandler.c:219)
==31911==    by 0x144907: xio_retrieveoptions (xio.c:285)
==31911==    by 0x140395: tlsio_openssl_retrieveoptions (tlsio_openssl.c:335)
==31911==    by 0x14488B: xio_retrieveoptions (xio.c:276)
==31911==    by 0x14F12C: ResetConnectionIfNecessary (iothubtransport_mqtt_common.c:1977)
==31911==    by 0x15074B: UpdateMqttConnectionStateIfNeeded (iothubtransport_mqtt_common.c:2585)
==31911==    by 0x15290C: IoTHubTransport_MQTT_Common_DoWork (iothubtransport_mqtt_common.c:3474)
==31911==  Block was alloc'd at
==31911==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==31911==    by 0x144990: CreateInternal (optionhandler.c:28)
==31911==    by 0x144D37: OptionHandler_Create (optionhandler.c:142)
==31911==    by 0x14543E: socketio_retrieveoptions (socketio_berkeley.c:178)
==31911==    by 0x14488B: xio_retrieveoptions (xio.c:276)
==31911==    by 0x140395: tlsio_openssl_retrieveoptions (tlsio_openssl.c:335)
==31911==    by 0x14488B: xio_retrieveoptions (xio.c:276)
==31911==    by 0x14F12C: ResetConnectionIfNecessary (iothubtransport_mqtt_common.c:1977)
==31911==    by 0x15074B: UpdateMqttConnectionStateIfNeeded (iothubtransport_mqtt_common.c:2585)
==31911==    by 0x15290C: IoTHubTransport_MQTT_Common_DoWork (iothubtransport_mqtt_common.c:3474)
==31911==    by 0x14AD63: IoTHubTransportMqtt_DoWork (iothubtransportmqtt.c:121)
==31911==    by 0x11DD46: IoTHubClientCore_LL_DoWork (iothub_client_core_ll.c:2123)