### PR TITLE
Add TLS SNI extension to wolfSSL adapter

### DIFF
--- a/adapters/tlsio_wolfssl.c
+++ b/adapters/tlsio_wolfssl.c
@@ -597,6 +597,32 @@ static int enable_domain_check(TLS_IO_INSTANCE* tls_io_instance)
     return result;
 }
 
+// SNI (Server Name Indication) sends the hostname in the TLS ClientHello so the
+// server can select the correct certificate.  This is separate from domain-name
+// validation performed by wolfSSL_check_domain_name(), which only checks the
+// server certificate CN/SAN after the handshake completes.
+static int enable_sni(TLS_IO_INSTANCE* tls_io_instance)
+{
+    int result = 0;
+
+#ifdef HAVE_SNI
+    if (tls_io_instance->hostname != NULL)
+    {
+        if (wolfSSL_UseSNI(tls_io_instance->ssl, WOLFSSL_SNI_HOST_NAME,
+                           tls_io_instance->hostname,
+                           (unsigned short)strlen(tls_io_instance->hostname)) != WOLFSSL_SUCCESS)
+        {
+            LogError("Failed to set SNI hostname to '%s'", tls_io_instance->hostname);
+            result = MU_FAILURE;
+        }
+    }
+#else
+    (void)tls_io_instance;
+#endif
+
+    return result;
+}
+
 static int prepare_wolfssl_open(TLS_IO_INSTANCE* tls_io_instance)
 {
     int result;
@@ -604,6 +630,11 @@ static int prepare_wolfssl_open(TLS_IO_INSTANCE* tls_io_instance)
     if (enable_domain_check(tls_io_instance))
     {
         LogError("Failed to configure domain name verification");
+        result = MU_FAILURE;
+    }
+    else if (enable_sni(tls_io_instance) != 0)
+    {
+        LogError("Failed to configure SNI");
         result = MU_FAILURE;
     }
     else if (add_certificate_to_store(tls_io_instance) != 0)

--- a/tests/tlsio_wolfssl_ut/tlsio_wolfssl_ut.c
+++ b/tests/tlsio_wolfssl_ut/tlsio_wolfssl_ut.c
@@ -135,6 +135,10 @@ MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_get_error, WOLFSSL*, ssl, int,
 MOCK_FUNCTION_END(SSL_SUCCESS)
 MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_check_domain_name, WOLFSSL*, ssl, const char*, dn)
 MOCK_FUNCTION_END(SSL_SUCCESS)
+#ifdef HAVE_SNI
+MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_UseSNI, WOLFSSL*, ssl, unsigned char, type, const void*, data, unsigned short, size)
+MOCK_FUNCTION_END(WOLFSSL_SUCCESS)
+#endif
 
 #if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX >= 0x04000000
 MOCK_FUNCTION_WITH_CODE(WOLFSSL_API, int, wolfSSL_Debugging_ON)
@@ -399,6 +403,9 @@ TEST_FUNCTION(tlsio_wolfssl_open_set_dev_id_succeeds)
 
     STRICT_EXPECTED_CALL(wolfSSL_SetDevId(TEST_WOLFSSL, 11));
     STRICT_EXPECTED_CALL(wolfSSL_check_domain_name(TEST_WOLFSSL, IGNORED_ARG));
