### PR TITLE
installed-deps: re-export c_logging_v2 and find_dependency(macro_utils_c)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,7 +718,7 @@ if(LINUX)
     endif()
 endif()
 
-target_link_libraries(aziotsharedutil PUBLIC ${aziotsharedutil_target_libs})
+target_link_libraries(aziotsharedutil PUBLIC ${aziotsharedutil_target_libs} c_logging_v2)
 if(${build_as_dynamic})
     target_link_libraries(aziotsharedutil_dll PUBLIC ${aziotsharedutil_target_libs} macro_utils_c)
     target_link_libraries(aziotsharedutil_dll PRIVATE c_logging_v2)
@@ -777,6 +777,13 @@ if(${build_as_dynamic})
 else(${build_as_dynamic})
     set(targets aziotsharedutil)
 endif(${build_as_dynamic})
+
+# Re-export c_logging_v2 (and c_logging_v2_core) via aziotsharedutilTargets so
+# downstream installed-deps consumers can resolve the c_logging_v2 imported
+# target referenced by aziotsharedutil's INTERFACE_LINK_LIBRARIES.
+if(TARGET c_logging_v2 AND TARGET c_logging_v2_core)
+    list(APPEND targets c_logging_v2 c_logging_v2_core)
+endif()
 
 install (TARGETS ${targets} EXPORT aziotsharedutilTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/configs/azure_c_shared_utilityConfig.cmake
+++ b/configs/azure_c_shared_utilityConfig.cmake
@@ -1,9 +1,14 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+include(CMakeFindDependencyMacro)
+
+# aziotsharedutil's exported targets reference macro_utils_c via INTERFACE_LINK_LIBRARIES,
+# so consumers must be able to resolve it before the targets file is included.
+find_dependency(macro_utils_c)
+
 if(UNIX)
     if(${use_http})
-        include(CMakeFindDependencyMacro)
         find_dependency(CURL)
     endif()
 endif()


### PR DESCRIPTION
Downstream consumers using -Duse_installed_dependencies=ON failed to link because the installed ziotsharedutilTargets.cmake referenced macro_utils_c and c_logging_v2 imported targets that were never exported with the c-utility package.

## Symptoms

uhttp/uamqp built from a fresh make install of c-utility hit:

``nCMake Error at CMakeLists.txt:84 (find_package):
  ... azure_c_shared_utility ... considered to be NOT FOUND.
  The following imported targets are referenced, but are missing:
  macro_utils_c
``n
or at link time for samples:

``n/usr/bin/ld: ... undefined reference to `logger_log`
``n
## Changes

- configs/azure_c_shared_utilityConfig.cmake: add ind_dependency(macro_utils_c) so the macro_utils_c target is loaded before ziotsharedutilTargets is included. macro-utils-c already installs its own package config under <prefix>/cmake/.
- CMakeLists.txt: link ziotsharedutil PUBLIC c_logging_v2 (consumers need logger_log when expanding xlogging.h macros) and re-export c_logging_v2 and c_logging_v2_core via ziotsharedutilTargets so consumers don't need to separately ind_package(c_logging) (which has no installed config).

## Verified

Fresh linux_install_deps.sh end-to-end now succeeds for both uhttp (samples/uhttp_sample links cleanly) and uamqp (all transports' samples build) on Ubuntu 22.04.