### PR TITLE
Adding IPv6 Dual Stack Support for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,14 @@ option(use_cppunittest "set use_cppunittest to ON to build CppUnitTest tests on 
 option(suppress_header_searches "do not try to find headers - used when compiler check will fail" OFF)
 option(use_custom_heap "use externally defined heap functions instead of the malloc family" OFF)
 option(no_openssl_engine "Disables the use of ENGINEs in OpenSSL" OFF)
+option(enable_ipv6 "set enable_ipv6 to ON to enable dual-stack support (default is OFF)" OFF)
 
 if(${use_custom_heap})
     add_definitions(-DGB_USE_CUSTOM_HEAP)
+endif()
+
+if (${enable_ipv6})
+    add_definitions(-DIPV6_ENABLED)
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ option(use_cppunittest "set use_cppunittest to ON to build CppUnitTest tests on 
 option(suppress_header_searches "do not try to find headers - used when compiler check will fail" OFF)
 option(use_custom_heap "use externally defined heap functions instead of the malloc family" OFF)
 option(no_openssl_engine "Disables the use of ENGINEs in OpenSSL" OFF)
-option(enable_ipv6 "set enable_ipv6 to ON to enable dual-stack support (default is OFF)" OFF)
+option(enable_ipv6 "set enable_ipv6 to ON to enable dual-ip-stack (IPv4 and IPv6) support (default is OFF for IPv4 only)" OFF)
 
 if(${use_custom_heap})
     add_definitions(-DGB_USE_CUSTOM_HEAP)

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -281,225 +281,6 @@ static int lookup_address(SOCKET_IO_INSTANCE* socket_io_instance)
     return result;
 }
 
-static int initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
-{
-    int result;
-    int flags;
-    struct addrinfo* addr = NULL;
-    struct sockaddr* connect_addr = NULL;
-    struct sockaddr_in6* connect_addr6 = NULL;
-    struct sockaddr_un addrInfoUn;
-    socklen_t connect_addr_len;
-
-    if(socket_io_instance->address_type == ADDRESS_TYPE_IP)
-    {
-        if(!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
-        {
-            LogError("DNS did not resolve IP address");
-            result = MU_FAILURE;
-        }
-        else
-        {
-            addr = dns_resolver_get_addrInfo(socket_io_instance->dns_resolver);
-
-            if (addr == NULL)
-            {
-                LogError("DNS resolution failed");
-                result = MU_FAILURE;
-            }
-            else if (addr->ai_family == AF_INET)
-            {
-                connect_addr = addr->ai_addr;
-                connect_addr_len = sizeof(*addr->ai_addr);
-                result = 0;
-            } 
-            else if (addr->ai_family == AF_INET6)
-            {
-                connect_addr6 = (struct sockaddr_in6*) addr->ai_addr;
-                connect_addr_len = sizeof(struct sockaddr_in6);
-                result = 0;
-            }
-            else {
-                LogError("Socket failure...");
-                result = MU_FAILURE;
-            }
-        }
-    }
-    else
-    {
-        size_t hostname_len = strlen(socket_io_instance->hostname);
-        if (hostname_len + 1 > sizeof(addrInfoUn.sun_path))
-        {
-            LogError("Hostname %s is too long for a unix socket (max len = %lu)", socket_io_instance->hostname, (unsigned long)sizeof(addrInfoUn.sun_path));
-            result = MU_FAILURE;
-        }
-        else
-        {
-            memset(&addrInfoUn, 0, sizeof(addrInfoUn));
-            addrInfoUn.sun_family = AF_UNIX;
-            // No need to add NULL terminator due to the above memset
-            (void)memcpy(addrInfoUn.sun_path, socket_io_instance->hostname, hostname_len);
-
-            connect_addr = (struct sockaddr*)&addrInfoUn;
-            connect_addr_len = sizeof(addrInfoUn);
-            result = 0;
-        }
-    }
-
-    if (addr->ai_family == AF_INET)
-    {
-        socket_io_instance->socket = socket (AF_INET, SOCK_STREAM, 0);
-        if (socket_io_instance->socket < SOCKET_SUCCESS)
-        {
-            LogError("Failure: socket create failure %d.", socket_io_instance->socket);
-            result = MU_FAILURE;
-        }
-    } else if (addr->ai_family == AF_INET6)
-    {
-        socket_io_instance->socket = socket (AF_INET6, SOCK_STREAM, 0);
-        if (socket_io_instance->socket < SOCKET_SUCCESS)
-        {
-            LogError("Failure: socket create failure %d.", socket_io_instance->socket);
-            result = MU_FAILURE;
-        }
-    } else 
-    {
-        result = MU_FAILURE;
-        LogError("Failure: Should not go through here.");
-    }
-
-    if(result == 0)
-    {
-        if ((-1 == (flags = fcntl(socket_io_instance->socket, F_GETFL, 0))) ||
-            (fcntl(socket_io_instance->socket, F_SETFL, flags | O_NONBLOCK) == -1))
-        {
-            LogError("Failure: fcntl failure.");
-            result = MU_FAILURE;
-        }
-        else
-        {
-            
-            if (addr->ai_family == AF_INET)
-            {
-                result = connect(socket_io_instance->socket, connect_addr, connect_addr_len);
-            } 
-            else
-            {
-                result = connect(socket_io_instance->socket, (struct sockaddr*)connect_addr6, connect_addr_len);
-            }
-            
-            if ((result != 0) && (errno != EINPROGRESS))
-            {
-                LogError("Failure: connect failure %d.", errno);
-                result = MU_FAILURE;
-            }
-            else
-            {
-                // Async connect will return -1.
-                result = 0;
-                if (socket_io_instance->on_io_open_complete != NULL)
-                {
-                    socket_io_instance->on_io_open_complete(socket_io_instance->on_io_open_complete_context, IO_OPEN_OK /*: IO_OPEN_ERROR*/);
-                }
-            }
-        }
-
-        if (result != 0)
-        {
-            if (socket_io_instance->socket >= SOCKET_SUCCESS)
-            {
-                close(socket_io_instance->socket);
-            }
-            socket_io_instance->socket = INVALID_SOCKET;
-        }
-    }
-
-    return result;
-}
-
-static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
-{
-    int result;
-
-    result = lookup_address(socket_io_instance);
-
-    if(socket_io_instance->io_state == IO_STATE_OPEN)
-    {
-        if (result == 0)
-        {
-            result = initiate_socket_connection(socket_io_instance);
-        }
-    }
-
-    return result;
-}
-
-static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
-{
-    int result;
-    int err;
-    int retval;
-    int select_errno = 0;
-
-    fd_set fdset;
-    struct timeval tv;
-
-    FD_ZERO(&fdset);
-    FD_SET(socket_io_instance->socket, &fdset);
-    tv.tv_sec = CONNECT_TIMEOUT;
-    tv.tv_usec = 0;
-
-    do
-    {
-        retval = select(socket_io_instance->socket + 1, NULL, &fdset, NULL, &tv);
-
-        if (retval < 0)
-        {
-            select_errno = errno;
-        }
-    } while (retval < 0 && select_errno == EINTR);
-
-    if (retval != 1)
-    {
-        LogError("Failure: select failure.");
-        result = MU_FAILURE;
-    }
-    else
-    {
-        int so_error = 0;
-        socklen_t len = sizeof(so_error);
-        err = getsockopt(socket_io_instance->socket, SOL_SOCKET, SO_ERROR, &so_error, &len);
-        if (err != 0)
-        {
-            LogError("Failure: getsockopt failure %d.", errno);
-            result = MU_FAILURE;
-        }
-        else if (so_error != 0)
-        {
-            err = so_error;
-            LogError("Failure: connect failure %d.", so_error);
-            result = MU_FAILURE;
-        }
-        else
-        {
-            result = 0;
-        }
-    }
-
-    if (result != 0)
-    {
-        if (socket_io_instance->socket >= SOCKET_SUCCESS)
-        {
-            close(socket_io_instance->socket);
-        }
-        socket_io_instance->socket = INVALID_SOCKET;
-    }
-
-    return result;
-}
-
-
-
 #ifndef __APPLE__
 static void destroy_network_interface_descriptions(NETWORK_INTERFACE_DESCRIPTION* nid)
 {
@@ -708,6 +489,220 @@ static int set_target_network_interface(int socket, char* mac_address)
 }
 #endif //__APPLE__
 
+static int initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    int result;
+    int flags;
+    struct addrinfo* addr = NULL;
+    struct sockaddr* connect_addr = NULL;
+#ifdef IPV6_ENABLED
+    struct sockaddr_in6* connect_addr6 = NULL;
+#endif // IPV6_ENABLED
+    struct sockaddr_un addrInfoUn;
+    socklen_t connect_addr_len;
+
+    if(socket_io_instance->address_type == ADDRESS_TYPE_IP)
+    {
+        if(!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
+        {
+            LogError("DNS did not resolve IP address");
+            result = MU_FAILURE;
+        }
+        else
+        {
+            addr = dns_resolver_get_addrInfo(socket_io_instance->dns_resolver);
+
+            if (addr == NULL)
+            {
+                LogError("DNS resolution failed");
+                result = MU_FAILURE;
+            }
+#ifdef IPV6_ENABLED
+            else if (addr->ai_family == AF_INET6)
+            {
+                connect_addr6 = (struct sockaddr_in6*) addr->ai_addr;
+                connect_addr_len = sizeof(struct sockaddr_in6);
+                result = 0;
+            }
+#endif // IPV6_ENABLED
+            else
+            {
+                connect_addr = addr->ai_addr;
+                connect_addr_len = sizeof(*addr->ai_addr);
+                result = 0;
+            }
+        }
+    }
+    else
+    {
+        size_t hostname_len = strlen(socket_io_instance->hostname);
+        if (hostname_len + 1 > sizeof(addrInfoUn.sun_path))
+        {
+            LogError("Hostname %s is too long for a unix socket (max len = %lu)", socket_io_instance->hostname, (unsigned long)sizeof(addrInfoUn.sun_path));
+            result = MU_FAILURE;
+        }
+        else
+        {
+            memset(&addrInfoUn, 0, sizeof(addrInfoUn));
+            addrInfoUn.sun_family = AF_UNIX;
+            // No need to add NULL terminator due to the above memset
+            (void)memcpy(addrInfoUn.sun_path, socket_io_instance->hostname, hostname_len);
+
+            connect_addr = (struct sockaddr*)&addrInfoUn;
+            connect_addr_len = sizeof(addrInfoUn);
+            result = 0;
+        }
+    }
+
+    socket_io_instance->socket = socket (socket_io_instance->address_type == ADDRESS_TYPE_IP ? addr->ai_family : AF_UNIX, SOCK_STREAM, 0);
+
+    if (socket_io_instance->socket < SOCKET_SUCCESS)
+    {
+        LogError("Failure: socket create failure %d.", socket_io_instance->socket);
+        result = MU_FAILURE;
+    }
+#ifndef __APPLE__
+    else if (socket_io_instance->target_mac_address != NULL &&
+                set_target_network_interface(socket_io_instance->socket, socket_io_instance->target_mac_address) != 0)
+    {
+        LogError("Failure: failed selecting target network interface (MACADDR=%s).", socket_io_instance->target_mac_address);
+        result = MU_FAILURE;
+    }
+#endif //__APPLE__
+
+    if(result == 0)
+    {
+        if ((-1 == (flags = fcntl(socket_io_instance->socket, F_GETFL, 0))) ||
+            (fcntl(socket_io_instance->socket, F_SETFL, flags | O_NONBLOCK) == -1))
+        {
+            LogError("Failure: fcntl failure.");
+            result = MU_FAILURE;
+        }
+        else
+        {
+#ifndef IPV6_ENABLED
+            result = connect(socket_io_instance->socket, connect_addr, connect_addr_len);
+#else
+            if (addr->ai_family == AF_INET6)
+            {
+                result = connect(socket_io_instance->socket, (struct sockaddr*)connect_addr6, connect_addr_len);
+            }
+            else 
+            {
+                result = connect(socket_io_instance->socket, connect_addr, connect_addr_len);
+            }
+#endif // IPV6_ENABLED
+            
+            if ((result != 0) && (errno != EINPROGRESS))
+            {
+                LogError("Failure: connect failure %d.", errno);
+                result = MU_FAILURE;
+            }
+            else
+            {
+                // Async connect will return -1.
+                result = 0;
+                if (socket_io_instance->on_io_open_complete != NULL)
+                {
+                    socket_io_instance->on_io_open_complete(socket_io_instance->on_io_open_complete_context, IO_OPEN_OK /*: IO_OPEN_ERROR*/);
+                }
+            }
+        }
+
+        if (result != 0)
+        {
+            if (socket_io_instance->socket >= SOCKET_SUCCESS)
+            {
+                close(socket_io_instance->socket);
+            }
+            socket_io_instance->socket = INVALID_SOCKET;
+        }
+    }
+
+    return result;
+}
+
+static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    int result;
+
+    result = lookup_address(socket_io_instance);
+
+    if(socket_io_instance->io_state == IO_STATE_OPEN)
+    {
+        if (result == 0)
+        {
+            result = initiate_socket_connection(socket_io_instance);
+        }
+    }
+
+    return result;
+}
+
+static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    int result;
+    int err;
+    int retval;
+    int select_errno = 0;
+
+    fd_set fdset;
+    struct timeval tv;
+
+    FD_ZERO(&fdset);
+    FD_SET(socket_io_instance->socket, &fdset);
+    tv.tv_sec = CONNECT_TIMEOUT;
+    tv.tv_usec = 0;
+
+    do
+    {
+        retval = select(socket_io_instance->socket + 1, NULL, &fdset, NULL, &tv);
+
+        if (retval < 0)
+        {
+            select_errno = errno;
+        }
+    } while (retval < 0 && select_errno == EINTR);
+
+    if (retval != 1)
+    {
+        LogError("Failure: select failure.");
+        result = MU_FAILURE;
+    }
+    else
+    {
+        int so_error = 0;
+        socklen_t len = sizeof(so_error);
+        err = getsockopt(socket_io_instance->socket, SOL_SOCKET, SO_ERROR, &so_error, &len);
+        if (err != 0)
+        {
+            LogError("Failure: getsockopt failure %d.", errno);
+            result = MU_FAILURE;
+        }
+        else if (so_error != 0)
+        {
+            err = so_error;
+            LogError("Failure: connect failure %d.", so_error);
+            result = MU_FAILURE;
+        }
+        else
+        {
+            result = 0;
+        }
+    }
+
+    if (result != 0)
+    {
+        if (socket_io_instance->socket >= SOCKET_SUCCESS)
+        {
+            close(socket_io_instance->socket);
+        }
+        socket_io_instance->socket = INVALID_SOCKET;
+    }
+
+    return result;
+}
+
 static void destroy_socket_io_instance(SOCKET_IO_INSTANCE* instance)
 {
     if (instance->dns_resolver != NULL)
@@ -859,14 +854,6 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
         }
         else
         {
-#ifndef __APPLE__
-            if (socket_io_instance->target_mac_address != NULL &&
-                     set_target_network_interface(socket_io_instance->socket, socket_io_instance->target_mac_address) != 0)
-            {
-                LogError("Failure: failed selecting target network interface (MACADDR=%s).", socket_io_instance->target_mac_address);
-                result = MU_FAILURE;
-            }
-#endif //__APPLE__
             if ((result = lookup_address_and_initiate_socket_connection(socket_io_instance)) != 0)
             {
                 LogError("lookup_address_and_connect_socket failed");

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -434,7 +434,7 @@ static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* soc
     return result;
 }
 
-static int wait_for_connection(SOCKET_IO_INSTANCE* socket_io_instance) // TODOR: Change the name of this function
+static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
 {
     int result;
     int err;
@@ -871,9 +871,9 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
             {
                 LogError("lookup_address_and_connect_socket failed");
             }
-            else if ((socket_io_instance->io_state == IO_STATE_OPEN) && (result = wait_for_connection(socket_io_instance)) != 0)
+            else if ((socket_io_instance->io_state == IO_STATE_OPEN) && (result = wait_for_socket_connection(socket_io_instance)) != 0)
             {
-                LogError("wait_for_connection failed");
+                LogError("wait_for_socket_connection failed");
             } 
             else
             {
@@ -1124,9 +1124,9 @@ void socketio_dowork(CONCRETE_IO_HANDLE socket_io)
                             LogError("Socketio_Failure: initiate_socket_connection failed");
                             indicate_error(socket_io_instance);
                         }
-                        else if (wait_for_connection(socket_io_instance) != 0)
+                        else if (wait_for_socket_connection(socket_io_instance) != 0)
                         {
-                            LogError("Socketio_Failure: wait_for_connection failed");
+                            LogError("Socketio_Failure: wait_for_socket_connection failed");
                             indicate_error(socket_io_instance);
                         }
                     }

--- a/src/dns_resolver_ares.c
+++ b/src/dns_resolver_ares.c
@@ -150,9 +150,10 @@ static void query_completed_cb(void *arg, int status, int timeouts, struct hoste
             else
             {
                 addr = (void *)ptr->ai_addr;
-
+                LogInfo("RAUL'S LOGS: Going through found addresses.");
                 if (he->h_addrtype == AF_INET)
                 {
+                    LogInfo("RAUL'S LOGS: Chose IPv4.");
                     memcpy(&addr->sin_addr, he->h_addr_list[0], sizeof(struct in_addr));
                     addr->sin_family = he->h_addrtype;
                     addr->sin_port = htons((unsigned short)dns->port);
@@ -166,6 +167,7 @@ static void query_completed_cb(void *arg, int status, int timeouts, struct hoste
 
                 if (he->h_addrtype == AF_INET6)
                 {
+                    LogInfo("RAUL'S LOGS: Chose IPv6.");
                     memcpy(&addr->sin_addr, he->h_addr_list[0], sizeof(struct in6_addr));
                     addr->sin_family = he->h_addrtype;
                     addr->sin_port = htons((unsigned short)dns->port);
@@ -209,8 +211,7 @@ bool dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE dns_in)
         }
         else if(!dns->in_progress)
         {
-            //ares_gethostbyname(dns->ares_resolver, dns->hostname, AF_UNSPEC, query_completed_cb, (void*)dns);
-            ares_gethostbyname(dns->ares_resolver, dns->hostname, AF_INET, query_completed_cb, (void*)dns);
+            ares_gethostbyname(dns->ares_resolver, dns->hostname, AF_UNSPEC, query_completed_cb, (void*)dns);
             dns->in_progress = true;
             // This synchronous implementation is incapable of being incomplete, so SRS_dns_resolver_30_023 does not ever happen
             /* Codes_SRS_dns_resolver_30_023: [ If the DNS lookup process is not yet complete, dns_resolver_is_create_complete shall return false. ]*/

--- a/src/dns_resolver_ares.c
+++ b/src/dns_resolver_ares.c
@@ -21,16 +21,19 @@
 // The default definition handles lwIP. Please add comments for other systems tested.
 #define EXTRACT_IPV4(ptr) ((struct sockaddr_in *) ptr->ai_addr)->sin_addr.s_addr
 
+#ifdef IPV6_ENABLED
 // EXTRACT_IPV6 pulls the uint32_t IPv6 address out of an addrinfo struct
 #define EXTRACT_IPV6(ptr) ((struct sockaddr_in6 *) ptr->ai_addr)->sin6_addr.s6_addr
-
+#endif // IPV6_ENABLED
 
 typedef struct
 {
     char* hostname;
     int port;
     uint32_t ip_v4;
+#ifdef IPV6_ENABLED
     uint8_t ip_v6[16];
+#endif // IPV6_ENABLED
     bool is_complete;
     bool is_failed;
     bool in_progress;
@@ -66,7 +69,9 @@ DNSRESOLVER_HANDLE dns_resolver_create(const char* hostname, int port, const DNS
             result->is_failed = false;
             result->in_progress = false;
             result->ip_v4 = 0;
+#ifdef IPV6_ENABLED
             memset(result->ip_v6, 0, sizeof(result->ip_v6)); // zero out the IPv6 address
+#endif // IPV6_ENABLED
             result->port = port;
             /* Codes_SRS_dns_resolver_30_010: [ dns_resolver_create shall make a copy of the hostname parameter to allow immediate deletion by the caller. ]*/
             ms_result = mallocAndStrcpy_s(&result->hostname, hostname);
@@ -114,7 +119,9 @@ static void query_completed_cb(void *arg, int status, int timeouts, struct hoste
     int i;
     struct addrinfo *ptr = NULL;
     struct sockaddr_in *addr;
+#ifdef IPV6_ENABLED
     struct sockaddr_in6 *addr6;
+#endif // IPV6_ENABLED
 
     DNSRESOLVER_INSTANCE *dns = (DNSRESOLVER_INSTANCE *)arg;
     (void)timeouts;
@@ -133,60 +140,60 @@ static void query_completed_cb(void *arg, int status, int timeouts, struct hoste
             dns->is_complete = true;
             dns->in_progress = false;
         }
+#ifdef IPV6_ENABLED
+        else if (he->h_addrtype == AF_INET6)
+        {
+            ptr = dns->addrInfo;
+
+            ptr->ai_addr = calloc(1, sizeof(struct sockaddr_in6));
+            addr6 = (void *)ptr->ai_addr;
+
+            if(ptr->ai_addr == NULL)
+            {
+                LogError("dns addrinfo ai_addr: allocation failed");
+                free(dns->addrInfo);
+                dns->is_failed = true;
+                dns->is_complete = true;
+                dns->in_progress = false;
+            } else {
+                memcpy(&addr6->sin6_addr, he->h_addr_list[0], sizeof(struct in6_addr));
+                addr6->sin6_family = he->h_addrtype;
+                addr6->sin6_port = htons((unsigned short)dns->port);
+
+                /* Codes_SRS_dns_resolver_30_033: [ If dns_resolver_is_create_complete has returned true and the lookup process has failed, dns_resolver_get_ipv4 shall return 0. ]*/
+                memcpy(dns->ip_v6, EXTRACT_IPV6(ptr), 16); // IPv6 address is 16 bytes
+                dns->addrInfo->ai_family = AF_INET6;
+                dns->is_failed = (dns->ip_v6 == 0);
+                dns->is_complete = true;
+                dns->in_progress = false;
+            }
+        }
+#endif // IPV6_ENABLED
         else
         {
             ptr = dns->addrInfo;
-            
-            if (he->h_addrtype == AF_INET)
+
+            ptr->ai_addr = calloc(1, sizeof(struct sockaddr_in));
+            addr = (void *)ptr->ai_addr;
+
+            if(ptr->ai_addr == NULL)
             {
-                ptr->ai_addr = calloc(1, sizeof(struct sockaddr_in));
-                addr = (void *)ptr->ai_addr;
+                LogError("dns addrinfo ai_addr: allocation failed");
+                free(dns->addrInfo);
+                dns->is_failed = true;
+                dns->is_complete = true;
+                dns->in_progress = false;
+            } else {
+                memcpy(&addr->sin_addr, he->h_addr_list[0], sizeof(struct in_addr));
+                addr->sin_family = he->h_addrtype;
+                addr->sin_port = htons((unsigned short)dns->port);
 
-                if(ptr->ai_addr == NULL)
-                {
-                    LogError("dns addrinfo ai_addr: allocation failed");
-                    free(dns->addrInfo);
-                    dns->is_failed = true;
-                    dns->is_complete = true;
-                    dns->in_progress = false;
-                } else {
-                    dns->addrInfo->ai_family = AF_INET;
-                    memcpy(&addr->sin_addr, he->h_addr_list[0], sizeof(struct in_addr));
-                    addr->sin_family = he->h_addrtype;
-                    addr->sin_port = htons((unsigned short)dns->port);
-
-                    /* Codes_SRS_dns_resolver_30_033: [ If dns_resolver_is_create_complete has returned true and the lookup process has failed, dns_resolver_get_ipv4 shall return 0. ]*/
-                    dns->ip_v4 = EXTRACT_IPV4(ptr);
-                    dns->is_failed = (dns->ip_v4 == 0);
-                    dns->is_complete = true;
-                    dns->in_progress = false;
-                }   
-            }
-            if (he->h_addrtype == AF_INET6)
-            {
-                ptr->ai_addr = calloc(1, sizeof(struct sockaddr_in6));
-                addr6 = (void *)ptr->ai_addr;
-
-                if(ptr->ai_addr == NULL)
-                {
-                    LogError("dns addrinfo ai_addr: allocation failed");
-                    free(dns->addrInfo);
-                    dns->is_failed = true;
-                    dns->is_complete = true;
-                    dns->in_progress = false;
-                } else {
-                    dns->addrInfo->ai_family = AF_INET6;
-                    memcpy(&addr6->sin6_addr, he->h_addr_list[0], sizeof(struct in6_addr));
-                    addr6->sin6_family = he->h_addrtype;
-                    addr6->sin6_port = htons((unsigned short)dns->port);
-
-                    /* Codes_SRS_dns_resolver_30_033: [ If dns_resolver_is_create_complete has returned true and the lookup process has failed, dns_resolver_get_ipv4 shall return 0. ]*/
-                    memcpy(dns->ip_v6, EXTRACT_IPV6(ptr), 16); // IPv6 address is 16 bytes
-                    dns->is_failed = (dns->ip_v6 == 0);
-                    dns->is_complete = true;
-                    dns->in_progress = false;
-                }
-
+                /* Codes_SRS_dns_resolver_30_033: [ If dns_resolver_is_create_complete has returned true and the lookup process has failed, dns_resolver_get_ipv4 shall return 0. ]*/
+                dns->ip_v4 = EXTRACT_IPV4(ptr);
+                dns->addrInfo->ai_family = AF_INET;
+                dns->is_failed = (dns->ip_v4 == 0);
+                dns->is_complete = true;
+                dns->in_progress = false;
             }
         }
     }
@@ -219,7 +226,11 @@ bool dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE dns_in)
         }
         else if(!dns->in_progress)
         {
+#ifdef IPV6_ENABLED
             ares_gethostbyname(dns->ares_resolver, dns->hostname, AF_UNSPEC, query_completed_cb, (void*)dns);
+#else
+            ares_gethostbyname(dns->ares_resolver, dns->hostname, AF_INET, query_completed_cb, (void*)dns);
+#endif // IPV6_ENABLED
             dns->in_progress = true;
             // This synchronous implementation is incapable of being incomplete, so SRS_dns_resolver_30_023 does not ever happen
             /* Codes_SRS_dns_resolver_30_023: [ If the DNS lookup process is not yet complete, dns_resolver_is_create_complete shall return false. ]*/

--- a/src/dns_resolver_sync.c
+++ b/src/dns_resolver_sync.c
@@ -52,7 +52,7 @@ DNSRESOLVER_HANDLE dns_resolver_create(const char* hostname, int port, const DNS
     }
     else
     {
-        result = malloc(sizeof(DNSRESOLVER_INSTANCE));
+        result = calloc(1, sizeof(DNSRESOLVER_INSTANCE));
         if (result == NULL)
         {
             /* Codes_SRS_dns_resolver_30_014: [ On any failure, dns_resolver_create shall log an error and return NULL. ]*/
@@ -64,10 +64,6 @@ DNSRESOLVER_HANDLE dns_resolver_create(const char* hostname, int port, const DNS
             int ms_result;
             result->is_complete = false;
             result->is_failed = false;
-            result->ip_v4 = 0;
-#ifdef IPV6_ENABLED
-            memset(result->ip_v6, 0, 16); // Zero out the IPv6 address
-#endif // IPV6_ENABLED
             result->port = port;
             /* Codes_SRS_dns_resolver_30_010: [ dns_resolver_create shall make a copy of the hostname parameter to allow immediate deletion by the caller. ]*/
             ms_result = mallocAndStrcpy_s(&result->hostname, hostname);
@@ -145,18 +141,21 @@ bool dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE dns_in)
                     case AF_INET:
                         /* Codes_SRS_dns_resolver_30_032: [ If dns_resolver_is_create_complete has returned true and the lookup process has succeeded, dns_resolver_get_ipv4 shall return the discovered IPv4 address. ]*/
                         dns->ip_v4 = EXTRACT_IPV4(ptr);
-#ifdef IPV6_ENABLED
                         dns->is_failed = false;
                         break;
+#ifdef IPV6_ENABLED
                     case AF_INET6:
                         memcpy(dns->ip_v6, EXTRACT_IPV6(ptr), 16);
                         dns->is_failed = false;
-#endif // IPV6_ENABLED
                         break;     
+#endif // IPV6_ENABLED
                     }
                 }
                 /* Codes_SRS_dns_resolver_30_033: [ If dns_resolver_is_create_complete has returned true and the lookup process has failed, dns_resolver_get_ipv4 shall return 0. ]*/
-#ifndef IPV6_ENABLED
+#ifdef IPV6_ENABLED
+                uint8_t zero[16] = { 0 }; // IPv6 address of all zeroes
+                dns->is_failed = (dns->ip_v4 == 0) && (memcmp(dns->ip_v6, zero, 16) == 0);
+#else
                 dns->is_failed = (dns->ip_v4 == 0);
 #endif // IPV6_ENABLED
             }

--- a/src/dns_resolver_sync.c
+++ b/src/dns_resolver_sync.c
@@ -61,6 +61,7 @@ DNSRESOLVER_HANDLE dns_resolver_create(const char* hostname, int port, const DNS
             result->is_complete = false;
             result->is_failed = false;
             result->ip_v4 = 0;
+            memset(result->ip_v6, 0, 16); // Zero out the IPv6 address
             result->port = port;
             /* Codes_SRS_dns_resolver_30_010: [ dns_resolver_create shall make a copy of the hostname parameter to allow immediate deletion by the caller. ]*/
             ms_result = mallocAndStrcpy_s(&result->hostname, hostname);

--- a/src/dns_resolver_sync.c
+++ b/src/dns_resolver_sync.c
@@ -21,15 +21,19 @@
 // The default definition handles lwIP. Please add comments for other systems tested.
 #define EXTRACT_IPV4(ptr) ((struct sockaddr_in *) ptr->ai_addr)->sin_addr.s_addr
 
+#ifdef IPV6_ENABLED
 // EXTRACT_IPV6 pulls the uint32_t IPv6 address out of an addrinfo struct
 #define EXTRACT_IPV6(ptr) ((struct sockaddr_in6 *) ptr->ai_addr)->sin6_addr.s6_addr
+#endif // IPV6_ENABLED
 
 typedef struct
 {
     char* hostname;
     int port;
     uint32_t ip_v4;
+#ifdef IPV6_ENABLED
     uint8_t ip_v6[16];
+#endif // IPV6_ENABLED
     bool is_complete;
     bool is_failed;
     struct addrinfo* addrInfo;
@@ -61,7 +65,9 @@ DNSRESOLVER_HANDLE dns_resolver_create(const char* hostname, int port, const DNS
             result->is_complete = false;
             result->is_failed = false;
             result->ip_v4 = 0;
+#ifdef IPV6_ENABLED
             memset(result->ip_v6, 0, 16); // Zero out the IPv6 address
+#endif // IPV6_ENABLED
             result->port = port;
             /* Codes_SRS_dns_resolver_30_010: [ dns_resolver_create shall make a copy of the hostname parameter to allow immediate deletion by the caller. ]*/
             ms_result = mallocAndStrcpy_s(&result->hostname, hostname);
@@ -107,7 +113,11 @@ bool dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE dns_in)
             // Setup the hints address info structure
             // which is passed to the getaddrinfo() function
             memset(&hints, 0, sizeof(hints));
+#ifdef IPV6_ENABLED
             hints.ai_family = AF_UNSPEC;
+#else
+            hints.ai_family = AF_INET;
+#endif // IPV6_ENABLED
             hints.ai_socktype = SOCK_STREAM;
             hints.ai_protocol = 0;
 
@@ -133,18 +143,22 @@ bool dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE dns_in)
                     switch (ptr->ai_family)
                     {
                     case AF_INET:
+                        /* Codes_SRS_dns_resolver_30_032: [ If dns_resolver_is_create_complete has returned true and the lookup process has succeeded, dns_resolver_get_ipv4 shall return the discovered IPv4 address. ]*/
                         dns->ip_v4 = EXTRACT_IPV4(ptr);
+#ifdef IPV6_ENABLED
                         dns->is_failed = false;
                         break;
                     case AF_INET6:
                         memcpy(dns->ip_v6, EXTRACT_IPV6(ptr), 16);
                         dns->is_failed = false;
-                        break;
+#endif // IPV6_ENABLED
+                        break;     
                     }
-                    /* Codes_SRS_dns_resolver_30_032: [ If dns_resolver_is_create_complete has returned true and the lookup process has succeeded, dns_resolver_get_ipv4 shall return the discovered IPv4 address. ]*/
                 }
                 /* Codes_SRS_dns_resolver_30_033: [ If dns_resolver_is_create_complete has returned true and the lookup process has failed, dns_resolver_get_ipv4 shall return 0. ]*/
-                // dns->is_failed = (dns->ip_v4 == 0);
+#ifndef IPV6_ENABLED
+                dns->is_failed = (dns->ip_v4 == 0);
+#endif // IPV6_ENABLED
             }
             else
             {


### PR DESCRIPTION
Adding IPv6 Dual Stack support for Linux
- Enabled with cmake option.
- Moved socket creation to after DNS query to enable IPv6 socket creation.
- Added handling of IPv6 addresses for Linux async and sync dns.