### PR TITLE
Add support to disable tls verification

### DIFF
--- a/adapters/httpapi_compact.c
+++ b/adapters/httpapi_compact.c
@@ -57,6 +57,7 @@ typedef struct HTTP_HANDLE_DATA_TAG
     unsigned int    is_connected : 1;
     unsigned int    send_completed : 1;
     bool            tls_renegotiation;
+    bool            tls_verification;
 } HTTP_HANDLE_DATA;
 
 /*the following function does the same as sscanf(pos2, "%d", &sec)*/
@@ -1444,6 +1445,12 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
     {
         bool tls_renegotiation = *(bool*)value;
         http_instance->tls_renegotiation = tls_renegotiation;
+        result = HTTPAPI_OK;
+    }
+    else if (strcmp(OPTION_DISABLE_TLS_VERIFICATION, optionName) == 0)
+    {
+        bool tls_verification = *(bool*)value;
+        http_instance->tls_verification = tls_verification;
         result = HTTPAPI_OK;
     }
     else

--- a/adapters/tlsio_mbedtls.c
+++ b/adapters/tlsio_mbedtls.c
@@ -1029,6 +1029,20 @@ int tlsio_mbedtls_setoption(CONCRETE_IO_HANDLE tls_io, const char *optionName, c
                 result = 0;
             }
         }
+         else if (strcmp(optionName, OPTION_DISABLE_TLS_VERIFICATION) == 0)
+        {
+            if (value == NULL)
+            {
+                LogError("Invalid value set for tls verification");
+                result = MU_FAILURE;
+            }
+            else
+            {
+                bool set_verification = *((bool*)(value));
+                mbedtls_ssl_conf_authmode(&tls_io_instance->config, set_verification ? MBEDTLS_SSL_VERIFY_NONE: MBEDTLS_SSL_VERIFY_REQUIRED);
+                result = 0 ;
+            }
+        }
         else
         {
             // tls_io_instance->socket_io is never NULL


### PR DESCRIPTION
Our product uses azure-c-shared-utility to establish communication with a web server.
In our case, we want to disable TLS server verification for certain calls to this server.
This PR aims to add an option to disable/enable TLS server verification using http_compact/mbedtls.