### PR TITLE
Add csr_gen platform abstraction for CSR generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ if(${use_schannel})
     set(source_c_files ${source_c_files}
         ./adapters/tlsio_schannel.c
         ./adapters/x509_schannel.c
+        ./adapters/csr_gen_schannel.c
     )
 endif()
 # If SocketIO isn't used, then we need to substitute stubs for HTTP Proxy
@@ -320,6 +321,7 @@ if(${use_openssl})
     set(source_c_files ${source_c_files}
         ./adapters/tlsio_openssl.c
         ./adapters/x509_openssl.c
+        ./adapters/csr_gen_openssl.c
     )
 endif()
 if(${use_applessl})
@@ -433,6 +435,7 @@ if(${use_schannel})
     set(source_h_files ${source_h_files}
     ./inc/azure_c_shared_utility/tlsio_schannel.h
     ./inc/azure_c_shared_utility/x509_schannel.h
+    ./inc/azure_c_shared_utility/csr_gen.h
     )
 endif()
 
@@ -453,6 +456,7 @@ if(${use_openssl})
     set(source_h_files ${source_h_files}
         ./inc/azure_c_shared_utility/tlsio_openssl.h
         ./inc/azure_c_shared_utility/x509_openssl.h
+        ./inc/azure_c_shared_utility/csr_gen.h
         )
 endif()
 if(${use_applessl})
@@ -476,6 +480,7 @@ if(DEFINED LINUX OR DEFINED MACOSX)
     SOURCE
       ${CMAKE_CURRENT_LIST_DIR}/adapters/tlsio_openssl.c
       ${CMAKE_CURRENT_LIST_DIR}/adapters/x509_openssl.c
+      ${CMAKE_CURRENT_LIST_DIR}/adapters/csr_gen_openssl.c
       ${CMAKE_CURRENT_LIST_DIR}/adapters/httpapi_curl.c
     PROPERTY COMPILE_OPTIONS
       -Wno-deprecated-declarations
@@ -560,7 +565,7 @@ endif(${use_http})
 
 if(${use_schannel})
     if(WIN32)
-         set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} crypt32 ws2_32 secur32 advapi32 ncrypt)
+         set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} crypt32 ws2_32 secur32 advapi32 ncrypt bcrypt)
     endif()
 endif()
 

