### PR TITLE
Fix library when using use_http=OFF (gh#622)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,8 @@ if(${use_http})
         ./src/httpheaders.c
         ${HTTP_C_FILE}
     )
+else()
+    add_definitions(-DHTTP_DISABLED)
 endif()
 
 if(${use_schannel})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,8 +276,7 @@ if(${use_http})
         ./src/httpheaders.c
         ${HTTP_C_FILE}
     )
-else()
-    add_definitions(-DHTTP_DISABLED)
+    add_definitions(-DUSE_HTTP)
 endif()
 
 if(${use_schannel})

--- a/adapters/platform_linux.c
+++ b/adapters/platform_linux.c
@@ -4,7 +4,9 @@
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/xio.h"
 #include "azure_c_shared_utility/xlogging.h"
+#ifdef USE_HTTP
 #include "azure_c_shared_utility/httpapiex.h"
+#endif // USE_HTTP
 #ifdef USE_OPENSSL
 #include "azure_c_shared_utility/tlsio_openssl.h"
 #else
@@ -30,15 +32,15 @@ const IO_INTERFACE_DESCRIPTION* tlsio_openssl_get_interface_description();
 int platform_init(void)
 {
     int result = 0;
+#if defined(USE_HTTP)
 #ifndef DONT_USE_UPLOADTOBLOB
-#if !defined(HTTP_DISABLED)
     if (HTTPAPIEX_Init() == HTTPAPIEX_ERROR)
     {
         LogError("HTTP for upload to blob failed on initialization.");
         result = MU_FAILURE;
     }
-#endif /* HTTP_DISABLED */
 #endif /* DONT_USE_UPLOADTOBLOB */
+#endif /* USE_HTTP */
 #ifdef USE_OPENSSL
     if (result == 0)
     {
@@ -93,11 +95,12 @@ STRING_HANDLE platform_get_platform_info(PLATFORM_INFO_OPTION options)
 
 void platform_deinit(void)
 {
+#if defined(USE_HTTP)
 #ifndef DONT_USE_UPLOADTOBLOB
-#if !defined(HTTP_DISABLED)
     HTTPAPIEX_Deinit();
-#endif /* HTTP_DISABLED */
 #endif /* DONT_USE_UPLOADTOBLOB */
+#endif /* USE_HTTP */
+
 #ifdef USE_OPENSSL
     tlsio_openssl_deinit();
 #elif USE_WOLFSSL

--- a/adapters/platform_linux.c
+++ b/adapters/platform_linux.c
@@ -31,11 +31,13 @@ int platform_init(void)
 {
     int result = 0;
 #ifndef DONT_USE_UPLOADTOBLOB
+#if !defined(HTTP_DISABLED)
     if (HTTPAPIEX_Init() == HTTPAPIEX_ERROR)
     {
         LogError("HTTP for upload to blob failed on initialization.");
         result = MU_FAILURE;
     }
+#endif /* HTTP_DISABLED */
 #endif /* DONT_USE_UPLOADTOBLOB */
 #ifdef USE_OPENSSL
     if (result == 0)
@@ -92,7 +94,9 @@ STRING_HANDLE platform_get_platform_info(PLATFORM_INFO_OPTION options)
 void platform_deinit(void)
 {
 #ifndef DONT_USE_UPLOADTOBLOB
+#if !defined(HTTP_DISABLED)
     HTTPAPIEX_Deinit();
+#endif /* HTTP_DISABLED */
 #endif /* DONT_USE_UPLOADTOBLOB */
 #ifdef USE_OPENSSL
     tlsio_openssl_deinit();

--- a/adapters/platform_linux.c
+++ b/adapters/platform_linux.c
@@ -32,7 +32,7 @@ const IO_INTERFACE_DESCRIPTION* tlsio_openssl_get_interface_description();
 int platform_init(void)
 {
     int result = 0;
-#if defined(USE_HTTP)
+#ifdef USE_HTTP
 #ifndef DONT_USE_UPLOADTOBLOB
     if (HTTPAPIEX_Init() == HTTPAPIEX_ERROR)
     {
@@ -95,7 +95,7 @@ STRING_HANDLE platform_get_platform_info(PLATFORM_INFO_OPTION options)
 
 void platform_deinit(void)
 {
-#if defined(USE_HTTP)
+#ifdef USE_HTTP
 #ifndef DONT_USE_UPLOADTOBLOB
     HTTPAPIEX_Deinit();
 #endif /* DONT_USE_UPLOADTOBLOB */

--- a/configs/azure_c_shared_utilityConfig.cmake
+++ b/configs/azure_c_shared_utilityConfig.cmake
@@ -2,8 +2,10 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 if(UNIX)
-    include(CMakeFindDependencyMacro)
-    find_dependency(CURL)
+    if(${use_http})
+        include(CMakeFindDependencyMacro)
+        find_dependency(CURL)
+    endif()
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")

--- a/jenkins/linux_c_option_test.sh
+++ b/jenkins/linux_c_option_test.sh
@@ -42,6 +42,7 @@ declare -a arr=(
     "-Duse_builtin_httpapi=ON"
     "-Duse_default_uuid=ON"
     "-Dno_openssl_engine=ON"
+    "-Duse_http=OFF"
 )
 
 for item in "${arr[@]}"


### PR DESCRIPTION
This fix addresses https://github.com/Azure/azure-c-shared-utility/issues/622

Tested on Ubuntu 20.04 using -Duse_http=ON and OFF, with and without curl (and libcurl-dev) installed and uninstalled.
Also tested with azure-iot-sdk-c locally with the use_http=ON/OFF.