### PR TITLE
Change variable name to avoid variable shadowing

### DIFF
--- a/adapters/tlsio_mbedtls.c
+++ b/adapters/tlsio_mbedtls.c
@@ -713,7 +713,7 @@ int tlsio_mbedtls_close(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMPLETE on_io_cl
     return result;
 }
 
-int tlsio_mbedtls_send(CONCRETE_IO_HANDLE tls_io, const void *buffer, size_t size, ON_SEND_COMPLETE on_send_complete, void *callback_context)
+int tlsio_mbedtls_send(CONCRETE_IO_HANDLE tls_io, const void *buffer, size_t size, ON_SEND_COMPLETE on_send_complete_obj, void *callback_context)
 {
     int result = 0;
 
@@ -732,7 +732,7 @@ int tlsio_mbedtls_send(CONCRETE_IO_HANDLE tls_io, const void *buffer, size_t siz
         }
         else
         {
-            tls_io_instance->send_complete_info.on_send_complete = on_send_complete;
+            tls_io_instance->send_complete_info.on_send_complete = on_send_complete_obj;
             tls_io_instance->send_complete_info.on_send_complete_callback_context = callback_context;
             tls_io_instance->send_complete_info.last_fragmented_req_status = IO_SEND_OK;
             int out_left = (int)size;

--- a/adapters/tlsio_mbedtls.c
+++ b/adapters/tlsio_mbedtls.c
@@ -732,7 +732,7 @@ int tlsio_mbedtls_send(CONCRETE_IO_HANDLE tls_io, const void *buffer, size_t siz
         }
         else
         {
-            tls_io_instance->send_complete_info.on_send_complete = on_send_complete_obj;
+            tls_io_instance->send_complete_info.on_send_complete = on_send_complete_callback;
             tls_io_instance->send_complete_info.on_send_complete_callback_context = callback_context;
             tls_io_instance->send_complete_info.last_fragmented_req_status = IO_SEND_OK;
             int out_left = (int)size;

--- a/adapters/tlsio_mbedtls.c
+++ b/adapters/tlsio_mbedtls.c
@@ -713,7 +713,7 @@ int tlsio_mbedtls_close(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMPLETE on_io_cl
     return result;
 }
 
-int tlsio_mbedtls_send(CONCRETE_IO_HANDLE tls_io, const void *buffer, size_t size, ON_SEND_COMPLETE on_send_complete_obj, void *callback_context)
+int tlsio_mbedtls_send(CONCRETE_IO_HANDLE tls_io, const void *buffer, size_t size, ON_SEND_COMPLETE on_send_complete_callback, void *callback_context)
 {
     int result = 0;
 


### PR DESCRIPTION
**Problem:** When compiling with ARM, a warning is given that variable shadowing is possibly occurring. This was caused by the object type and a variable of that type having the same name (despite having different capitalization). While the compiler understands what's going on, it may lead to errors in understanding for others reading the code. 

**Solution:** Changing the variable name resolved the issue. 

**Links for more info:**

https://stackoverflow.com/questions/38533407/how-bad-is-redefining-shadowing-a-local-variable

https://stackoverflow.com/questions/15066925/same-name-but-with-different-case-variable-and-function-names-in-c
