### PR TITLE
Fix Windows x64 CI: suppress LTCG C4702, check Release exit code, increase timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ if ((NOT TARGET c_build_tools) AND (EXISTS ${CMAKE_CURRENT_LIST_DIR}/deps/c-buil
     set_default_build_options()
 endif()
 
+# Suppress C4702 (unreachable code) which is spuriously emitted during
+# Link-Time Code Generation (/GL + /LTCG) in Release builds.
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4702")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4702")
+endif()
+
 if ((NOT TARGET macro_utils_c) AND (EXISTS ${CMAKE_CURRENT_LIST_DIR}/deps/macro-utils-c/CMakeLists.txt))
     add_subdirectory(deps/macro-utils-c)
 endif()

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -64,7 +64,7 @@ jobs:
     displayName: 'Component Detection'
 
 - job: windowsx64
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   variables:
     CodeQL.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
     CodeQL.Language: cpp

--- a/build_all/windows/build.cmd
+++ b/build_all/windows/build.cmd
@@ -165,6 +165,7 @@ if %MAKE_NUGET_PKG% == yes (
 	if not defined build-config (
 		echo ***Building both configurations***
 		msbuild /m %SOLUTION_NAME%.sln /p:Configuration=Release
+		if not !ERRORLEVEL!==0 exit /b !ERRORLEVEL!
 		msbuild /m %SOLUTION_NAME%.sln /p:Configuration=Debug
 		if not !ERRORLEVEL!==0 exit /b !ERRORLEVEL!
 	) else (


### PR DESCRIPTION
The Windows x64 job has been failing since CodeQL started actively tracing the build (rather than skipping as redundant for the same commit). Three overlapping issues fixed:

## 1. Suppress C4702 (unreachable code) in LTCG builds
Add \/wd4702\ to \CMAKE_C_FLAGS\/\CMAKE_CXX_FLAGS\ for MSVC. Warning C4702 is spuriously emitted during Link-Time Code Generation (\/GL\ + \/LTCG\) in Release builds, affecting ~60 source files across \src/\, \dapters/\, \deps/umock-c/\, and tests. These are false positives from whole-program optimization that see dead code paths invisible to per-TU compilation.

## 2. Fix build.cmd to check Release build exit code
\uild_all/windows/build.cmd\ runs Release then Debug builds sequentially, but only checks \ERRORLEVEL\ after the Debug build. The Release build's failure was silently masked. Added an \ERRORLEVEL\ check after the Release \msbuild\ call.

## 3. Increase Windows x64 timeout from 90 to 120 minutes
CodeQL build tracing adds ~5x overhead to compilation (18 min → 89 min). The 90-minute job timeout was occasionally exceeded, causing the build task to be canceled mid-Debug-build. Increased to 120 minutes.

### Build history (same commit \ff8697\, weekly scheduled):
| Date | CodeQL tracing | Result | Cause |
|------|---------------|--------|-------|
| 6/29 | Skipped (redundant) | **Pass** | Build finished in ~18 min |
| 7/6  | Active | **Fail** | Build barely finished (~89 min), CodeQL Finalize canceled |
| 7/13 | Active | **Fail** | Debug build canceled at 90-min timeout |