### PR TITLE
Vcpkg CURL fix for build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,8 +503,7 @@ if(${use_http})
         if (NOT use_builtin_httpapi)
 
             # try CMake find_package first
-            set(CURL_DIR CMake)
-            find_package(CURL CONFIG)
+            find_package(CURL)
 
             # As mentioned at https://cmake.org/Wiki/CMake_Cross_Compiling the
             # pkg-config tool can not be used by cmake while cross compiling.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,21 +501,20 @@ if(${use_http})
         set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} crypt32 winhttp)
     else()
         if (NOT use_builtin_httpapi)
-            if (CMAKE_CROSSCOMPILING)
-                # As mentioned at https://cmake.org/Wiki/CMake_Cross_Compiling the
-                # pkg-config tool can not be used by cmake while cross compiling.
-                message(STATUS "Cross compiling not using pkg-config")
-            else()
-                # try pkg-config first
-                find_package(PkgConfig)
-                if(PKG_CONFIG_FOUND)
-                    pkg_check_modules(CURL libcurl)
-                endif()
-            endif()
 
-            # if that didn't work, try CMake find_package
-            if(NOT CURL_FOUND)
-                find_package(CURL)
+            # try CMake find_package first
+            find_package(CURL)
+
+            # As mentioned at https://cmake.org/Wiki/CMake_Cross_Compiling the
+            # pkg-config tool can not be used by cmake while cross compiling.
+            if (NOT CMAKE_CROSSCOMPILING)
+                # if find_package didn't work, try pkg-config
+                if(NOT CURL_FOUND)
+                    find_package(PkgConfig)
+                    if(PKG_CONFIG_FOUND)
+                        pkg_check_modules(CURL libcurl)
+                    endif()
+                endif()
             endif()
 
             set(CURL_FIND_REQUIRED 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,7 +503,7 @@ if(${use_http})
         if (NOT use_builtin_httpapi)
 
             # try CMake find_package first
-            find_package(CURL CONFIG)
+            find_package(CURL)
 
             # As mentioned at https://cmake.org/Wiki/CMake_Cross_Compiling the
             # pkg-config tool can not be used by cmake while cross compiling.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,7 +503,7 @@ if(${use_http})
         if (NOT use_builtin_httpapi)
 
             # try CMake find_package first
-            find_package(CURL)
+            find_package(CURL CONFIG)
 
             # As mentioned at https://cmake.org/Wiki/CMake_Cross_Compiling the
             # pkg-config tool can not be used by cmake while cross compiling.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,7 +503,8 @@ if(${use_http})
         if (NOT use_builtin_httpapi)
 
             # try CMake find_package first
-            find_package(CURL)
+            set(CURL_DIR CMake)
+            find_package(CURL CONFIG)
 
             # As mentioned at https://cmake.org/Wiki/CMake_Cross_Compiling the
             # pkg-config tool can not be used by cmake while cross compiling.

--- a/configs/azure_c_shared_utilityConfig.cmake
+++ b/configs/azure_c_shared_utilityConfig.cmake
@@ -4,7 +4,8 @@
 include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")
 
 include(CMakeFindDependencyMacro)
-find_dependency(CURL)
+set(CURL_DIR CMake)
+find_dependency(CURL CONFIG)
 
 get_target_property(AZURE_C_SHARED_UTILITY_INCLUDES aziotsharedutil INTERFACE_INCLUDE_DIRECTORIES)
 

--- a/configs/azure_c_shared_utilityConfig.cmake
+++ b/configs/azure_c_shared_utilityConfig.cmake
@@ -3,7 +3,7 @@
 
 if(UNIX)
     include(CMakeFindDependencyMacro)
-    find_dependency(CURL CONFIG)
+    find_dependency(CURL)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")

--- a/configs/azure_c_shared_utilityConfig.cmake
+++ b/configs/azure_c_shared_utilityConfig.cmake
@@ -1,11 +1,12 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")
+if(UNIX)
+    include(CMakeFindDependencyMacro)
+    find_dependency(CURL CONFIG)
+endif()
 
-include(CMakeFindDependencyMacro)
-set(CURL_DIR CMake)
-find_dependency(CURL CONFIG)
+include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")
 
 get_target_property(AZURE_C_SHARED_UTILITY_INCLUDES aziotsharedutil INTERFACE_INCLUDE_DIRECTORIES)
 

--- a/configs/azure_c_shared_utilityConfig.cmake
+++ b/configs/azure_c_shared_utilityConfig.cmake
@@ -1,6 +1,9 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+include(CMakeFindDependencyMacro)
+find_dependency(CURL CONFIG)
+
 include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")
 
 get_target_property(AZURE_C_SHARED_UTILITY_INCLUDES aziotsharedutil INTERFACE_INCLUDE_DIRECTORIES)
@@ -9,4 +12,3 @@ set(AZURE_C_SHARED_UTILITY_INCLUDES ${AZURE_C_SHARED_UTILITY_INCLUDES} CACHE INT
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityFunctions.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/azure_iot_build_rules.cmake")
-

--- a/configs/azure_c_shared_utilityConfig.cmake
+++ b/configs/azure_c_shared_utilityConfig.cmake
@@ -1,10 +1,10 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")
+
 include(CMakeFindDependencyMacro)
 find_dependency(CURL)
-
-include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")
 
 get_target_property(AZURE_C_SHARED_UTILITY_INCLUDES aziotsharedutil INTERFACE_INCLUDE_DIRECTORIES)
 

--- a/configs/azure_c_shared_utilityConfig.cmake
+++ b/configs/azure_c_shared_utilityConfig.cmake
@@ -2,7 +2,7 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 include(CMakeFindDependencyMacro)
-find_dependency(CURL CONFIG)
+find_dependency(CURL)
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")
 


### PR DESCRIPTION
This change updates how CURL is found for vcpkg.  It now checks CMake's find_package() before trying pkg-config.  This change is needed for vcpkg build.
As a result, the Config.cmake file must forward its dependency on CURL downstream.
