### PR TITLE
Remerge header install location change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,7 +688,7 @@ install (TARGETS ${targets} EXPORT aziotsharedutilTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
 )
-install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot/azure_c_shared_utility)
+install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azure_c_shared_utility)
 install (FILES ${micromock_h_files_full_path} ${INSTALL_H_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
 
 


### PR DESCRIPTION
Re-merging change found in PR #531, original solution to issue #530.
However, this solution caused the vcpkg build to fail.  To fix this failure, a patch will need to be applied in the vcpkg repo to `azure-c-shared-utility/CMakeLists.txt` reverting this change.  This will need to occur with the next vcpkg release that contains this PR merge.

See below:
```
diff --git a/CMakeLists.txt b/CMakeLists.txt
index ddcbaf57..1cd00da7 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,7 +688,7 @@ install (TARGETS ${targets} EXPORT aziotsharedutilTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
 )
-install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azure_c_shared_utility)
+install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot/azure_c_shared_utility)
 install (FILES ${micromock_h_files_full_path} ${INSTALL_H_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)


```

To add the patch to vcpkg, add the patch file to the `ports/azure-c-shared-utility` directory.  Update the corresponding `portfile.cmake` to include reference to the new patch for both master and public preview logic branches.
E.g.:

```
        PATCHES
            fix-utilityFunctions-conditions.patch
            disable-error.patch
            install-location.patch
```