--- a/adapters/csr_gen_openssl.c
+++ b/adapters/csr_gen_openssl.c
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// OpenSSL-based implementation of csr_gen.h.
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <openssl/bio.h>
+
+#include "azure_c_shared_utility/csr_gen.h"
+#include "azure_c_shared_utility/azure_base64.h"
+#include "azure_c_shared_utility/buffer_.h"
+#include "azure_c_shared_utility/strings.h"
+#include "azure_c_shared_utility/crt_abstractions.h"
+#include "azure_c_shared_utility/optimize_size.h"
+#include "azure_c_shared_utility/xlogging.h"
+#include "azure_macro_utils/macro_utils.h"
+
+int csr_gen_ec_p256(const char* common_name, char** csr_base64, char** private_key_pem)
+{
+    int result = MU_FAILURE;
+    EVP_PKEY* pkey = NULL;
+    X509_REQ* req = NULL;
+    unsigned char* der_buf = NULL;
+    BUFFER_HANDLE der_buffer = NULL;
+    STRING_HANDLE b64 = NULL;
+    BIO* bio = NULL;
+    char* csr_out = NULL;
+    char* key_out = NULL;
+
+    if (common_name == NULL || csr_base64 == NULL || private_key_pem == NULL)
+    {
+        LogError("Invalid argument to csr_gen_ec_p256");
+        return MU_FAILURE;
+    }
+
+    *csr_base64 = NULL;
+    *private_key_pem = NULL;
+
+    do
+    {
+        if ((pkey = EVP_EC_gen("P-256")) == NULL)
+        {
+            LogError("EVP_EC_gen(P-256) failed");
+            break;
+        }
+
+        if ((req = X509_REQ_new()) == NULL)
+        {
+            LogError("X509_REQ_new failed");
+            break;
+        }
+
+        X509_REQ_set_version(req, 0);
+
+        X509_NAME* name = X509_REQ_get_subject_name(req);
+        if (name == NULL ||
+            X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                (const unsigned char*)common_name, -1, -1, 0) != 1)
+        {
+            LogError("Failed to set CSR subject CN");
+            break;
+        }
+
+        if (X509_REQ_set_pubkey(req, pkey) != 1 ||
+            X509_REQ_sign(req, pkey, EVP_sha256()) <= 0)
+        {
+            LogError("Failed to sign CSR");
+            break;
+        }
+
+        // CSR -> DER -> base64
+        int der_len = i2d_X509_REQ(req, &der_buf);
+        if (der_len <= 0)
+        {
+            LogError("i2d_X509_REQ failed");
+            break;
+        }
+
+        if ((der_buffer = BUFFER_create(der_buf, (size_t)der_len)) == NULL)
+        {
+            LogError("BUFFER_create failed");
+            break;
+        }
+
+        if ((b64 = Azure_Base64_Encode(der_buffer)) == NULL)
+        {
+            LogError("Azure_Base64_Encode failed");
+            break;
+        }
+
+        if (mallocAndStrcpy_s(&csr_out, STRING_c_str(b64)) != 0)
+        {
+            LogError("mallocAndStrcpy_s for CSR failed");
+            break;
+        }
+
+        // Private key -> PKCS#8 PEM
+        if ((bio = BIO_new(BIO_s_mem())) == NULL)
+        {
+            LogError("BIO_new failed");
+            break;
+        }
+
+        if (PEM_write_bio_PrivateKey(bio, pkey, NULL, NULL, 0, NULL, NULL) != 1)
+        {
+            LogError("PEM_write_bio_PrivateKey failed");
+            break;
+        }
+
+        char* pem_data = NULL;
+        long pem_len = BIO_get_mem_data(bio, &pem_data);
+        if (pem_len <= 0 || pem_data == NULL)
+        {
+            LogError("BIO_get_mem_data returned empty PEM");
+            break;
+        }
+
+        if ((key_out = (char*)malloc((size_t)pem_len + 1)) == NULL)
+        {
+            LogError("malloc for PEM private key failed");
+            break;
+        }
+        memcpy(key_out, pem_data, (size_t)pem_len);
+        key_out[pem_len] = '\0';
+
+        *csr_base64 = csr_out;
+        csr_out = NULL;
+        *private_key_pem = key_out;
+        key_out = NULL;
+        result = 0;
+    } while (0);
+
+    free(csr_out);
+    free(key_out);
+    if (bio != NULL) BIO_free(bio);
+    if (b64 != NULL) STRING_delete(b64);
+    if (der_buffer != NULL) BUFFER_delete(der_buffer);
+    if (der_buf != NULL) OPENSSL_free(der_buf);
+    if (req != NULL) X509_REQ_free(req);
+    if (pkey != NULL) EVP_PKEY_free(pkey);
+
+    return result;
+}

