### PR TITLE
Enable libaziotsharedutil so versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,10 @@ endif()
 project(azure_c_shared_utility)
 
 FILE(READ ${CMAKE_CURRENT_LIST_DIR}/version.txt C_SHARED_VERSION)
-string(REGEX MATCH "^([0-9]+)[\\.]([0-9]+)[\\.]([0-9]+)$" _ ${C_SHARED_VERSION})
+string(STRIP "${C_SHARED_VERSION}" C_SHARED_VERSION)
+if(NOT C_SHARED_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+    message(FATAL_ERROR "Malformed version in version.txt: '${C_SHARED_VERSION}'")
+endif()
 set(C_SHARED_VERSION_MAJOR ${CMAKE_MATCH_1})
 
 #bring in dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 project(azure_c_shared_utility)
 
 FILE(READ ${CMAKE_CURRENT_LIST_DIR}/version.txt C_SHARED_VERSION)
+string(REGEX MATCH "^([0-9]+)[\\.]([0-9]+)[\\.]([0-9]+)$" _ ${C_SHARED_VERSION})
+set(C_SHARED_VERSION_MAJOR ${CMAKE_MATCH_1})
 
 #bring in dependencies
 #do not add or build any tests of the dependencies
@@ -598,7 +600,11 @@ if(${build_as_dynamic})
         ${source_h_files}
         ${def_files}
     )
-    set_target_properties(aziotsharedutil_dll PROPERTIES OUTPUT_NAME "aziotsharedutil_dll")
+    set_target_properties(aziotsharedutil_dll PROPERTIES
+        OUTPUT_NAME "aziotsharedutil_dll"
+        VERSION ${C_SHARED_VERSION}
+        SOVERSION ${C_SHARED_VERSION_MAJOR}
+    )
 endif()
 
 set(aziotsharedutil_target_libs)


### PR DESCRIPTION
Use the C_SHARED_VERSION on the aziotsharedutil_dll.so library for versioning. Have cmake build the symlinks required for proper so library versioning.

**Testing**
- Successful build via the azure-iot-sdk-c.
- Verified that the so versioning uses the version.txt string.
- Verified that the so library and versioning symlinks are created
/usr/lib/libaziotsharedutil_dll.so
/usr/lib/libaziotsharedutil_dll.so.1
/usr/lib/libaziotsharedutil_dll.so.1.1.12
