### PR TITLE
hmac.c: fix mismatching function prototype

### DIFF
--- a/src/hmac.c
+++ b/src/hmac.c
@@ -208,7 +208,7 @@ int hmacFinalBits(HMACContext *ctx,
 *   sha Error Code.
 *
 */
-int hmacResult(HMACContext *ctx, uint8_t *digest)
+int hmacResult(HMACContext *ctx, uint8_t digest[USHAMaxHashSize])
 {
     if (!ctx) return shaNull;
 


### PR DESCRIPTION
The reported function raises a warning when compilers assert the flag
`-Warray-parameter=`, signaling that an array-type argument was promoted
to a pointer-type argument.

While in practice in most C implementations this is correct, fixing the
warning (and, in this case, indicating the maximum size for the array)
would represent a best-practice for finding out-of-bound accesses or
identifying wrongly-sized arrays passed in the function.

Signed-off-by: Francesco Giancane <francesco.giancane@accenture.com>