### PR TITLE
Add Negotiate/GSSAPI proxy authentication for HTTPS and MQTT-over-WSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ option(use_builtin_httpapi "set use_builtin_httpapi to ON to use the built-in ht
 option(use_cppunittest "set use_cppunittest to ON to build CppUnitTest tests on Windows (default is OFF)" OFF)
 option(suppress_header_searches "do not try to find headers - used when compiler check will fail" OFF)
 option(use_custom_heap "use externally defined heap functions instead of the malloc family" OFF)
+option(use_gssapi "set use_gssapi to ON to enable Kerberos/SPNEGO proxy authentication in http_proxy_io (default is OFF)" OFF)
 option(no_openssl_engine "Disables the use of ENGINEs in OpenSSL" OFF)
 option(enable_ipv6 "set enable_ipv6 to ON to enable dual-ip-stack (IPv4 and IPv6) support (default is OFF for IPv4 only)" OFF)
 
@@ -716,6 +717,11 @@ if(LINUX)
     if(${use_c_ares})
         set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} cares)
     endif()
+endif()
+
+if(${use_gssapi})
+    set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} gssapi_krb5)
+    add_definitions(-DAZURE_C_SHARED_UTILITY_USE_GSSAPI=1)
 endif()
 
 target_link_libraries(aziotsharedutil PUBLIC ${aziotsharedutil_target_libs} c_logging_v2)