+#ifdef HAVE_SNI
+    STRICT_EXPECTED_CALL(wolfSSL_UseSNI(TEST_WOLFSSL, WOLFSSL_SNI_HOST_NAME, IGNORED_ARG, IGNORED_ARG));
+#endif
     STRICT_EXPECTED_CALL(xio_open(TEST_IO_HANDLE, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(wolfSSL_connect(TEST_WOLFSSL));
 
@@ -428,6 +435,9 @@ TEST_FUNCTION(tlsio_wolfssl_open_set_dev_id_2_succeeds)
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(wolfSSL_check_domain_name(TEST_WOLFSSL, IGNORED_ARG));
+#ifdef HAVE_SNI
+    STRICT_EXPECTED_CALL(wolfSSL_UseSNI(TEST_WOLFSSL, WOLFSSL_SNI_HOST_NAME, IGNORED_ARG, IGNORED_ARG));
+#endif
     STRICT_EXPECTED_CALL(xio_open(TEST_IO_HANDLE, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(wolfSSL_connect(TEST_WOLFSSL));
     STRICT_EXPECTED_CALL(wolfSSL_SetDevId(TEST_WOLFSSL, 11));
@@ -1016,5 +1026,30 @@ TEST_FUNCTION(tlsio_wolfssl_on_io_recv_timeout_success)
     (void)tlsio_wolfssl_close(io_handle, on_close_complete, NULL);
     tlsio_wolfssl_destroy(io_handle);
 }
+
+#ifdef HAVE_SNI
+TEST_FUNCTION(tlsio_wolfssl_open_sni_failure_fails)
+{
+    //arrange
+    TLSIO_CONFIG tls_io_config;
+    memset(&tls_io_config, 0, sizeof(tls_io_config));
+    tls_io_config.hostname = TEST_HOSTNAME;
+    CONCRETE_IO_HANDLE io_handle = tlsio_wolfssl_create(&tls_io_config);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(wolfSSL_check_domain_name(TEST_WOLFSSL, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(wolfSSL_UseSNI(TEST_WOLFSSL, WOLFSSL_SNI_HOST_NAME, IGNORED_ARG, IGNORED_ARG))
+        .SetReturn(WOLFSSL_FAILURE);
+
+    //act
+    int test_result = tlsio_wolfssl_open(io_handle, on_io_open_complete, NULL, on_bytes_recv, NULL, on_error, NULL);
+
+    //assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, test_result);
+
+    //clean
+    tlsio_wolfssl_destroy(io_handle);
+}
+#endif
 
 END_TEST_SUITE(tlsio_wolfssl_ut)


### PR DESCRIPTION
## Summary

The wolfSSL TLS adapter (`tlsio_wolfssl.c`) calls `wolfSSL_check_domain_name()` for post-handshake certificate validation but **never calls `wolfSSL_UseSNI()`** to set the TLS Server Name Indication (SNI) extension in the ClientHello message. This causes all clients using the wolfSSL adapter to connect without SNI, preventing TLS servers from selecting the correct certificate based on the requested hostname.

## Root Cause

`wolfSSL_check_domain_name()` only configures CN/SAN validation of the server certificate **after** the handshake completes. It does **not** add the SNI extension to the outgoing ClientHello. The `wolfSSL_UseSNI()` API is required for that purpose.

In contrast, the mbedTLS adapter already handles this correctly because `mbedtls_ssl_set_hostname()` sets both certificate validation **and** the SNI extension in a single call.

This was previously reported in #2154, where SNI was incorrectly claimed to be enabled. The response conflated `wolfSSL_check_domain_name` (certificate validation) with `wolfSSL_UseSNI` (TLS extension) — these are two entirely different mechanisms.

## Changes

### `adapters/tlsio_wolfssl.c`
- Added `enable_sni()` function that calls `wolfSSL_UseSNI()` with `WOLFSSL_SNI_HOST_NAME`
- Guarded by `#ifdef HAVE_SNI` so it compiles to a no-op when wolfSSL is built without SNI support
- Called from `prepare_wolfssl_open()` after `enable_domain_check()`
- Logs an error on SNI configuration failure

### `tests/tlsio_wolfssl_ut/tlsio_wolfssl_ut.c`
- Added `wolfSSL_UseSNI` mock (guarded by `#ifdef HAVE_SNI`)
- Updated existing `open` tests to expect the `wolfSSL_UseSNI` call in the correct sequence
- Added `tlsio_wolfssl_open_sni_failure_fails` test for the SNI failure path

## Impact

All IoT device clients using the wolfSSL TLS adapter will now send the correct SNI hostname in TLS ClientHello messages, enabling servers to:
- Select the appropriate TLS certificate based on hostname
- Route connections correctly in multi-tenant environments

This affects embedded IoT devices connecting to Azure IoT Hub and Azure Device Provisioning Service (DPS). Telemetry analysis shows approximately **17% of MQTT connections** to Azure DPS arrive without SNI due to this gap.

## Build Compatibility

The fix is guarded by `#ifdef HAVE_SNI`, which is a standard wolfSSL compile-time flag. When `HAVE_SNI` is not defined (e.g., minimal wolfSSL builds), the code compiles to a no-op with no behavioral change.

## Related

- Fixes #2154 (SNI not set in wolfSSL adapter)