### PR TITLE
ssl: formalise LibreSSL detection checks

### DIFF
--- a/adapters/tlsio_openssl.c
+++ b/adapters/tlsio_openssl.c
@@ -1060,7 +1060,7 @@ static int create_openssl_instance(TLS_IO_INSTANCE* tlsInstance)
 
     const SSL_METHOD* method = NULL;
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (OPENSSL_VERSION_NUMBER >= 0x20000000L)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
     if (tlsInstance->tls_version == VERSION_1_2)
     {
         method = TLSv1_2_method();
@@ -1262,7 +1262,7 @@ void tlsio_openssl_deinit(void)
 
 #if   (OPENSSL_VERSION_NUMBER < 0x10000000L)
     ERR_remove_state(0);
-#elif (OPENSSL_VERSION_NUMBER < 0x10100000L) || (OPENSSL_VERSION_NUMBER >= 0x20000000L)
+#elif (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
     ERR_remove_thread_state(NULL);
 #endif
 #if  (OPENSSL_VERSION_NUMBER >= 0x10002000L) &&  (OPENSSL_VERSION_NUMBER < 0x10010000L) && (SSL_COMP_free_compression_methods)


### PR DESCRIPTION
The `tlsio_openssl` adapter checks whether libssl is provided by LibreSSL before performing certain operations by checking whether `OPENSSL_VERSION_NUMBER` is or exceeds `0x20000000`. This check causes compile-time failures under OpenSSL 3, which identifies itself with an `OPENSSL_VERSION_NUMBER` of `0x30000000` or above and has an API that deviates from LibreSSL's.

When checking for LibreSSL, instead explicitly check whether `LIBRESSL_VERSION_NUMBER` is defined.