### PR TITLE
fix crash wiht invalid proxy configuration

### DIFF
--- a/src/http_proxy_io.c
+++ b/src/http_proxy_io.c
@@ -951,7 +951,7 @@ static void* http_proxy_io_clone_option(const char* name, const void* value)
     {
         if (strcmp(name, OPTION_UNDERLYING_IO_OPTIONS) == 0)
         {
-            result = (void*)value;
+            result = (void*)OptionHandler_Clone((OPTIONHANDLER_HANDLE)value);
         }
         else
         {


### PR DESCRIPTION
This patch fixes a crash when trying to connect iothub with invalid proxy configuration