--- a/adapters/csr_gen_schannel.c
+++ b/adapters/csr_gen_schannel.c
@@ -1,0 +1,385 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Windows (Schannel / CNG + WinCrypt) implementation of csr_gen.h.
+//
+// Generates an ephemeral ECDSA P-256 key with BCrypt, builds a PKCS#10
+// CertificationRequest using CryptEncodeObjectEx, signs the TBS with
+// BCryptSignHash, and exports the private key as PKCS#8 PEM.
+
+#include <windows.h>
+#include <wincrypt.h>
+#include <bcrypt.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "azure_c_shared_utility/csr_gen.h"
+#include "azure_c_shared_utility/crt_abstractions.h"
+#include "azure_c_shared_utility/optimize_size.h"
+#include "azure_c_shared_utility/xlogging.h"
+#include "azure_macro_utils/macro_utils.h"
+
+#ifndef BCRYPT_SUCCESS
+#define BCRYPT_SUCCESS(s) ((s) >= 0)
+#endif
+
+#define P256_COORD_LEN  32u
+
+static void secure_local_free(void* p) { if (p != NULL) LocalFree(p); }
+
+// Wrap a base64 payload into PEM with given label; returns malloc'd string.
+static char* pem_wrap(const char* label, const BYTE* data, DWORD len)
+{
+    // First compute base64 with CRLF line breaks.
+    DWORD b64_len = 0;
+    if (!CryptBinaryToStringA(data, len, CRYPT_STRING_BASE64, NULL, &b64_len))
+    {
+        LogError("CryptBinaryToStringA size query failed");
+        return NULL;
+    }
+    char* b64 = (char*)malloc(b64_len);
+    if (b64 == NULL) return NULL;
+    if (!CryptBinaryToStringA(data, len, CRYPT_STRING_BASE64, b64, &b64_len))
+    {
+        free(b64);
+        return NULL;
+    }
+
+    size_t header_len = strlen("-----BEGIN ") + strlen(label) + strlen("-----\n");
+    size_t footer_len = strlen("-----END ") + strlen(label) + strlen("-----\n");
+    size_t total = header_len + b64_len + footer_len + 1;
+    char* pem = (char*)malloc(total);
+    if (pem == NULL) { free(b64); return NULL; }
+    int written = sprintf_s(pem, total, "-----BEGIN %s-----\n%s-----END %s-----\n", label, b64, label);
+    free(b64);
+    if (written < 0) { free(pem); return NULL; }
+    return pem;
+}
+
+// Build DER-encoded parameters = OID(szOID_ECC_CURVE_P256).
+// Caller must LocalFree *out.
+static BOOL encode_p256_curve_oid_params(BYTE** out, DWORD* out_len)
+{
+    return CryptEncodeObjectEx(X509_ASN_ENCODING, X509_OBJECT_IDENTIFIER,
+        szOID_ECC_CURVE_P256, CRYPT_ENCODE_ALLOC_FLAG, NULL, out, out_len);
+}
+
+// Build DER-encoded Subject Name with a single CN RDN.
+// Caller must LocalFree *out.
+static BOOL encode_subject_cn(const char* common_name, BYTE** out, DWORD* out_len)
+{
+    CERT_RDN_ATTR rdn_attr;
+    memset(&rdn_attr, 0, sizeof(rdn_attr));
+    rdn_attr.pszObjId = szOID_COMMON_NAME;
+    rdn_attr.dwValueType = CERT_RDN_UTF8_STRING;
+    rdn_attr.Value.pbData = (BYTE*)common_name;
+    rdn_attr.Value.cbData = (DWORD)strlen(common_name);
+
+    CERT_RDN rdn;
+    rdn.cRDNAttr = 1;
+    rdn.rgRDNAttr = &rdn_attr;
+
+    CERT_NAME_INFO name_info;
+    name_info.cRDN = 1;
+    name_info.rgRDN = &rdn;
+
+    return CryptEncodeObjectEx(X509_ASN_ENCODING, X509_NAME,
+        &name_info, CRYPT_ENCODE_ALLOC_FLAG, NULL, out, out_len);
+}
+
+// Encode the ECDSA signature (raw R||S, each P256_COORD_LEN bytes) as DER
+// SEQUENCE { INTEGER r, INTEGER s }. Caller must LocalFree *out.
+static BOOL encode_ecdsa_signature(const BYTE* raw_sig, BYTE** out, DWORD* out_len)
+{
+    CERT_ECC_SIGNATURE ecc_sig;
+    ecc_sig.r.cbData = P256_COORD_LEN;
+    ecc_sig.r.pbData = (BYTE*)raw_sig;
+    ecc_sig.s.cbData = P256_COORD_LEN;
+    ecc_sig.s.pbData = (BYTE*)(raw_sig + P256_COORD_LEN);
+    return CryptEncodeObjectEx(X509_ASN_ENCODING, X509_ECC_SIGNATURE,
+        &ecc_sig, CRYPT_ENCODE_ALLOC_FLAG, NULL, out, out_len);
+}
+
+// Build and DER-encode PKCS#8 PrivateKeyInfo for an EC P-256 private key
+// (d, with optional publicKey embedded). Caller must LocalFree *out.
+static BOOL encode_pkcs8_ec_private_key(const BYTE* d, const BYTE* pub_x, const BYTE* pub_y,
+    BYTE** out, DWORD* out_len)
+{
+    // Build uncompressed public point (0x04 || X || Y) for the optional publicKey.
+    BYTE public_point[1 + P256_COORD_LEN * 2];
+    public_point[0] = 0x04;
+    memcpy(public_point + 1, pub_x, P256_COORD_LEN);
+    memcpy(public_point + 1 + P256_COORD_LEN, pub_y, P256_COORD_LEN);
+
+    // 1. Encode RFC 5915 ECPrivateKey.
+    CRYPT_ECC_PRIVATE_KEY_INFO ec_pki;
+    memset(&ec_pki, 0, sizeof(ec_pki));
+    ec_pki.dwVersion = CRYPT_ECC_PRIVATE_KEY_INFO_v1;
+    ec_pki.PrivateKey.cbData = P256_COORD_LEN;
+    ec_pki.PrivateKey.pbData = (BYTE*)d;
+    ec_pki.szCurveOid = szOID_ECC_CURVE_P256;
+    ec_pki.PublicKey.cbData = sizeof(public_point);
+    ec_pki.PublicKey.pbData = public_point;
+
+    BYTE* ec_der = NULL;
+    DWORD ec_der_len = 0;
+    if (!CryptEncodeObjectEx(X509_ASN_ENCODING, X509_ECC_PRIVATE_KEY,
+        &ec_pki, CRYPT_ENCODE_ALLOC_FLAG, NULL, &ec_der, &ec_der_len))
+    {
+        LogError("Encode X509_ECC_PRIVATE_KEY failed (err=0x%08x)", (unsigned)GetLastError());
+        return FALSE;
+    }
+
+    // 2. Encode P-256 curve OID as algorithm parameters.
+    BYTE* curve_params = NULL;
+    DWORD curve_params_len = 0;
+    if (!encode_p256_curve_oid_params(&curve_params, &curve_params_len))
+    {
+        LogError("Encode P-256 curve OID failed (err=0x%08x)", (unsigned)GetLastError());
+        LocalFree(ec_der);
+        return FALSE;
+    }
+
+    // 3. Wrap in PKCS#8 PrivateKeyInfo.
+    CRYPT_PRIVATE_KEY_INFO pki;
+    memset(&pki, 0, sizeof(pki));
+    pki.Version = 0;
+    pki.Algorithm.pszObjId = (LPSTR)szOID_ECC_PUBLIC_KEY;
+    pki.Algorithm.Parameters.pbData = curve_params;
+    pki.Algorithm.Parameters.cbData = curve_params_len;
+    pki.PrivateKey.pbData = ec_der;
+    pki.PrivateKey.cbData = ec_der_len;
+
+    BOOL ok = CryptEncodeObjectEx(X509_ASN_ENCODING, PKCS_PRIVATE_KEY_INFO,
+        &pki, CRYPT_ENCODE_ALLOC_FLAG, NULL, out, out_len);
+
+    LocalFree(ec_der);
+    LocalFree(curve_params);
+
+    if (!ok)
+    {
+        LogError("Encode PKCS_PRIVATE_KEY_INFO failed (err=0x%08x)", (unsigned)GetLastError());
+    }
+    return ok;
+}
+
+int csr_gen_ec_p256(const char* common_name, char** csr_base64, char** private_key_pem)
+{
+    int result = MU_FAILURE;
+    BCRYPT_ALG_HANDLE hAlg = NULL;
+    BCRYPT_ALG_HANDLE hHashAlg = NULL;
+    BCRYPT_KEY_HANDLE hKey = NULL;
+    BYTE* keypair_blob = NULL;
+    DWORD blob_len = 0;
+    BYTE* subject_der = NULL;     DWORD subject_der_len = 0;
+    BYTE* curve_params = NULL;    DWORD curve_params_len = 0;
+    BYTE* tbs_der = NULL;         DWORD tbs_der_len = 0;
+    BYTE* sig_der = NULL;         DWORD sig_der_len = 0;
+    BYTE* csr_der = NULL;         DWORD csr_der_len = 0;
+    BYTE* pkcs8_der = NULL;       DWORD pkcs8_der_len = 0;
+    char* csr_b64_out = NULL;
+    char* key_pem_out = NULL;
+
+    if (common_name == NULL || csr_base64 == NULL || private_key_pem == NULL)
+    {
+        LogError("Invalid argument to csr_gen_ec_p256");
+        return MU_FAILURE;
+    }
+    *csr_base64 = NULL;
+    *private_key_pem = NULL;
+
+    do
+    {
+        // --- 1. Generate ECDSA P-256 key pair ---
+        if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(&hAlg,
+                BCRYPT_ECDSA_P256_ALGORITHM, NULL, 0)))
+        {
+            LogError("BCryptOpenAlgorithmProvider(ECDSA_P256) failed");
+            break;
+        }
+        if (!BCRYPT_SUCCESS(BCryptGenerateKeyPair(hAlg, &hKey, 256, 0)))
+        {
+            LogError("BCryptGenerateKeyPair failed");
+            break;
+        }
+        if (!BCRYPT_SUCCESS(BCryptFinalizeKeyPair(hKey, 0)))
+        {
+            LogError("BCryptFinalizeKeyPair failed");
+            break;
+        }
+
+        // --- 2. Export key material: BCRYPT_ECCKEY_BLOB header + X + Y + d ---
+        if (!BCRYPT_SUCCESS(BCryptExportKey(hKey, NULL, BCRYPT_ECCPRIVATE_BLOB,
+                NULL, 0, &blob_len, 0)))
+        {
+            LogError("BCryptExportKey size query failed");
+            break;
+        }
+        keypair_blob = (BYTE*)malloc(blob_len);
+        if (keypair_blob == NULL) { LogError("OOM keypair blob"); break; }
+        if (!BCRYPT_SUCCESS(BCryptExportKey(hKey, NULL, BCRYPT_ECCPRIVATE_BLOB,
+                keypair_blob, blob_len, &blob_len, 0)))
+        {
+            LogError("BCryptExportKey failed");
+            break;
+        }
+
+        BCRYPT_ECCKEY_BLOB* hdr = (BCRYPT_ECCKEY_BLOB*)keypair_blob;
+        if (hdr->cbKey != P256_COORD_LEN ||
+            blob_len < sizeof(BCRYPT_ECCKEY_BLOB) + 3 * P256_COORD_LEN)
+        {
+            LogError("Unexpected ECC key blob layout");
+            break;
+        }
+        const BYTE* pub_x = keypair_blob + sizeof(BCRYPT_ECCKEY_BLOB);
+        const BYTE* pub_y = pub_x + P256_COORD_LEN;
+        const BYTE* priv_d = pub_y + P256_COORD_LEN;
+
+        // --- 3. Build CSR TBS (CERT_REQUEST_INFO) ---
+        if (!encode_subject_cn(common_name, &subject_der, &subject_der_len))
+        {
+            LogError("Encode subject CN failed");
+            break;
+        }
+        if (!encode_p256_curve_oid_params(&curve_params, &curve_params_len))
+        {
+            LogError("Encode curve params failed");
+            break;
+        }
+
+        BYTE public_point[1 + P256_COORD_LEN * 2];
+        public_point[0] = 0x04;
+        memcpy(public_point + 1, pub_x, P256_COORD_LEN);
+        memcpy(public_point + 1 + P256_COORD_LEN, pub_y, P256_COORD_LEN);
+
+        CERT_REQUEST_INFO req_info;
+        memset(&req_info, 0, sizeof(req_info));
+        req_info.dwVersion = CERT_REQUEST_V1;
+        req_info.Subject.cbData = subject_der_len;
+        req_info.Subject.pbData = subject_der;
+        req_info.SubjectPublicKeyInfo.Algorithm.pszObjId = (LPSTR)szOID_ECC_PUBLIC_KEY;
+        req_info.SubjectPublicKeyInfo.Algorithm.Parameters.cbData = curve_params_len;
+        req_info.SubjectPublicKeyInfo.Algorithm.Parameters.pbData = curve_params;
+        req_info.SubjectPublicKeyInfo.PublicKey.cbData = sizeof(public_point);
+        req_info.SubjectPublicKeyInfo.PublicKey.pbData = public_point;
+        req_info.SubjectPublicKeyInfo.PublicKey.cUnusedBits = 0;
+        req_info.cAttribute = 0;
+        req_info.rgAttribute = NULL;
+
+        if (!CryptEncodeObjectEx(X509_ASN_ENCODING, X509_CERT_REQUEST_TO_BE_SIGNED,
+                &req_info, CRYPT_ENCODE_ALLOC_FLAG, NULL, &tbs_der, &tbs_der_len))
+        {
+            LogError("Encode CSR TBS failed (err=0x%08x)", (unsigned)GetLastError());
+            break;
+        }
+
+        // --- 4. SHA-256 the TBS ---
+        BYTE tbs_hash[32];
+        if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(&hHashAlg,
+                BCRYPT_SHA256_ALGORITHM, NULL, 0)))
+        {
+            LogError("BCryptOpenAlgorithmProvider(SHA256) failed");
+            break;
+        }
+        if (!BCRYPT_SUCCESS(BCryptHash(hHashAlg, NULL, 0,
+                tbs_der, tbs_der_len, tbs_hash, sizeof(tbs_hash))))
+        {
+            LogError("BCryptHash failed");
+            break;
+        }
+
+        // --- 5. Sign hash (raw ECDSA -> R||S, 64 bytes for P-256) ---
+        BYTE raw_sig[P256_COORD_LEN * 2];
+        DWORD raw_sig_len = 0;
+        if (!BCRYPT_SUCCESS(BCryptSignHash(hKey, NULL, tbs_hash, sizeof(tbs_hash),
+                raw_sig, sizeof(raw_sig), &raw_sig_len, 0))
+            || raw_sig_len != sizeof(raw_sig))
+        {
+            LogError("BCryptSignHash failed");
+            break;
+        }
+
+        if (!encode_ecdsa_signature(raw_sig, &sig_der, &sig_der_len))
+        {
+            LogError("Encode ECDSA signature failed");
+            break;
+        }
+
+        // --- 6. Build CERT_SIGNED_CONTENT_INFO and encode full CSR ---
+        CERT_SIGNED_CONTENT_INFO signed_info;
+        memset(&signed_info, 0, sizeof(signed_info));
+        signed_info.ToBeSigned.cbData = tbs_der_len;
+        signed_info.ToBeSigned.pbData = tbs_der;
+        signed_info.SignatureAlgorithm.pszObjId = (LPSTR)szOID_ECDSA_SHA256;
+        signed_info.SignatureAlgorithm.Parameters.cbData = 0;
+        signed_info.SignatureAlgorithm.Parameters.pbData = NULL;
+        signed_info.Signature.cbData = sig_der_len;
+        signed_info.Signature.pbData = sig_der;
+        signed_info.Signature.cUnusedBits = 0;
+
+        if (!CryptEncodeObjectEx(X509_ASN_ENCODING, X509_CERT,
+                &signed_info, CRYPT_ENCODE_ALLOC_FLAG, NULL, &csr_der, &csr_der_len))
+        {
+            LogError("Encode signed CSR failed (err=0x%08x)", (unsigned)GetLastError());
+            break;
+        }
+
+        // --- 7. Base64-encode the CSR DER (no line breaks, no PEM armor) ---
+        DWORD b64_len = 0;
+        if (!CryptBinaryToStringA(csr_der, csr_der_len,
+                CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, NULL, &b64_len))
+        {
+            LogError("CryptBinaryToStringA size query failed");
+            break;
+        }
+        csr_b64_out = (char*)malloc(b64_len);
+        if (csr_b64_out == NULL) { LogError("OOM csr base64"); break; }
+        if (!CryptBinaryToStringA(csr_der, csr_der_len,
+                CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, csr_b64_out, &b64_len))
+        {
+            LogError("CryptBinaryToStringA failed");
+            break;
+        }
+
+        // --- 8. Export private key as PKCS#8 PEM ---
+        if (!encode_pkcs8_ec_private_key(priv_d, pub_x, pub_y, &pkcs8_der, &pkcs8_der_len))
+        {
+            break;
+        }
+
+        key_pem_out = pem_wrap("PRIVATE KEY", pkcs8_der, pkcs8_der_len);
+        if (key_pem_out == NULL)
+        {
+            LogError("pem_wrap failed");
+            break;
+        }
+
+        *csr_base64 = csr_b64_out; csr_b64_out = NULL;
+        *private_key_pem = key_pem_out; key_pem_out = NULL;
+        result = 0;
+    } while (0);
+
+    free(csr_b64_out);
+    free(key_pem_out);
+    if (keypair_blob != NULL)
+    {
+        SecureZeroMemory(keypair_blob, blob_len);
+        free(keypair_blob);
+    }
+    secure_local_free(subject_der);
+    secure_local_free(curve_params);
+    secure_local_free(tbs_der);
+    secure_local_free(sig_der);
+    secure_local_free(csr_der);
+    if (pkcs8_der != NULL)
+    {
+        SecureZeroMemory(pkcs8_der, pkcs8_der_len);
+        LocalFree(pkcs8_der);
+    }
+    if (hKey != NULL) BCryptDestroyKey(hKey);
+    if (hHashAlg != NULL) BCryptCloseAlgorithmProvider(hHashAlg, 0);
+    if (hAlg != NULL) BCryptCloseAlgorithmProvider(hAlg, 0);
+
+    return result;
+}

