### PR TITLE
change linux time to use int64_t

### DIFF
--- a/adapters/linux_time.c
+++ b/adapters/linux_time.c
@@ -73,6 +73,6 @@ int64_t get_time_ms()
         return INVALID_TIME_VALUE;
     }
 
-    return (int64_t)((int64_t)ts.tv_sec * MILLISECONDS_IN_ONE_SECOND + (int64_t)ts.tv_nsec / NANOSECONDS_IN_ONE_MILLISECOND);
+    return (int64_t)((int64_t)ts.tv_sec * MILLISECONDS_IN_1_SECOND + (int64_t)ts.tv_nsec / NANOSECONDS_IN_1_MILLISECOND);
 }
 

--- a/adapters/linux_time.c
+++ b/adapters/linux_time.c
@@ -15,9 +15,6 @@
 clockid_t time_basis = -1;
 #endif
 
-#define MILLISECONDS_IN_ONE_SECOND 1000
-#define NANOSECONDS_IN_ONE_MILLISECOND 1000000
-
 void set_time_basis(void)
 {
 // The time basis depends on what clock is available. Prefer CLOCK_MONOTONIC,

--- a/adapters/linux_time.c
+++ b/adapters/linux_time.c
@@ -61,7 +61,7 @@ int get_time_ns(struct timespec* ts)
     return err;
 }
 
-time_t get_time_ms()
+int64_t get_time_ms()
 {
     struct timespec ts;
     if (get_time_ns(&ts) != 0)
@@ -70,6 +70,6 @@ time_t get_time_ms()
         return INVALID_TIME_VALUE;
     }
 
-    return (time_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+    return (int64_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
 }
 

--- a/adapters/linux_time.c
+++ b/adapters/linux_time.c
@@ -73,6 +73,6 @@ int64_t get_time_ms()
         return INVALID_TIME_VALUE;
     }
 
-    return (int64_t)(ts.tv_sec * MILLISECONDS_IN_ONE_SECOND + ts.tv_nsec / NANOSECONDS_IN_ONE_MILLISECOND);
+    return (int64_t)((int64_t)ts.tv_sec * MILLISECONDS_IN_ONE_SECOND + (int64_t)ts.tv_nsec / NANOSECONDS_IN_ONE_MILLISECOND);
 }
 

--- a/adapters/linux_time.c
+++ b/adapters/linux_time.c
@@ -15,6 +15,9 @@
 clockid_t time_basis = -1;
 #endif
 
+#define MILLISECONDS_IN_ONE_SECOND 1000
+#define NANOSECONDS_IN_ONE_MILLISECOND 1000000
+
 void set_time_basis(void)
 {
 // The time basis depends on what clock is available. Prefer CLOCK_MONOTONIC,
@@ -70,6 +73,6 @@ int64_t get_time_ms()
         return INVALID_TIME_VALUE;
     }
 
-    return (int64_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+    return (int64_t)(ts.tv_sec * MILLISECONDS_IN_ONE_SECOND + ts.tv_nsec / NANOSECONDS_IN_ONE_MILLISECOND);
 }
 

--- a/adapters/linux_time.h
+++ b/adapters/linux_time.h
@@ -4,6 +4,7 @@
 #ifndef LINUX_TIME_H
 #define LINUX_TIME_H
 
+#include <stdint.h>
 #include <time.h>
 #include <pthread.h>
 
@@ -13,9 +14,9 @@ extern clockid_t time_basis;
 
 extern void set_time_basis(void);
 extern int get_time_ns(struct timespec* ts);
-extern time_t get_time_ms(void);
+extern int64_t get_time_ms(void);
 
-#define INVALID_TIME_VALUE      (time_t)(-1)
+#define INVALID_TIME_VALUE      (int64_t)(-1)
 
 
 #define NANOSECONDS_IN_1_SECOND 1000000000L

--- a/adapters/tickcounter_linux.c
+++ b/adapters/tickcounter_linux.c
@@ -12,7 +12,7 @@
 
 typedef struct TICK_COUNTER_INSTANCE_TAG
 {
-    time_t init_time_value;
+    int64_t init_time_value;
     tickcounter_ms_t current_ms;
 } TICK_COUNTER_INSTANCE;
 
@@ -57,7 +57,7 @@ int tickcounter_get_current_ms(TICK_COUNTER_HANDLE tick_counter, tickcounter_ms_
     }
     else
     {
-        time_t time_value = get_time_ms();
+        int64_t time_value = get_time_ms();
         if (time_value == INVALID_TIME_VALUE)
         {
             result = MU_FAILURE;
@@ -65,7 +65,7 @@ int tickcounter_get_current_ms(TICK_COUNTER_HANDLE tick_counter, tickcounter_ms_
         else
         {
             TICK_COUNTER_INSTANCE* tick_counter_instance = (TICK_COUNTER_INSTANCE*)tick_counter;
-            tick_counter_instance->current_ms = (tickcounter_ms_t)(difftime(time_value, tick_counter_instance->init_time_value));
+            tick_counter_instance->current_ms = (tickcounter_ms_t) time_value - tick_counter_instance->init_time_value;
             *current_ms = tick_counter_instance->current_ms;
             result = 0;
         }


### PR DESCRIPTION
fixes #526 

`time_t` is platform dependent and therefore size could be 32 bits. Milliseconds overflow after about 25 days with 32 bit so this increases the ms time to be 64 bits wide.