### PR TITLE
fix memory leak mbedtls + curl

### DIFF
--- a/adapters/httpapi_curl.c
+++ b/adapters/httpapi_curl.c
@@ -297,6 +297,10 @@ static CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr)
             result = CURLE_SSL_CERTPROBLEM;
         }
 #elif USE_MBEDTLS
+        
+        // save ssl context
+        httpHandleData->config = *((mbedtls_ssl_config*)ssl_ctx);
+         
         // set device cert and key
         if (
             (httpHandleData->x509certificate != NULL) && (httpHandleData->x509privatekey != NULL) &&
@@ -333,10 +337,6 @@ static CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr)
 #endif
         else
         {
-
-#if USE_MBEDTLS
-            httpHandleData->config = *((mbedtls_ssl_config*)ssl_ctx);
-#endif
             result = CURLE_OK;
         }
     }

--- a/adapters/httpapi_curl.c
+++ b/adapters/httpapi_curl.c
@@ -333,7 +333,10 @@ static CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr)
 #endif
         else
         {
-        	httpHandleData->config = *((mbedtls_ssl_config*)ssl_ctx);
+
+#if USE_MBEDTLS
+            httpHandleData->config = *((mbedtls_ssl_config*)ssl_ctx);
+#endif
             result = CURLE_OK;
         }
     }

--- a/adapters/httpapi_curl.c
+++ b/adapters/httpapi_curl.c
@@ -48,6 +48,7 @@ typedef struct HTTP_HANDLE_DATA_TAG
     mbedtls_x509_crt cert;
     mbedtls_pk_context key;
     mbedtls_x509_crt trusted_certificates;
+    mbedtls_ssl_config config;
 #endif
 } HTTP_HANDLE_DATA;
 
@@ -148,6 +149,7 @@ HTTP_HANDLE HTTPAPI_CreateConnection(const char* hostName)
                         mbedtls_x509_crt_init(&httpHandleData->cert);
                         mbedtls_pk_init(&httpHandleData->key);
                         mbedtls_x509_crt_init(&httpHandleData->trusted_certificates);
+                        mbedtls_ssl_config_init(&httpHandleData->config);
 #endif
                     }
                 }
@@ -175,6 +177,7 @@ void HTTPAPI_CloseConnection(HTTP_HANDLE handle)
         mbedtls_x509_crt_free(&httpHandleData->cert);
         mbedtls_pk_free(&httpHandleData->key);
         mbedtls_x509_crt_free(&httpHandleData->trusted_certificates);
+        mbedtls_ssl_config_free( &httpHandleData->config);
 #endif
         free(httpHandleData);
     }
@@ -330,6 +333,7 @@ static CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr)
 #endif
         else
         {
+        	httpHandleData->config = *((mbedtls_ssl_config*)ssl_ctx);
             result = CURLE_OK;
         }
     }


### PR DESCRIPTION
This pull request fixes a potential memory leak when using curl with mbedlts

````
==32503== HEAP SUMMARY:
==32503==     in use at exit: 1,014 bytes in 3 blocks
==32503==   total heap usage: 33,097 allocs, 33,094 frees, 3,034,693 bytes allocated
==32503== 
==32503== 24 bytes in 1 blocks are definitely lost in loss record 1 of 3
==32503==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==32503==    by 0x4912B4B: ??? (in /usr/lib/x86_64-linux-gnu/libmbedtls.so.2.16.3)
==32503==    by 0x1BDB58: ssl_ctx_callback (httpapi_curl.c:303)
==32503==    by 0x48D5B89: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==32503==    by 0x48D713E: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==32503==    by 0x48D7FAE: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==32503==    by 0x4883295: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==32503==    by 0x4884D12: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==32503==    by 0x48A58EC: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==32503==    by 0x48A6980: curl_multi_perform (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==32503==    by 0x489CDFA: curl_easy_perform (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==32503==    by 0x1C085D: HTTPAPI_ExecuteRequest (httpapi_curl.c:645)
==32503== 
==32503== LEAK SUMMARY:
==32503==    definitely lost: 24 bytes in 1 blocks
==32503==    indirectly lost: 0 bytes in 0 blocks
==32503==      possibly lost: 0 bytes in 0 blocks
==32503==    still reachable: 990 bytes in 2 blocks
==32503==         suppressed: 0 bytes in 0 blocks
````
