### PR TITLE
SDL bugfixes (part 2)

### DIFF
--- a/src/singlylinkedlist.c
+++ b/src/singlylinkedlist.c
@@ -47,6 +47,7 @@ void singlylinkedlist_destroy(SINGLYLINKEDLIST_HANDLE list)
             LIST_ITEM_INSTANCE* current_item = list_instance->head;
             list_instance->head = (LIST_ITEM_INSTANCE*)current_item->next;
             free(current_item);
+            current_item = NULL;
         }
 
         /* Codes_SRS_LIST_01_003: [singlylinkedlist_destroy shall free all resources associated with the list identified by the handle argument.] */

--- a/src/uws_client.c
+++ b/src/uws_client.c
@@ -572,6 +572,7 @@ void uws_client_destroy(UWS_CLIENT_HANDLE uws_client)
             }
 
             free(uws_client->protocols);
+            uws_client->protocols = NULL;
         }
 
         /* Codes_SRS_UWS_CLIENT_01_019: [ uws_client_destroy shall free all resources associated with the uws instance. ]*/

--- a/src/uws_client.c
+++ b/src/uws_client.c
@@ -568,6 +568,7 @@ void uws_client_destroy(UWS_CLIENT_HANDLE uws_client)
             for (i = 0; i < uws_client->protocol_count; i++)
             {
                 free(uws_client->protocols[i].protocol);
+                uws_client->protocols[i].protocol = NULL;
             }
 
             free(uws_client->protocols);


### PR DESCRIPTION
17992325 - Defect : UsingUninitVar, Component : c-utility\src\uws_client.c
[warning]c-utility\src\singlylinkedlist.c(48,0): Warning C6001: Using uninitialized memory '*list_instance->head'.