--- a/inc/azure_c_shared_utility/csr_gen.h
+++ b/inc/azure_c_shared_utility/csr_gen.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Platform-abstracted Certificate Signing Request (CSR) generation.
+//
+// Two implementations are provided in c-utility/adapters:
+//   - csr_gen_openssl.c  (built when use_openssl  is ON)
+//   - csr_gen_schannel.c (built when use_schannel is ON)
+//
+// Both implementations produce byte-identical output *formats*:
+//   csr_base64      = Base64(DER(PKCS#10 CertificationRequest)), no PEM armor
+//   private_key_pem = PEM "-----BEGIN PRIVATE KEY-----" PKCS#8 PrivateKeyInfo
+// so downstream consumers do not need to know which platform API produced them.
+
+#ifndef CSR_GEN_H
+#define CSR_GEN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "umock_c/umock_c_prod.h"
+
+// Generate a P-256 ECDSA key pair, build a CSR with the given common name signed
+// with the new key, and return the base64(DER) CSR plus PKCS#8 PEM private key.
+// On success returns 0 and sets *csr_base64 / *private_key_pem to malloc'd
+// NUL-terminated strings owned by the caller. On failure returns non-zero.
+MOCKABLE_FUNCTION(, int, csr_gen_ec_p256, const char*, common_name, char**, csr_base64, char**, private_key_pem);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CSR_GEN_H */


### PR DESCRIPTION
Introduce csr_gen.h with csr_gen_ec_p256() and two adapter implementations:
  - adapters/csr_gen_openssl.c  (Linux, built with use_openssl)
  - adapters/csr_gen_schannel.c (Windows, built with use_schannel, using BCrypt + CryptEncodeObjectEx)

Both produce identical output formats:
  * csr_base64      = Base64(DER(PKCS#10 CertificationRequest))
  * private_key_pem = PKCS#8 PEM

This lets test/e2e code generate ECDSA P-256 CSRs without calling native SSL APIs directly.