### PR TITLE
Mbed fix

### DIFF
--- a/adapters/tlsio_mbedtls.c
+++ b/adapters/tlsio_mbedtls.c
@@ -581,8 +581,6 @@ void tlsio_mbedtls_destroy(CONCRETE_IO_HANDLE tls_io)
 
         mbedtls_uninit(tls_io_instance);
 
-        xio_close(tls_io_instance->socket_io, NULL, NULL);
-
         if (tls_io_instance->socket_io_read_bytes != NULL)
         {
             free(tls_io_instance->socket_io_read_bytes);

--- a/tests/tlsio_mbedtls_ut/tlsio_mbedtls_ut.c
+++ b/tests/tlsio_mbedtls_ut/tlsio_mbedtls_ut.c
@@ -574,7 +574,6 @@ BEGIN_TEST_SUITE(tlsio_mbedtls_ut)
         STRICT_EXPECTED_CALL(mbedtls_pk_free(IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(mbedtls_ctr_drbg_free(IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(mbedtls_entropy_free(IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(xio_close(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(xio_destroy(IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_NUM_ARG));


### PR DESCRIPTION
This looks to duplicate the close which is done in `tlsio_mbedtls_close()`
https://github.com/Azure/azure-c-shared-utility/blob/735be16a943c2a9cbbddef0543f871f5bc0e27ab/adapters/tlsio_mbedtls.c#L704

We don't do an xio close in these tlsio_ adapters either.


https://github.com/Azure/azure-c-shared-utility/blob/735be16a943c2a9cbbddef0543f871f5bc0e27ab/adapters/tlsio_openssl.c#L1357-L1395
https://github.com/Azure/azure-c-shared-utility/blob/735be16a943c2a9cbbddef0543f871f5bc0e27ab/adapters/tlsio_schannel.c#L1149-L1217


I repro'd the issue detailed by #569 and removing this resolves the issue. I also ran the iot sample using mbedtls with MQTT and MQTT w/ WS and it looks to run just fine.