--- a/adapters/httpapi_curl.c
+++ b/adapters/httpapi_curl.c
@@ -1043,6 +1043,12 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
                 }
                 else
                 {
+                    /* Negotiate (Kerberos/SPNEGO) proxy auth, falling back to Basic.
+                     * Curl picks whichever scheme the proxy advertises in 407 responses.
+                     * Ignore CURLE_NOT_BUILT_IN: if curl lacks GSSAPI, Basic still works. */
+                    (void)curl_easy_setopt(httpHandleData->curl, CURLOPT_PROXYAUTH,
+                                           CURLAUTH_NEGOTIATE | CURLAUTH_BASIC);
+
                     if (proxy_data->username != NULL && proxy_data->password != NULL)
                     {
                         size_t authLen = safe_add_size_t(strlen(proxy_data->username), strlen(proxy_data->password));

--- a/devdoc/http_proxy_io_requirements.md
+++ b/devdoc/http_proxy_io_requirements.md
@@ -92,6 +92,8 @@ int http_proxy_io_open(CONCRETE_IO_HANDLE http_proxy_io, ON_IO_OPEN_COMPLETE on_
 
 **SRS_HTTP_PROXY_IO_01_051: [** The arguments `on_io_open_complete_context`, `on_bytes_received_context` and `on_io_error_context` shall be allowed to be NULL. **]**
 
+**SRS_HTTP_PROXY_IO_01_105: [** `http_proxy_io_open` shall free any CONNECT response bytes buffered during a previous open attempt before opening the underlying IO. **]**
+
 ###  http_proxy_io_close
 
 `http_proxy_io_close` is the implementation provided via `http_proxy_io_get_interface_description` for the `concrete_io_close` member.
@@ -269,6 +271,28 @@ extern const IO_INTERFACE_DESCRIPTION* http_proxy_io_get_interface_description(v
 **SRS_HTTP_PROXY_IO_01_088: [** `on_underlying_io_error` called with NULL context shall do nothing. **]**
 
 **SRS_HTTP_PROXY_IO_01_089: [** If the `on_underlying_io_error` callback is called while the IO is OPEN, the `on_io_error` callback shall be called with the `on_io_error_context` argument as `context`. **]**
+
+###  Negotiate (SPNEGO) proxy authentication
+
+The following requirements apply only when the library is built with `AZURE_C_SHARED_UTILITY_USE_GSSAPI` (CMake option `use_gssapi`). Relevant specifications: RFC 4559 (SPNEGO-based HTTP authentication), RFC 7235 (HTTP authentication framework).
+
+**SRS_HTTP_PROXY_IO_01_096: [** If the CONNECT response status code is 407 and the response contains a `Proxy-Authenticate` challenge for the `Negotiate` scheme, the IO shall attempt SPNEGO authentication by sending a new CONNECT request carrying a `Proxy-Authorization: Negotiate <base64 token>` header. **]**
+
+**SRS_HTTP_PROXY_IO_01_097: [** The `Negotiate` challenge shall be recognized case-insensitively at any position within a comma-separated challenge list and across multiple `Proxy-Authenticate` header lines. **]**
+
+**SRS_HTTP_PROXY_IO_01_098: [** If the challenge carries a base64 token, that token shall be base64-decoded and passed as the input token to `gss_init_sec_context` for the next handshake round; a bare `Negotiate` challenge shall start a round with no input token. **]**
+
+**SRS_HTTP_PROXY_IO_01_099: [** `gss_init_sec_context` shall be invoked requesting the SPNEGO mechanism (OID 1.3.6.1.5.5.2). **]**
+
+**SRS_HTTP_PROXY_IO_01_100: [** Before parsing the response to the follow-up CONNECT, any not-yet-received body bytes of the 407 response (per `Content-Length`) shall be discarded. **]**
+
+**SRS_HTTP_PROXY_IO_01_101: [** If the 407 body length cannot be determined unambiguously (`Transfer-Encoding` present, `Content-Length` missing, malformed, or overflowing), the negotiation shall be aborted and the `on_open_complete` callback triggered with `IO_OPEN_ERROR`. **]**
+
+**SRS_HTTP_PROXY_IO_01_102: [** If the 407 response indicates `Connection: close` (or `Proxy-Connection: close`), the negotiation shall be aborted and the `on_open_complete` callback triggered with `IO_OPEN_ERROR`. **]**
+
+**SRS_HTTP_PROXY_IO_01_103: [** If the proxy replies 407 again after GSSAPI has reported the security context complete, or if `gss_init_sec_context` fails or yields an empty output token, the `on_open_complete` callback shall be triggered with `IO_OPEN_ERROR`. **]**
+
+**SRS_HTTP_PROXY_IO_01_104: [** `http_proxy_io_open` shall discard any partially negotiated state from a previous session (GSS security context, negotiate-complete flag, body-drain counter) before opening the underlying IO. **]**
 
 ## RFC 2817 relevant part
 

--- a/src/http_proxy_io.c
+++ b/src/http_proxy_io.c
@@ -20,7 +20,6 @@
 #include <ctype.h>
 #include <string.h>
 #include <gssapi/gssapi.h>
-#include <gssapi/gssapi_krb5.h>
 #endif
 
 static const char* const OPTION_UNDERLYING_IO_OPTIONS = "underlying_io_options";
@@ -265,6 +264,12 @@ static void http_proxy_io_destroy(CONCRETE_IO_HANDLE http_proxy_io)
 #ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
 static void unchecked_on_send_complete(void* context, IO_SEND_RESULT send_result);
 
+/* Static OIDs instead of the libraries' exported constants: RFC 4559 requires
+ * SPNEGO (not raw krb5) tokens under the Negotiate scheme, and MIT/Heimdal
+ * export these under different symbol names. */
+static gss_OID_desc spnego_mech_oid = { 6, (void*)"\x2b\x06\x01\x05\x05\x02" };                         /* 1.3.6.1.5.5.2 */
+static gss_OID_desc hostbased_service_oid = { 10, (void*)"\x2a\x86\x48\x86\xf7\x12\x01\x02\x01\x04" };  /* 1.2.840.113554.1.2.1.4 */
+
 /* Case-insensitive ASCII prefix match. Used to find headers regardless of how
  * a particular proxy chose to capitalize them. */
 static int has_prefix_ci(const char* s, size_t s_len, const char* prefix, size_t prefix_len)
@@ -284,16 +289,42 @@ static int has_prefix_ci(const char* s, size_t s_len, const char* prefix, size_t
     return 1;
 }
 
+/* True if the comma-separated header value [value, value_end) contains the
+ * token "close" (case-insensitive, whole word). */
+static int value_has_close_token(const char* value, const char* value_end)
+{
+    const char* p = value;
+    while (p < value_end)
+    {
+        const char* token_start;
+        while ((p < value_end) && ((*p == ' ') || (*p == '\t') || (*p == ',')))
+        {
+            p++;
+        }
+        token_start = p;
+        while ((p < value_end) && (*p != ' ') && (*p != '\t') && (*p != ','))
+        {
+            p++;
+        }
+        if (((size_t)(p - token_start) == 5) && has_prefix_ci(token_start, 5, "close", 5))
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* Inspect the buffered 407 response and compute how many body bytes still need
  * to be discarded before the proxy's reply to the next CONNECT can be parsed.
- * On success returns 0 and writes the drain count to *drain (0 if the response
- * carried no body, or if everything is already in the buffer). Returns
- * non-zero if the body length cannot be determined unambiguously: chunked
- * transfer-encoding, missing Content-Length, or a malformed Content-Length
- * value — in any of those cases the only safe move is to abort the negotiate
- * retry, since reusing the connection would risk parsing body bytes as the
- * start of the next response. */
-static int compute_body_drain(const unsigned char* response, size_t response_size, size_t* drain)
+ * On success returns 0, writes the drain count to *drain (0 if the response
+ * carried no body, or if everything is already in the buffer) and sets
+ * *connection_close if the proxy announced it will close the connection.
+ * Returns non-zero if the body length cannot be determined unambiguously:
+ * chunked transfer-encoding, missing Content-Length, or a malformed
+ * Content-Length value — in any of those cases the only safe move is to abort
+ * the negotiate retry, since reusing the connection would risk parsing body
+ * bytes as the start of the next response. */
+static int compute_body_drain(const unsigned char* response, size_t response_size, size_t* drain, int* connection_close)
 {
     const char* p = (const char*)response;
     const char* headers_end;
@@ -303,6 +334,7 @@ static int compute_body_drain(const unsigned char* response, size_t response_siz
     const char* line;
 
     *drain = 0;
+    *connection_close = 0;
     headers_end = strstr(p, "\r\n\r\n");
     if (headers_end == NULL)
     {
@@ -345,6 +377,10 @@ static int compute_body_drain(const unsigned char* response, size_t response_siz
             }
             while ((value < next_line) && (*value >= '0') && (*value <= '9'))
             {
+                if (parsed > (SIZE_MAX - 9) / 10)
+                {
+                    return __LINE__;
+                }
                 parsed = (parsed * 10) + (size_t)(*value - '0');
                 found_digit = 1;
                 value++;
@@ -354,6 +390,17 @@ static int compute_body_drain(const unsigned char* response, size_t response_siz
                 return __LINE__;
             }
             content_length = parsed;
+        }
+        /* Codes_SRS_HTTP_PROXY_IO_01_102: [ If the 407 response indicates Connection: close (or Proxy-Connection: close), the negotiation shall be aborted and the on_open_complete callback triggered with IO_OPEN_ERROR. ]*/
+        if (has_prefix_ci(line, line_len, "Connection:", 11) &&
+            value_has_close_token(line + 11, next_line))
+        {
+            *connection_close = 1;
+        }
+        if (has_prefix_ci(line, line_len, "Proxy-Connection:", 17) &&
+            value_has_close_token(line + 17, next_line))
+        {
+            *connection_close = 1;
         }
         line = next_line + 2;
     }
@@ -372,11 +419,33 @@ static int compute_body_drain(const unsigned char* response, size_t response_siz
     return 0;
 }
 
-/* Walk the CONNECT response headers and locate a `Proxy-Authenticate: Negotiate
- * [<token>]` challenge. On success returns 0 and `*out_token` points to a
- * malloc'd null-terminated copy of the base64 token (empty string if the proxy
- * sent only the bare `Negotiate` keyword). Returns non-zero if no Negotiate
- * challenge is present. */
+/* True if [s, end) is a token68/base64 run: base64 alphabet with '=' accepted
+ * only as trailing padding. */
+static int is_base64_token(const char* s, const char* end)
+{
+    const char* p = s;
+    if (p == end)
+    {
+        return 0;
+    }
+    while ((p < end) &&
+           (((*p >= 'A') && (*p <= 'Z')) || ((*p >= 'a') && (*p <= 'z')) ||
+            ((*p >= '0') && (*p <= '9')) || (*p == '+') || (*p == '/')))
+    {
+        p++;
+    }
+    while ((p < end) && (*p == '='))
+    {
+        p++;
+    }
+    return (p == end) ? 1 : 0;
+}
+
+/* Walk the CONNECT response headers and locate a `Negotiate [<token>]`
+ * challenge in a `Proxy-Authenticate` header. On success returns 0 and
+ * `*out_token` points to a malloc'd null-terminated copy of the base64 token
+ * (empty string if the proxy sent only the bare `Negotiate` keyword). Returns
+ * non-zero if no Negotiate challenge is present. */
 static int extract_negotiate_challenge(const char* response, char** out_token)
 {
     static const char header_name[] = "Proxy-Authenticate:";
@@ -406,46 +475,75 @@ static int extract_negotiate_challenge(const char* response, char** out_token)
         line_len = (size_t)(next_line - line);
         if (has_prefix_ci(line, line_len, header_name, header_name_len))
         {
-            const char* value = line + header_name_len;
+            /* Codes_SRS_HTTP_PROXY_IO_01_097: [ The Negotiate challenge shall be recognized case-insensitively at any position within a comma-separated challenge list and across multiple Proxy-Authenticate header lines. ]*/
+            /* RFC 7235: the value is a comma-separated challenge list. A naive
+             * split would also cut a challenge's own auth-param list apart
+             * (e.g. `Digest realm="x", qop="auth"`), but that is harmless for
+             * locating a whole-word `Negotiate` member; commas inside quoted
+             * strings must not split, or `Basic realm="a,b"` would leak
+             * fragments that could false-match. */
+            const char* member = line + header_name_len;
             const char* line_end = next_line;
-            const char* scheme;
-            const char* token_start;
-            const char* token_end;
-            size_t scheme_len;
-            size_t token_len;
-            while ((value < line_end) && (*value == ' ' || *value == '\t'))
+            while (member < line_end)
             {
-                value++;
-            }
-            scheme = value;
-            scheme_len = (size_t)(line_end - scheme);
-            /* Match "Negotiate" case-insensitively as a whole word. */
-            if ((scheme_len >= 9) &&
-                has_prefix_ci(scheme, scheme_len, "Negotiate", 9) &&
-                ((scheme_len == 9) || (scheme[9] == ' ') || (scheme[9] == '\t')))
-            {
-                token_start = scheme + 9;
-                while ((token_start < line_end) && (*token_start == ' ' || *token_start == '\t'))
+                const char* member_end;
+                const char* trimmed;
+                size_t member_len;
+                int in_quotes = 0;
+                while ((member < line_end) && ((*member == ' ') || (*member == '\t') || (*member == ',')))
                 {
-                    token_start++;
+                    member++;
                 }
-                token_end = line_end;
-                while ((token_end > token_start) && ((*(token_end - 1) == ' ') || (*(token_end - 1) == '\t')))
+                member_end = member;
+                while ((member_end < line_end) && (in_quotes || (*member_end != ',')))
                 {
-                    token_end--;
+                    if (*member_end == '"')
+                    {
+                        in_quotes = !in_quotes;
+                    }
+                    else if (in_quotes && (*member_end == '\\') && ((member_end + 1) < line_end))
+                    {
+                        member_end++;
+                    }
+                    member_end++;
                 }
-                token_len = (size_t)(token_end - token_start);
-                *out_token = (char*)malloc(token_len + 1);
-                if (*out_token == NULL)
+                trimmed = member_end;
+                while ((trimmed > member) && ((*(trimmed - 1) == ' ') || (*(trimmed - 1) == '\t')))
                 {
-                    return __LINE__;
+                    trimmed--;
                 }
-                if (token_len > 0)
+                member_len = (size_t)(trimmed - member);
+                if ((member_len >= 9) &&
+                    has_prefix_ci(member, member_len, "Negotiate", 9) &&
+                    ((member_len == 9) || (member[9] == ' ') || (member[9] == '\t')))
                 {
-                    memcpy(*out_token, token_start, token_len);
+                    const char* token_start = member + 9;
+                    size_t token_len;
+                    while ((token_start < trimmed) && ((*token_start == ' ') || (*token_start == '\t')))
+                    {
+                        token_start++;
+                    }
+                    /* Anything after the keyword that is not a token68/base64
+                     * run is an auth-param list, which RFC 4559 does not
+                     * define for Negotiate — treat the challenge as bare. */
+                    if (!is_base64_token(token_start, trimmed))
+                    {
+                        token_start = trimmed;
+                    }
+                    token_len = (size_t)(trimmed - token_start);
+                    *out_token = (char*)malloc(token_len + 1);
+                    if (*out_token == NULL)
+                    {
+                        return __LINE__;
+                    }
+                    if (token_len > 0)
+                    {
+                        memcpy(*out_token, token_start, token_len);
+                    }
+                    (*out_token)[token_len] = '\0';
+                    return 0;
                 }
-                (*out_token)[token_len] = '\0';
-                return 0;
+                member = member_end + 1;
             }
         }
         line = next_line + 2;
@@ -475,7 +573,7 @@ static int ensure_gss_target_name(HTTP_PROXY_IO_INSTANCE* instance)
     (void)sprintf(name_str, "HTTP@%s", instance->proxy_hostname);
     name_buffer.value = name_str;
     name_buffer.length = name_len;
-    major = gss_import_name(&minor, &name_buffer, (gss_OID)GSS_C_NT_HOSTBASED_SERVICE, &instance->gss_target_name);
+    major = gss_import_name(&minor, &name_buffer, &hostbased_service_oid, &instance->gss_target_name);
     free(name_str);
     if (GSS_ERROR(major))
     {
@@ -506,6 +604,7 @@ static int gss_step_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* serv
         return __LINE__;
     }
 
+    /* Codes_SRS_HTTP_PROXY_IO_01_098: [ If the challenge carries a base64 token, that token shall be base64-decoded and passed as the input token to gss_init_sec_context for the next handshake round; a bare Negotiate challenge shall start a round with no input token. ]*/
     if ((server_token_b64 != NULL) && (server_token_b64[0] != '\0'))
     {
         decoded_input = Azure_Base64_Decode(server_token_b64);
@@ -518,12 +617,15 @@ static int gss_step_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* serv
         input_token.length = BUFFER_length(decoded_input);
     }
 
+    /* Codes_SRS_HTTP_PROXY_IO_01_099: [ gss_init_sec_context shall be invoked requesting the SPNEGO mechanism (OID 1.3.6.1.5.5.2). ]*/
+    /* No GSS_C_MUTUAL_FLAG: the server's final token (delivered in the 200
+     * response) is never processed, so mutual auth could not be verified. */
     major = gss_init_sec_context(&minor,
                                  GSS_C_NO_CREDENTIAL,
                                  &instance->gss_ctx,
                                  instance->gss_target_name,
-                                 (gss_OID)gss_mech_krb5,
-                                 GSS_C_MUTUAL_FLAG | GSS_C_SEQUENCE_FLAG,
+                                 &spnego_mech_oid,
+                                 GSS_C_SEQUENCE_FLAG,
                                  0,
                                  GSS_C_NO_CHANNEL_BINDINGS,
                                  (decoded_input != NULL) ? &input_token : GSS_C_NO_BUFFER,
@@ -537,6 +639,7 @@ static int gss_step_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* serv
         BUFFER_delete(decoded_input);
     }
 
+    /* Codes_SRS_HTTP_PROXY_IO_01_103: [ If the proxy replies 407 again after GSSAPI has reported the security context complete, or if gss_init_sec_context fails or yields an empty output token, the on_open_complete callback shall be triggered with IO_OPEN_ERROR. ]*/
     if (GSS_ERROR(major))
     {
         LogError("gss_init_sec_context failed (major=0x%08x minor=0x%08x)", (unsigned int)major, (unsigned int)minor);
@@ -544,16 +647,16 @@ static int gss_step_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* serv
         return __LINE__;
     }
 
-    if (major == GSS_S_COMPLETE)
-    {
-        instance->negotiate_complete = 1;
-    }
-
     if (output_token.length == 0)
     {
         (void)gss_release_buffer(&minor, &output_token);
         LogError("gss_init_sec_context returned an empty output token");
         return __LINE__;
+    }
+
+    if (major == GSS_S_COMPLETE)
+    {
+        instance->negotiate_complete = 1;
     }
 
     *out_b64 = Azure_Base64_Encode_Bytes((const unsigned char*)output_token.value, output_token.length);
@@ -629,6 +732,7 @@ static int try_proxy_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* res
     char* server_token = NULL;
     STRING_HANDLE encoded_output = NULL;
     size_t drain = 0;
+    int connection_close = 0;
     int result;
 
     if (extract_negotiate_challenge(response, &server_token) != 0)
@@ -636,6 +740,7 @@ static int try_proxy_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* res
         return __LINE__;
     }
 
+    /* Codes_SRS_HTTP_PROXY_IO_01_103: [ If the proxy replies 407 again after GSSAPI has reported the security context complete, or if gss_init_sec_context fails or yields an empty output token, the on_open_complete callback shall be triggered with IO_OPEN_ERROR. ]*/
     /* If we've already told GSSAPI we're done and the proxy still says 407,
      * we have nothing left to offer — fail. */
     if (instance->negotiate_complete)
@@ -649,9 +754,19 @@ static int try_proxy_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* res
      * still need to be discarded before the proxy's reply to the next CONNECT
      * can be parsed — otherwise tail body bytes corrupt the next status line
      * and we get "Cannot decode HTTP response". */
-    if (compute_body_drain(instance->receive_buffer, instance->receive_buffer_size, &drain) != 0)
+    /* Codes_SRS_HTTP_PROXY_IO_01_101: [ If the 407 body length cannot be determined unambiguously (Transfer-Encoding present, Content-Length missing, malformed, or overflowing), the negotiation shall be aborted and the on_open_complete callback triggered with IO_OPEN_ERROR. ]*/
+    if (compute_body_drain(instance->receive_buffer, instance->receive_buffer_size, &drain, &connection_close) != 0)
     {
         LogError("Cannot determine 407 body length for keep-alive drain");
+        free(server_token);
+        return __LINE__;
+    }
+
+    if (connection_close)
+    {
+        /* The follow-up CONNECT would go into a socket the proxy is about to
+         * close; fail fast so the caller can retry on a fresh connection. */
+        LogError("Proxy indicated Connection: close on the 407 response");
         free(server_token);
         return __LINE__;
     }
@@ -681,6 +796,19 @@ static int try_proxy_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* res
     result = send_connect_with_negotiate(instance, encoded_output);
     STRING_delete(encoded_output);
     return result;
+}
+
+/* Codes_SRS_HTTP_PROXY_IO_01_104: [ http_proxy_io_open shall discard any partially negotiated state from a previous session (GSS security context, negotiate-complete flag, body-drain counter) before opening the underlying IO. ]*/
+static void reset_negotiate_state(HTTP_PROXY_IO_INSTANCE* instance)
+{
+    if (instance->gss_ctx != GSS_C_NO_CONTEXT)
+    {
+        OM_uint32 minor;
+        (void)gss_delete_sec_context(&minor, &instance->gss_ctx, GSS_C_NO_BUFFER);
+        instance->gss_ctx = GSS_C_NO_CONTEXT;
+    }
+    instance->negotiate_complete = 0;
+    instance->body_bytes_to_drain = 0;
 }
 #endif /* AZURE_C_SHARED_UTILITY_USE_GSSAPI */
 
@@ -1091,6 +1219,7 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
         case HTTP_PROXY_IO_STATE_WAITING_FOR_CONNECT_RESPONSE:
         {
 #ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+            /* Codes_SRS_HTTP_PROXY_IO_01_100: [ Before parsing the response to the follow-up CONNECT, any not-yet-received body bytes of the 407 response (per Content-Length) shall be discarded. ]*/
             /* Drain any remaining body bytes from the prior 407 response
              * before parsing the reply to the follow-up CONNECT. */
             if (http_proxy_io_instance->body_bytes_to_drain > 0)
@@ -1161,6 +1290,7 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                     else if ((status_code < 200) || (status_code > 299))
                     {
 #ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+                        /* Codes_SRS_HTTP_PROXY_IO_01_096: [ If the CONNECT response status code is 407 and the response contains a Proxy-Authenticate challenge for the Negotiate scheme, the IO shall attempt SPNEGO authentication by sending a new CONNECT request carrying a Proxy-Authorization: Negotiate <base64 token> header. ]*/
                         if ((status_code == 407) &&
                             (try_proxy_negotiate(http_proxy_io_instance,
                                                  (const char*)http_proxy_io_instance->receive_buffer) == 0))
@@ -1239,6 +1369,17 @@ static int http_proxy_io_open(CONCRETE_IO_HANDLE http_proxy_io, ON_IO_OPEN_COMPL
 
             http_proxy_io_instance->on_io_open_complete = on_io_open_complete;
             http_proxy_io_instance->on_io_open_complete_context = on_io_open_complete_context;
+
+            /* Codes_SRS_HTTP_PROXY_IO_01_105: [ http_proxy_io_open shall free any CONNECT response bytes buffered during a previous open attempt before opening the underlying IO. ]*/
+            if (http_proxy_io_instance->receive_buffer != NULL)
+            {
+                free(http_proxy_io_instance->receive_buffer);
+                http_proxy_io_instance->receive_buffer = NULL;
+            }
+            http_proxy_io_instance->receive_buffer_size = 0;
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+            reset_negotiate_state(http_proxy_io_instance);
+#endif
 
             http_proxy_io_instance->http_proxy_io_state = HTTP_PROXY_IO_STATE_OPENING_UNDERLYING_IO;
 

--- a/src/http_proxy_io.c
+++ b/src/http_proxy_io.c
@@ -13,6 +13,15 @@
 #include "azure_c_shared_utility/http_proxy_io.h"
 #include "azure_c_shared_utility/azure_base64.h"
 #include "azure_c_shared_utility/safe_math.h"
+#include "azure_c_shared_utility/strings.h"
+#include "azure_c_shared_utility/buffer_.h"
+
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+#include <ctype.h>
+#include <string.h>
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_krb5.h>
+#endif
 
 static const char* const OPTION_UNDERLYING_IO_OPTIONS = "underlying_io_options";
 
@@ -46,6 +55,12 @@ typedef struct HTTP_PROXY_IO_INSTANCE_TAG
     XIO_HANDLE underlying_io;
     unsigned char* receive_buffer;
     size_t receive_buffer_size;
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+    gss_ctx_id_t gss_ctx;
+    gss_name_t gss_target_name;
+    int negotiate_complete;
+    size_t body_bytes_to_drain;
+#endif
 } HTTP_PROXY_IO_INSTANCE;
 
 static CONCRETE_IO_HANDLE http_proxy_io_create(void* io_create_parameters)
@@ -189,6 +204,12 @@ static CONCRETE_IO_HANDLE http_proxy_io_create(void* io_create_parameters)
                                         result->receive_buffer = NULL;
                                         result->receive_buffer_size = 0;
                                         result->http_proxy_io_state = HTTP_PROXY_IO_STATE_CLOSED;
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+                                        result->gss_ctx = GSS_C_NO_CONTEXT;
+                                        result->gss_target_name = GSS_C_NO_NAME;
+                                        result->negotiate_complete = 0;
+                                        result->body_bytes_to_drain = 0;
+#endif
                                     }
                                 }
                             }
@@ -221,6 +242,18 @@ static void http_proxy_io_destroy(CONCRETE_IO_HANDLE http_proxy_io)
 
         /* Codes_SRS_HTTP_PROXY_IO_01_016: [ http_proxy_io_destroy shall destroy the underlying IO created in http_proxy_io_create by calling xio_destroy. ]*/
         xio_destroy(http_proxy_io_instance->underlying_io);
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+        if (http_proxy_io_instance->gss_ctx != GSS_C_NO_CONTEXT)
+        {
+            OM_uint32 minor;
+            (void)gss_delete_sec_context(&minor, &http_proxy_io_instance->gss_ctx, GSS_C_NO_BUFFER);
+        }
+        if (http_proxy_io_instance->gss_target_name != GSS_C_NO_NAME)
+        {
+            OM_uint32 minor;
+            (void)gss_release_name(&minor, &http_proxy_io_instance->gss_target_name);
+        }
+#endif
         free(http_proxy_io_instance->hostname);
         free(http_proxy_io_instance->proxy_hostname);
         free(http_proxy_io_instance->username);
@@ -228,6 +261,428 @@ static void http_proxy_io_destroy(CONCRETE_IO_HANDLE http_proxy_io)
         free(http_proxy_io_instance);
     }
 }
+
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+static void unchecked_on_send_complete(void* context, IO_SEND_RESULT send_result);
+
+/* Case-insensitive ASCII prefix match. Used to find headers regardless of how
+ * a particular proxy chose to capitalize them. */
+static int has_prefix_ci(const char* s, size_t s_len, const char* prefix, size_t prefix_len)
+{
+    size_t i;
+    if (s_len < prefix_len)
+    {
+        return 0;
+    }
+    for (i = 0; i < prefix_len; i++)
+    {
+        if (tolower((unsigned char)s[i]) != tolower((unsigned char)prefix[i]))
+        {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* Inspect the buffered 407 response and compute how many body bytes still need
+ * to be discarded before the proxy's reply to the next CONNECT can be parsed.
+ * On success returns 0 and writes the drain count to *drain (0 if the response
+ * carried no body, or if everything is already in the buffer). Returns
+ * non-zero if the body length cannot be determined unambiguously: chunked
+ * transfer-encoding, missing Content-Length, or a malformed Content-Length
+ * value — in any of those cases the only safe move is to abort the negotiate
+ * retry, since reusing the connection would risk parsing body bytes as the
+ * start of the next response. */
+static int compute_body_drain(const unsigned char* response, size_t response_size, size_t* drain)
+{
+    const char* p = (const char*)response;
+    const char* headers_end;
+    size_t headers_len;
+    size_t body_in_buffer;
+    size_t content_length = (size_t)-1;
+    const char* line;
+
+    *drain = 0;
+    headers_end = strstr(p, "\r\n\r\n");
+    if (headers_end == NULL)
+    {
+        return __LINE__;
+    }
+    headers_len = (size_t)(headers_end - p);
+    body_in_buffer = response_size - headers_len - 4;
+
+    /* Walk header lines, skipping the status line. */
+    line = strstr(p, "\r\n");
+    if ((line == NULL) || (line >= headers_end))
+    {
+        return __LINE__;
+    }
+    line += 2;
+    while (line < headers_end)
+    {
+        const char* next_line = strstr(line, "\r\n");
+        size_t line_len;
+        if ((next_line == NULL) || (next_line > headers_end))
+        {
+            next_line = headers_end;
+        }
+        line_len = (size_t)(next_line - line);
+
+        if (has_prefix_ci(line, line_len, "Transfer-Encoding:", 18))
+        {
+            /* Any Transfer-Encoding (chunked or otherwise) on a 407 means we
+             * cannot compute drain from a simple byte count. Bail. */
+            return __LINE__;
+        }
+        if (has_prefix_ci(line, line_len, "Content-Length:", 15))
+        {
+            const char* value = line + 15;
+            size_t parsed = 0;
+            int found_digit = 0;
+            while ((value < next_line) && ((*value == ' ') || (*value == '\t')))
+            {
+                value++;
+            }
+            while ((value < next_line) && (*value >= '0') && (*value <= '9'))
+            {
+                parsed = (parsed * 10) + (size_t)(*value - '0');
+                found_digit = 1;
+                value++;
+            }
+            if (!found_digit)
+            {
+                return __LINE__;
+            }
+            content_length = parsed;
+        }
+        line = next_line + 2;
+    }
+
+    if (content_length == (size_t)-1)
+    {
+        /* RFC 7230: without Content-Length or chunked, the body is delimited
+         * by connection close — so the connection cannot be reused. */
+        return __LINE__;
+    }
+
+    if (content_length > body_in_buffer)
+    {
+        *drain = content_length - body_in_buffer;
+    }
+    return 0;
+}
+
+/* Walk the CONNECT response headers and locate a `Proxy-Authenticate: Negotiate
+ * [<token>]` challenge. On success returns 0 and `*out_token` points to a
+ * malloc'd null-terminated copy of the base64 token (empty string if the proxy
+ * sent only the bare `Negotiate` keyword). Returns non-zero if no Negotiate
+ * challenge is present. */
+static int extract_negotiate_challenge(const char* response, char** out_token)
+{
+    static const char header_name[] = "Proxy-Authenticate:";
+    const size_t header_name_len = sizeof(header_name) - 1;
+    const char* headers_end;
+    const char* line;
+    *out_token = NULL;
+    headers_end = strstr(response, "\r\n\r\n");
+    if (headers_end == NULL)
+    {
+        return __LINE__;
+    }
+    line = strstr(response, "\r\n");
+    if ((line == NULL) || (line >= headers_end))
+    {
+        return __LINE__;
+    }
+    line += 2;
+    while (line < headers_end)
+    {
+        const char* next_line = strstr(line, "\r\n");
+        size_t line_len;
+        if ((next_line == NULL) || (next_line > headers_end))
+        {
+            next_line = headers_end;
+        }
+        line_len = (size_t)(next_line - line);
+        if (has_prefix_ci(line, line_len, header_name, header_name_len))
+        {
+            const char* value = line + header_name_len;
+            const char* line_end = next_line;
+            const char* scheme;
+            const char* token_start;
+            const char* token_end;
+            size_t scheme_len;
+            size_t token_len;
+            while ((value < line_end) && (*value == ' ' || *value == '\t'))
+            {
+                value++;
+            }
+            scheme = value;
+            scheme_len = (size_t)(line_end - scheme);
+            /* Match "Negotiate" case-insensitively as a whole word. */
+            if ((scheme_len >= 9) &&
+                has_prefix_ci(scheme, scheme_len, "Negotiate", 9) &&
+                ((scheme_len == 9) || (scheme[9] == ' ') || (scheme[9] == '\t')))
+            {
+                token_start = scheme + 9;
+                while ((token_start < line_end) && (*token_start == ' ' || *token_start == '\t'))
+                {
+                    token_start++;
+                }
+                token_end = line_end;
+                while ((token_end > token_start) && ((*(token_end - 1) == ' ') || (*(token_end - 1) == '\t')))
+                {
+                    token_end--;
+                }
+                token_len = (size_t)(token_end - token_start);
+                *out_token = (char*)malloc(token_len + 1);
+                if (*out_token == NULL)
+                {
+                    return __LINE__;
+                }
+                if (token_len > 0)
+                {
+                    memcpy(*out_token, token_start, token_len);
+                }
+                (*out_token)[token_len] = '\0';
+                return 0;
+            }
+        }
+        line = next_line + 2;
+    }
+    return __LINE__;
+}
+
+/* Resolve the GSS service name "HTTP@<proxy-host>" on first use and cache it
+ * on the instance for subsequent rounds of the SPNEGO handshake. */
+static int ensure_gss_target_name(HTTP_PROXY_IO_INSTANCE* instance)
+{
+    OM_uint32 major, minor;
+    gss_buffer_desc name_buffer;
+    size_t name_len;
+    char* name_str;
+    if (instance->gss_target_name != GSS_C_NO_NAME)
+    {
+        return 0;
+    }
+    name_len = strlen("HTTP@") + strlen(instance->proxy_hostname);
+    name_str = (char*)malloc(name_len + 1);
+    if (name_str == NULL)
+    {
+        LogError("Cannot allocate GSS service name");
+        return __LINE__;
+    }
+    (void)sprintf(name_str, "HTTP@%s", instance->proxy_hostname);
+    name_buffer.value = name_str;
+    name_buffer.length = name_len;
+    major = gss_import_name(&minor, &name_buffer, (gss_OID)GSS_C_NT_HOSTBASED_SERVICE, &instance->gss_target_name);
+    free(name_str);
+    if (GSS_ERROR(major))
+    {
+        LogError("gss_import_name failed (major=0x%08x minor=0x%08x)", (unsigned int)major, (unsigned int)minor);
+        instance->gss_target_name = GSS_C_NO_NAME;
+        return __LINE__;
+    }
+    return 0;
+}
+
+/* Run one round of gss_init_sec_context using `server_token_b64` (may be empty
+ * for the first round) and place the base64-encoded output token into
+ * `out_b64`. Caller owns *out_b64 and must STRING_delete it. Returns 0 on
+ * success, non-zero on failure. Marks negotiate_complete when GSSAPI signals
+ * the local side has nothing more to send. */
+static int gss_step_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* server_token_b64, STRING_HANDLE* out_b64)
+{
+    OM_uint32 major, minor;
+    gss_buffer_desc input_token = GSS_C_EMPTY_BUFFER;
+    gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
+    BUFFER_HANDLE decoded_input = NULL;
+    int result = 0;
+
+    *out_b64 = NULL;
+
+    if (ensure_gss_target_name(instance) != 0)
+    {
+        return __LINE__;
+    }
+
+    if ((server_token_b64 != NULL) && (server_token_b64[0] != '\0'))
+    {
+        decoded_input = Azure_Base64_Decode(server_token_b64);
+        if (decoded_input == NULL)
+        {
+            LogError("Cannot base64-decode server Negotiate token");
+            return __LINE__;
+        }
+        input_token.value = BUFFER_u_char(decoded_input);
+        input_token.length = BUFFER_length(decoded_input);
+    }
+
+    major = gss_init_sec_context(&minor,
+                                 GSS_C_NO_CREDENTIAL,
+                                 &instance->gss_ctx,
+                                 instance->gss_target_name,
+                                 (gss_OID)gss_mech_krb5,
+                                 GSS_C_MUTUAL_FLAG | GSS_C_SEQUENCE_FLAG,
+                                 0,
+                                 GSS_C_NO_CHANNEL_BINDINGS,
+                                 (decoded_input != NULL) ? &input_token : GSS_C_NO_BUFFER,
+                                 NULL,
+                                 &output_token,
+                                 NULL,
+                                 NULL);
+
+    if (decoded_input != NULL)
+    {
+        BUFFER_delete(decoded_input);
+    }
+
+    if (GSS_ERROR(major))
+    {
+        LogError("gss_init_sec_context failed (major=0x%08x minor=0x%08x)", (unsigned int)major, (unsigned int)minor);
+        (void)gss_release_buffer(&minor, &output_token);
+        return __LINE__;
+    }
+
+    if (major == GSS_S_COMPLETE)
+    {
+        instance->negotiate_complete = 1;
+    }
+
+    if (output_token.length == 0)
+    {
+        (void)gss_release_buffer(&minor, &output_token);
+        LogError("gss_init_sec_context returned an empty output token");
+        return __LINE__;
+    }
+
+    *out_b64 = Azure_Base64_Encode_Bytes((const unsigned char*)output_token.value, output_token.length);
+    (void)gss_release_buffer(&minor, &output_token);
+    if (*out_b64 == NULL)
+    {
+        LogError("Cannot base64-encode GSSAPI output token");
+        result = __LINE__;
+    }
+    return result;
+}
+
+/* Build "CONNECT host:port HTTP/1.1\r\nHost:host:port\r\nProxy-Authorization:
+ * Negotiate <b64>\r\n\r\n" and dispatch via xio_send. Returns 0 on success.
+ * On success the caller continues to wait in
+ * HTTP_PROXY_IO_STATE_WAITING_FOR_CONNECT_RESPONSE for the proxy's next reply. */
+static int send_connect_with_negotiate(HTTP_PROXY_IO_INSTANCE* instance, STRING_HANDLE b64_token)
+{
+    static const char request_format[] = "CONNECT %s:%d HTTP/1.1\r\nHost:%s:%d\r\nProxy-Authorization: Negotiate %s\r\n\r\n";
+    const char* token_str = STRING_c_str(b64_token);
+    int request_length;
+    char* connect_request;
+    int result;
+
+    request_length = (int)(strlen(request_format)
+                           + (strlen(instance->hostname) * 2)
+                           + strlen(token_str)
+                           + 12);
+    connect_request = (char*)malloc(request_length + 1);
+    if (connect_request == NULL)
+    {
+        LogError("Cannot allocate Negotiate CONNECT request");
+        return __LINE__;
+    }
+
+    request_length = sprintf(connect_request,
+                             request_format,
+                             instance->hostname,
+                             instance->port,
+                             instance->hostname,
+                             instance->port,
+                             token_str);
+    if (request_length < 0)
+    {
+        LogError("Cannot encode Negotiate CONNECT request");
+        free(connect_request);
+        return __LINE__;
+    }
+
+    if (xio_send(instance->underlying_io, connect_request, (size_t)request_length, unchecked_on_send_complete, NULL) != 0)
+    {
+        LogError("Could not send Negotiate CONNECT request");
+        result = __LINE__;
+    }
+    else
+    {
+        result = 0;
+    }
+
+    free(connect_request);
+    return result;
+}
+
+/* Combined entry point used from the bytes-received state machine: extract the
+ * server's Negotiate token from the buffered 407 response, compute how many
+ * body bytes still need to be drained, run one GSS step, send the resulting
+ * CONNECT, and reset the receive buffer so the next response is parsed
+ * cleanly. Returns 0 if a follow-up CONNECT is in flight and the caller
+ * should keep waiting; non-zero if the SPNEGO attempt failed (caller should
+ * error out). */
+static int try_proxy_negotiate(HTTP_PROXY_IO_INSTANCE* instance, const char* response)
+{
+    char* server_token = NULL;
+    STRING_HANDLE encoded_output = NULL;
+    size_t drain = 0;
+    int result;
+
+    if (extract_negotiate_challenge(response, &server_token) != 0)
+    {
+        return __LINE__;
+    }
+
+    /* If we've already told GSSAPI we're done and the proxy still says 407,
+     * we have nothing left to offer — fail. */
+    if (instance->negotiate_complete)
+    {
+        free(server_token);
+        return __LINE__;
+    }
+
+    /* The 407 typically carries an HTML body that has not yet fully arrived
+     * over TCP at the moment we see the headers. Compute how many body bytes
+     * still need to be discarded before the proxy's reply to the next CONNECT
+     * can be parsed — otherwise tail body bytes corrupt the next status line
+     * and we get "Cannot decode HTTP response". */
+    if (compute_body_drain(instance->receive_buffer, instance->receive_buffer_size, &drain) != 0)
+    {
+        LogError("Cannot determine 407 body length for keep-alive drain");
+        free(server_token);
+        return __LINE__;
+    }
+
+    result = gss_step_negotiate(instance, server_token, &encoded_output);
+    free(server_token);
+    if (result != 0)
+    {
+        if (encoded_output != NULL)
+        {
+            STRING_delete(encoded_output);
+        }
+        return result;
+    }
+
+    /* Reset receive buffer so the response to the next CONNECT is parsed from
+     * a clean slate. The drain counter ensures any in-flight body bytes get
+     * discarded before parsing starts. */
+    if (instance->receive_buffer != NULL)
+    {
+        free(instance->receive_buffer);
+        instance->receive_buffer = NULL;
+    }
+    instance->receive_buffer_size = 0;
+    instance->body_bytes_to_drain = drain;
+
+    result = send_connect_with_negotiate(instance, encoded_output);
+    STRING_delete(encoded_output);
+    return result;
+}
+#endif /* AZURE_C_SHARED_UTILITY_USE_GSSAPI */
 
 static void indicate_open_complete_error_and_close(HTTP_PROXY_IO_INSTANCE* http_proxy_io_instance)
 {
@@ -635,6 +1090,23 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
 
         case HTTP_PROXY_IO_STATE_WAITING_FOR_CONNECT_RESPONSE:
         {
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+            /* Drain any remaining body bytes from the prior 407 response
+             * before parsing the reply to the follow-up CONNECT. */
+            if (http_proxy_io_instance->body_bytes_to_drain > 0)
+            {
+                size_t drop = (size < http_proxy_io_instance->body_bytes_to_drain)
+                              ? size
+                              : http_proxy_io_instance->body_bytes_to_drain;
+                http_proxy_io_instance->body_bytes_to_drain -= drop;
+                buffer += drop;
+                size -= drop;
+                if (size == 0)
+                {
+                    break;
+                }
+            }
+#endif
             /* Codes_SRS_HTTP_PROXY_IO_01_065: [ When bytes are received and the response to the CONNECT request was not yet received, the bytes shall be accumulated until a double new-line is detected. ]*/
             // size_t malloc_size = http_proxy_io_instance->receive_buffer_size + size + 1;
             size_t realloc_size = safe_add_size_t(safe_add_size_t(http_proxy_io_instance->receive_buffer_size, size), 1);
@@ -688,6 +1160,17 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                     /* Codes_SRS_HTTP_PROXY_IO_01_090: [ Any successful (2xx) response to a CONNECT request indicates that the proxy has established a connection to the requested host and port, and has switched to tunneling the current connection to that server connection. ]*/
                     else if ((status_code < 200) || (status_code > 299))
                     {
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+                        if ((status_code == 407) &&
+                            (try_proxy_negotiate(http_proxy_io_instance,
+                                                 (const char*)http_proxy_io_instance->receive_buffer) == 0))
+                        {
+                            /* A follow-up CONNECT with Proxy-Authorization: Negotiate
+                             * <token> is now in flight; stay in WAITING_FOR_CONNECT_RESPONSE
+                             * and let the next response be parsed from a clean buffer. */
+                            break;
+                        }
+#endif
                         /* Codes_SRS_HTTP_PROXY_IO_01_071: [ If the status code is not successful, the on_open_complete callback shall be triggered with IO_OPEN_ERROR, passing also the on_open_complete_context argument as context. ]*/
                         LogError("Bad status (%d) received in CONNECT response", status_code);
                         indicate_open_complete_error_and_close(http_proxy_io_instance);

--- a/tests/http_proxy_io_ut/http_proxy_io_ut.c
+++ b/tests/http_proxy_io_ut/http_proxy_io_ut.c
@@ -83,6 +83,48 @@ MOCK_FUNCTION_END();
 
 #undef ENABLE_MOCKS
 
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+
+#include <gssapi/gssapi.h>
+
+#define TEST_BUFFER_HANDLE                      (BUFFER_HANDLE)0x4245
+#define TEST_GSS_NAME                           (gss_name_t)0x4321
+#define TEST_GSS_CTX                            (gss_ctx_id_t)0x4322
+
+static unsigned char test_gss_output_token_bytes[16] = { 0x60, 0x01 };
+static size_t g_gss_output_token_length;
+static OM_uint32 g_gss_init_result;
+static unsigned char test_decoded_server_token[4] = { 0xa1, 0x01 };
+
+/* The gss library is not linked into this test; these mocks stand in for it,
+ * following the tlsio_wolfssl_ut pattern for external libraries. */
+MOCK_FUNCTION_WITH_CODE(, OM_uint32, gss_import_name, OM_uint32*, minor_status, gss_buffer_t, input_name_buffer, gss_OID, input_name_type, gss_name_t*, output_name)
+    *minor_status = 0;
+    *output_name = TEST_GSS_NAME;
+MOCK_FUNCTION_END(GSS_S_COMPLETE)
+MOCK_FUNCTION_WITH_CODE(, OM_uint32, gss_init_sec_context, OM_uint32*, minor_status, gss_cred_id_t, claimant_cred_handle, gss_ctx_id_t*, context_handle, gss_name_t, target_name, gss_OID, mech_type, OM_uint32, req_flags, OM_uint32, time_req, gss_channel_bindings_t, input_chan_bindings, gss_buffer_t, input_token, gss_OID*, actual_mech_type, gss_buffer_t, output_token, OM_uint32*, ret_flags, OM_uint32*, time_rec)
+    *minor_status = 0;
+    if (!GSS_ERROR(g_gss_init_result))
+    {
+        *context_handle = TEST_GSS_CTX;
+    }
+    output_token->value = test_gss_output_token_bytes;
+    output_token->length = g_gss_output_token_length;
+MOCK_FUNCTION_END(g_gss_init_result)
+MOCK_FUNCTION_WITH_CODE(, OM_uint32, gss_delete_sec_context, OM_uint32*, minor_status, gss_ctx_id_t*, context_handle, gss_buffer_t, output_token)
+    *minor_status = 0;
+    *context_handle = GSS_C_NO_CONTEXT;
+MOCK_FUNCTION_END(GSS_S_COMPLETE)
+MOCK_FUNCTION_WITH_CODE(, OM_uint32, gss_release_name, OM_uint32*, minor_status, gss_name_t*, input_name)
+    *minor_status = 0;
+    *input_name = GSS_C_NO_NAME;
+MOCK_FUNCTION_END(GSS_S_COMPLETE)
+MOCK_FUNCTION_WITH_CODE(, OM_uint32, gss_release_buffer, OM_uint32*, minor_status, gss_buffer_t, buffer)
+    *minor_status = 0;
+MOCK_FUNCTION_END(GSS_S_COMPLETE)
+
+#endif /* AZURE_C_SHARED_UTILITY_USE_GSSAPI */
+
 static char* umocktypes_stringify_const_SOCKETIO_CONFIG_ptr(const SOCKETIO_CONFIG** value)
 {
     char* result = NULL;
@@ -339,6 +381,18 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_UMOCK_ALIAS_TYPE(ON_IO_CLOSE_COMPLETE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(ON_SEND_COMPLETE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(STRING_HANDLE, void*);
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+    REGISTER_UMOCK_ALIAS_TYPE(BUFFER_HANDLE, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(OM_uint32, unsigned int);
+    REGISTER_UMOCK_ALIAS_TYPE(gss_cred_id_t, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(gss_name_t, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(gss_OID, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(gss_buffer_t, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(gss_channel_bindings_t, void*);
+    REGISTER_GLOBAL_MOCK_RETURN(Azure_Base64_Decode, TEST_BUFFER_HANDLE);
+    REGISTER_GLOBAL_MOCK_RETURN(BUFFER_u_char, test_decoded_server_token);
+    REGISTER_GLOBAL_MOCK_RETURN(BUFFER_length, sizeof(test_decoded_server_token));
+#endif
     REGISTER_UMOCKC_PAIRED_CREATE_DESTROY_CALLS(xio_create, xio_destroy);
 }
 
@@ -355,6 +409,11 @@ TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
     {
         ASSERT_FAIL("our mutex is ABANDONED. Failure in test framework");
     }
+
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+    g_gss_init_result = GSS_S_COMPLETE;
+    g_gss_output_token_length = sizeof(test_gss_output_token_bytes);
+#endif
 
     umock_c_reset_all_calls();
 }
@@ -2578,6 +2637,8 @@ TEST_FUNCTION(after_a_bad_status_code_http_proxy_io_open_succeeds)
     g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)connect_response_300, sizeof(connect_response_300) - 1);
     umock_c_reset_all_calls();
 
+    /* Tests_SRS_HTTP_PROXY_IO_01_105: [ http_proxy_io_open shall free any CONNECT response bytes buffered during a previous open attempt before opening the underlying IO. ]*/
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
     STRICT_EXPECTED_CALL(xio_open(TEST_IO_HANDLE, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
         .IgnoreArgument_on_io_open_complete()
         .IgnoreArgument_on_io_open_complete_context()
@@ -2968,5 +3029,564 @@ TEST_FUNCTION(when_on_underlying_io_error_is_called_while_waiting_for_underlying
     // cleanup
     http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
 }
+
+#ifdef AZURE_C_SHARED_UTILITY_USE_GSSAPI
+
+/* Negotiate (SPNEGO) proxy authentication */
+
+static const char negotiate_connect_request[] = "CONNECT test_host:443 HTTP/1.1\r\nHost:test_host:443\r\nProxy-Authorization: Negotiate fake_gss_token\r\n\r\n";
+
+static CONCRETE_IO_HANDLE setup_negotiate_waiting_io(void)
+{
+    CONCRETE_IO_HANDLE http_io = http_proxy_io_get_interface_description()->concrete_io_create((void*)&http_proxy_io_config_no_username);
+    (void)http_proxy_io_get_interface_description()->concrete_io_open(http_io, test_on_io_open_complete, (void*)0x4242, test_on_bytes_received, (void*)0x4243, test_on_io_error, (void*)0x4244);
+    g_on_io_open_complete(g_on_io_open_complete_context, IO_OPEN_OK);
+    umock_c_reset_all_calls();
+    return http_io;
+}
+
+/* Expected calls for a first negotiate round on a fresh instance: challenge
+ * extraction, GSS service name resolution, one GSS step and the follow-up
+ * CONNECT carrying the encoded token. */
+static void expect_first_negotiate_round(void)
+{
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG)); // accumulate 407
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // challenge token copy
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // GSS service name
+    EXPECTED_CALL(gss_import_name(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // GSS service name
+    EXPECTED_CALL(gss_init_sec_context(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(Azure_Base64_Encode_Bytes(IGNORED_ARG, sizeof(test_gss_output_token_bytes)));
+    EXPECTED_CALL(gss_release_buffer(IGNORED_ARG, IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // challenge token copy
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // receive buffer
+    STRICT_EXPECTED_CALL(STRING_c_str(TEST_STRING_HANDLE))
+        .SetReturn("fake_gss_token");
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // CONNECT request
+    STRICT_EXPECTED_CALL(xio_send(TEST_IO_HANDLE, IGNORED_ARG, sizeof(negotiate_connect_request) - 1, IGNORED_ARG, NULL))
+        .ValidateArgumentBuffer(2, negotiate_connect_request, sizeof(negotiate_connect_request) - 1);
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // CONNECT request
+    STRICT_EXPECTED_CALL(STRING_delete(TEST_STRING_HANDLE));
+}
+
+/* Expected calls when the challenge is extracted but the negotiate attempt is
+ * aborted before the GSS step (undeterminable body length, connection close,
+ * handshake already complete). */
+static void expect_negotiate_abort(void)
+{
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG)); // accumulate 407
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // challenge token copy
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // challenge token copy
+    STRICT_EXPECTED_CALL(xio_close(TEST_IO_HANDLE, NULL, NULL));
+    STRICT_EXPECTED_CALL(test_on_io_open_complete((void*)0x4242, IO_OPEN_ERROR));
+}
+
+/* Expected calls when the GSS step itself fails (gss_init_sec_context error or
+ * empty output token). */
+static void expect_negotiate_gss_step_failure(void)
+{
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG)); // accumulate 407
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // challenge token copy
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // GSS service name
+    EXPECTED_CALL(gss_import_name(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // GSS service name
+    EXPECTED_CALL(gss_init_sec_context(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    EXPECTED_CALL(gss_release_buffer(IGNORED_ARG, IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // challenge token copy
+    STRICT_EXPECTED_CALL(xio_close(TEST_IO_HANDLE, NULL, NULL));
+    STRICT_EXPECTED_CALL(test_on_io_open_complete((void*)0x4242, IO_OPEN_ERROR));
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_096: [ If the CONNECT response status code is 407 and the response contains a Proxy-Authenticate challenge for the Negotiate scheme, the IO shall attempt SPNEGO authentication by sending a new CONNECT request carrying a Proxy-Authorization: Negotiate <base64 token> header. ]*/
+/* Tests_SRS_HTTP_PROXY_IO_01_098: [ If the challenge carries a base64 token, that token shall be base64-decoded and passed as the input token to gss_init_sec_context for the next handshake round; a bare Negotiate challenge shall start a round with no input token. ]*/
+TEST_FUNCTION(negotiate_challenge_in_407_sends_CONNECT_with_negotiate_token_and_200_opens)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+
+    expect_first_negotiate_round();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // arrange (proxy accepts the authenticated CONNECT)
+    umock_c_reset_all_calls();
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(test_on_io_open_complete((void*)0x4242, IO_OPEN_OK));
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)connect_response, sizeof(connect_response) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_100: [ Before parsing the response to the follow-up CONNECT, any not-yet-received body bytes of the 407 response (per Content-Length) shall be discarded. ]*/
+TEST_FUNCTION(negotiate_drains_pending_407_body_bytes_before_parsing_next_response)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 10\r\n\r\n12345";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_first_negotiate_round();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // act (the remaining 5 body bytes trickle in and must be discarded without any processing)
+    umock_c_reset_all_calls();
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)"67890", 5);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // arrange (the response to the authenticated CONNECT parses cleanly)
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(test_on_io_open_complete((void*)0x4242, IO_OPEN_OK));
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)connect_response, sizeof(connect_response) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_100: [ Before parsing the response to the follow-up CONNECT, any not-yet-received body bytes of the 407 response (per Content-Length) shall be discarded. ]*/
+TEST_FUNCTION(negotiate_drains_body_bytes_arriving_in_same_packet_as_next_response)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 10\r\n\r\n12345";
+    static const char drain_and_response[] = "67890HTTP/1.1 200\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_first_negotiate_round();
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    umock_c_reset_all_calls();
+
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(test_on_io_open_complete((void*)0x4242, IO_OPEN_OK));
+
+    // act (tail of the 407 body and the next response in one packet)
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)drain_and_response, sizeof(drain_and_response) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_097: [ The Negotiate challenge shall be recognized case-insensitively at any position within a comma-separated challenge list and across multiple Proxy-Authenticate header lines. ]*/
+TEST_FUNCTION(negotiate_first_in_comma_separated_challenge_list_is_recognized)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate, Basic realm=\"proxy\"\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_first_negotiate_round();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_097: [ The Negotiate challenge shall be recognized case-insensitively at any position within a comma-separated challenge list and across multiple Proxy-Authenticate header lines. ]*/
+TEST_FUNCTION(negotiate_after_other_challenge_in_list_is_recognized)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nproxy-authenticate: Basic realm=\"proxy\", negotiate\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_first_negotiate_round();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_097: [ The Negotiate challenge shall be recognized case-insensitively at any position within a comma-separated challenge list and across multiple Proxy-Authenticate header lines. ]*/
+TEST_FUNCTION(negotiate_after_challenge_with_quoted_comma_is_recognized)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"a,b\", Negotiate\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_first_negotiate_round();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_097: [ The Negotiate challenge shall be recognized case-insensitively at any position within a comma-separated challenge list and across multiple Proxy-Authenticate header lines. ]*/
+TEST_FUNCTION(negotiate_inside_quoted_string_is_not_recognized)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"foo, Negotiate xyz\"\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(xio_close(TEST_IO_HANDLE, NULL, NULL));
+    STRICT_EXPECTED_CALL(test_on_io_open_complete((void*)0x4242, IO_OPEN_ERROR));
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_071: [ If the status code is not successful, the on_open_complete callback shall be triggered with IO_OPEN_ERROR, passing also the on_open_complete_context argument as context. ]*/
+TEST_FUNCTION(a_407_without_negotiate_challenge_indicates_error)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"proxy\"\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(xio_close(TEST_IO_HANDLE, NULL, NULL));
+    STRICT_EXPECTED_CALL(test_on_io_open_complete((void*)0x4242, IO_OPEN_ERROR));
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_101: [ If the 407 body length cannot be determined unambiguously (Transfer-Encoding present, Content-Length missing, malformed, or overflowing), the negotiation shall be aborted and the on_open_complete callback triggered with IO_OPEN_ERROR. ]*/
+TEST_FUNCTION(chunked_407_response_aborts_negotiate)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nTransfer-Encoding: chunked\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_negotiate_abort();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_101: [ If the 407 body length cannot be determined unambiguously (Transfer-Encoding present, Content-Length missing, malformed, or overflowing), the negotiation shall be aborted and the on_open_complete callback triggered with IO_OPEN_ERROR. ]*/
+TEST_FUNCTION(missing_content_length_in_407_aborts_negotiate)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_negotiate_abort();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_101: [ If the 407 body length cannot be determined unambiguously (Transfer-Encoding present, Content-Length missing, malformed, or overflowing), the negotiation shall be aborted and the on_open_complete callback triggered with IO_OPEN_ERROR. ]*/
+TEST_FUNCTION(overflowing_content_length_in_407_aborts_negotiate)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 99999999999999999999999999\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_negotiate_abort();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_102: [ If the 407 response indicates Connection: close (or Proxy-Connection: close), the negotiation shall be aborted and the on_open_complete callback triggered with IO_OPEN_ERROR. ]*/
+TEST_FUNCTION(connection_close_in_407_aborts_negotiate)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_negotiate_abort();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_102: [ If the 407 response indicates Connection: close (or Proxy-Connection: close), the negotiation shall be aborted and the on_open_complete callback triggered with IO_OPEN_ERROR. ]*/
+TEST_FUNCTION(proxy_connection_close_in_407_aborts_negotiate)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 0\r\nProxy-Connection: Keep-Alive, close\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_negotiate_abort();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_103: [ If the proxy replies 407 again after GSSAPI has reported the security context complete, or if gss_init_sec_context fails or yields an empty output token, the on_open_complete callback shall be triggered with IO_OPEN_ERROR. ]*/
+TEST_FUNCTION(second_407_after_gss_complete_indicates_error)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    expect_first_negotiate_round();
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    umock_c_reset_all_calls();
+
+    expect_negotiate_abort();
+
+    // act (the proxy rejects the completed handshake - no endless retry)
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_103: [ If the proxy replies 407 again after GSSAPI has reported the security context complete, or if gss_init_sec_context fails or yields an empty output token, the on_open_complete callback shall be triggered with IO_OPEN_ERROR. ]*/
+TEST_FUNCTION(gss_init_sec_context_failure_indicates_error)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    g_gss_init_result = GSS_S_FAILURE;
+    expect_negotiate_gss_step_failure();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_103: [ If the proxy replies 407 again after GSSAPI has reported the security context complete, or if gss_init_sec_context fails or yields an empty output token, the on_open_complete callback shall be triggered with IO_OPEN_ERROR. ]*/
+TEST_FUNCTION(empty_gss_output_token_indicates_error)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    g_gss_output_token_length = 0;
+    expect_negotiate_gss_step_failure();
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_098: [ If the challenge carries a base64 token, that token shall be base64-decoded and passed as the input token to gss_init_sec_context for the next handshake round; a bare Negotiate challenge shall start a round with no input token. ]*/
+/* Tests_SRS_HTTP_PROXY_IO_01_099: [ gss_init_sec_context shall be invoked requesting the SPNEGO mechanism (OID 1.3.6.1.5.5.2). ]*/
+TEST_FUNCTION(negotiate_second_round_decodes_and_uses_the_server_token)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 0\r\n\r\n";
+    static const char response_407_with_token[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate c2VydmVy\r\nContent-Length: 0\r\n\r\n";
+
+    http_io = setup_negotiate_waiting_io();
+    g_gss_init_result = GSS_S_CONTINUE_NEEDED;
+    expect_first_negotiate_round();
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    umock_c_reset_all_calls();
+
+    g_gss_init_result = GSS_S_COMPLETE;
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG)); // accumulate second 407
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // challenge token copy
+    STRICT_EXPECTED_CALL(Azure_Base64_Decode("c2VydmVy"));
+    STRICT_EXPECTED_CALL(BUFFER_u_char(TEST_BUFFER_HANDLE));
+    STRICT_EXPECTED_CALL(BUFFER_length(TEST_BUFFER_HANDLE));
+    EXPECTED_CALL(gss_init_sec_context(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(BUFFER_delete(TEST_BUFFER_HANDLE));
+    STRICT_EXPECTED_CALL(Azure_Base64_Encode_Bytes(IGNORED_ARG, sizeof(test_gss_output_token_bytes)));
+    EXPECTED_CALL(gss_release_buffer(IGNORED_ARG, IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // challenge token copy
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // receive buffer
+    STRICT_EXPECTED_CALL(STRING_c_str(TEST_STRING_HANDLE))
+        .SetReturn("fake_gss_token");
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // CONNECT request
+    STRICT_EXPECTED_CALL(xio_send(TEST_IO_HANDLE, IGNORED_ARG, sizeof(negotiate_connect_request) - 1, IGNORED_ARG, NULL))
+        .ValidateArgumentBuffer(2, negotiate_connect_request, sizeof(negotiate_connect_request) - 1);
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // CONNECT request
+    STRICT_EXPECTED_CALL(STRING_delete(TEST_STRING_HANDLE));
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407_with_token, sizeof(response_407_with_token) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // arrange (proxy accepts)
+    umock_c_reset_all_calls();
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(test_on_io_open_complete((void*)0x4242, IO_OPEN_OK));
+
+    // act
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)connect_response, sizeof(connect_response) - 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+/* Tests_SRS_HTTP_PROXY_IO_01_104: [ http_proxy_io_open shall discard any partially negotiated state from a previous session (GSS security context, negotiate-complete flag, body-drain counter) before opening the underlying IO. ]*/
+TEST_FUNCTION(reopen_after_negotiate_in_flight_resets_negotiate_state)
+{
+    // arrange
+    CONCRETE_IO_HANDLE http_io;
+    /* Content-Length of 100 with no body in the buffer leaves 100 bytes of pending drain */
+    static const char response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 100\r\n\r\n";
+    int result;
+
+    http_io = setup_negotiate_waiting_io();
+    g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)response_407, sizeof(response_407) - 1);
+    (void)http_proxy_io_get_interface_description()->concrete_io_close(http_io, test_on_io_close_complete, (void*)0x4245);
+    umock_c_reset_all_calls();
+
+    EXPECTED_CALL(gss_delete_sec_context(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(xio_open(TEST_IO_HANDLE, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+        .IgnoreArgument_on_io_open_complete()
+        .IgnoreArgument_on_io_open_complete_context()
+        .IgnoreArgument_on_bytes_received()
+        .IgnoreArgument_on_bytes_received_context()
+        .IgnoreArgument_on_io_error()
+        .IgnoreArgument_on_io_error_context();
+
+    // act
+    result = http_proxy_io_get_interface_description()->concrete_io_open(http_io, test_on_io_open_complete, (void*)0x4242, test_on_bytes_received, (void*)0x4243, test_on_io_error, (void*)0x4244);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // arrange (fresh 407 on the new connection must not be swallowed by stale
+    // drain and must be able to negotiate again; the GSS service name stays cached)
+    g_on_io_open_complete(g_on_io_open_complete_context, IO_OPEN_OK);
+    umock_c_reset_all_calls();
+
+    EXPECTED_CALL(gballoc_realloc(IGNORED_ARG, IGNORED_ARG)); // accumulate 407
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // challenge token copy
+    EXPECTED_CALL(gss_init_sec_context(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(Azure_Base64_Encode_Bytes(IGNORED_ARG, sizeof(test_gss_output_token_bytes)));
+    EXPECTED_CALL(gss_release_buffer(IGNORED_ARG, IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // challenge token copy
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // receive buffer
+    STRICT_EXPECTED_CALL(STRING_c_str(TEST_STRING_HANDLE))
+        .SetReturn("fake_gss_token");
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); // CONNECT request
+    STRICT_EXPECTED_CALL(xio_send(TEST_IO_HANDLE, IGNORED_ARG, sizeof(negotiate_connect_request) - 1, IGNORED_ARG, NULL))
+        .ValidateArgumentBuffer(2, negotiate_connect_request, sizeof(negotiate_connect_request) - 1);
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG)); // CONNECT request
+    STRICT_EXPECTED_CALL(STRING_delete(TEST_STRING_HANDLE));
+
+    // act
+    {
+        static const char fresh_response_407[] = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Negotiate\r\nContent-Length: 0\r\n\r\n";
+        g_on_bytes_received(g_on_bytes_received_context, (const unsigned char*)fresh_response_407, sizeof(fresh_response_407) - 1);
+    }
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    http_proxy_io_get_interface_description()->concrete_io_destroy(http_io);
+}
+
+#endif /* AZURE_C_SHARED_UTILITY_USE_GSSAPI */
 
 END_TEST_SUITE(http_proxy_io_unittests)


### PR DESCRIPTION
## Summary

Adds support for authenticating to HTTP proxies that require **Negotiate (Kerberos/SPNEGO)** rather than Basic auth. This covers both proxy code paths in the library:

- **HTTPS / DPS path (`adapters/httpapi_curl.c`)** — sets `CURLOPT_PROXYAUTH` to `CURLAUTH_NEGOTIATE | CURLAUTH_BASIC`, so libcurl satisfies whichever scheme the proxy advertises in its 407 response, with Basic kept as a fallback. `CURLE_NOT_BUILT_IN` is ignored so builds of curl without GSSAPI still work.
- **MQTT-over-WSS path (`src/http_proxy_io.c`)** — the hand-rolled HTTP `CONNECT` tunnel now performs a multi-round-trip SPNEGO handshake. On a `407` carrying `Proxy-Authenticate: Negotiate`, it runs `gss_init_sec_context`, base64-encodes the output token, and re-issues `CONNECT` with `Proxy-Authorization: Negotiate <token>`, draining the 407 body before reusing the connection.

All new behavior is **gated behind a new CMake option `use_gssapi` (default OFF)**, which links `gssapi_krb5` and defines `AZURE_C_SHARED_UTILITY_USE_GSSAPI`. With the option off, the build is byte-for-byte unchanged.

## Details

- SPNEGO mechanism (OID `1.3.6.1.5.5.2`, per RFC 4559) is requested explicitly rather than raw krb5, using static OID descriptors portable across MIT and Heimdal.
- `Proxy-Authenticate` is parsed as an RFC 7235 comma-separated challenge list, honoring quoted strings, so `Negotiate` is recognized at any position and across multiple header lines (e.g. `Negotiate, Basic realm=...` and `Basic realm=..., Negotiate`).
- The negotiation aborts cleanly (→ `IO_OPEN_ERROR`) when the 407 signals `Connection: close` / `Proxy-Connection: close`, when the body length is ambiguous (`Transfer-Encoding`, missing/malformed/overflowing `Content-Length`), or when GSSAPI fails / yields an empty token.
- `http_proxy_io_open` resets all per-session negotiate state (GSS context, negotiate-complete flag, body-drain counter) and frees any stale receive buffer, so reopened instances don't hang or refuse to re-authenticate.
- `GSS_C_MUTUAL_FLAG` is not requested, since the server's final token is never processed and mutual auth could not actually be verified.

## Tests & docs

- Behavior specified as `SRS_HTTP_PROXY_IO_01_096..105` in `devdoc/http_proxy_io_requirements.md`.
- 18 new unit tests in `tests/http_proxy_io_ut` covering the negotiate handshake, body drain, challenge-list parsing, abort paths, and state reset on reopen (GSSAPI mocked).

## Compatibility / risk

- Default build (`use_gssapi=OFF`) is unaffected.
- The curl `CURLOPT_PROXYAUTH` change is active whenever a proxy is configured, but only broadens the accepted auth schemes; Basic remains the fallback.
