### PR TITLE
xlogging.h: undef LogInfo/LogError macros in NO_LOGGING shim

### DIFF
--- a/inc/azure_c_shared_utility/xlogging.h
+++ b/inc/azure_c_shared_utility/xlogging.h
@@ -42,6 +42,12 @@ typedef void(*LOGGER_LOG_GETLASTERROR)(const char* file, const char* func, int l
 
 #ifdef NO_LOGGING
 /*no logging is useful when time and fprintf are mocked*/
+/* Undef any macros previously defined by c-logging (logger_v1_v2.h) */
+#undef LOG
+#undef LogInfo
+#undef LogBinary
+#undef LogError
+#undef LogLastError
 #define LOG(...)
 #define LogInfo(...)
 #define LogBinary(...)


### PR DESCRIPTION
When NO_LOGGING is defined, xlogging.h redefines LogInfo, LogError, etc. as no-op macros. However, downstream consumers (e.g. c-logging v2) may have already defined these as function-style macros, causing redefinition warnings/errors.

This change #undefs each macro before redefining it under NO_LOGGING, matching the pattern already used elsewhere in the file.

Discovered while migrating uamqp/umqtt/uhttp/utpm to c-build-tools (round-6 NO_LOGGING build config).