### PR TITLE
fix: make socketio retries recoverable

### DIFF
--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -20,6 +20,7 @@
 #endif
 
 #include <signal.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -29,6 +30,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/select.h>
+#include <sys/time.h>
 #ifdef TIZENRT
 #include <net/lwip/tcp.h>
 #else
@@ -154,8 +156,6 @@ static void* socketio_CloneOption(const char* name, const void* value)
     }
     return result;
 }
-
-
 
 /*this function destroys an option previously created*/
 static void socketio_DestroyOption(const char* name, const void* value)
@@ -703,6 +703,38 @@ static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* soc
     return result;
 }
 
+// Computes the time left until deadline. Returns false, leaving remaining
+// zeroed, once the deadline has passed.
+static bool get_time_remaining(const struct timeval* deadline, struct timeval* remaining)
+{
+    bool result;
+    struct timeval now;
+
+    (void)gettimeofday(&now, NULL);
+
+    remaining->tv_sec = deadline->tv_sec - now.tv_sec;
+    remaining->tv_usec = deadline->tv_usec - now.tv_usec;
+
+    if (remaining->tv_usec < 0)
+    {
+        remaining->tv_usec += 1000000;
+        remaining->tv_sec--;
+    }
+
+    if (remaining->tv_sec < 0 || (remaining->tv_sec == 0 && remaining->tv_usec == 0))
+    {
+        remaining->tv_sec = 0;
+        remaining->tv_usec = 0;
+        result = false;
+    }
+    else
+    {
+        result = true;
+    }
+
+    return result;
+}
+
 static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
 {
     int result;
@@ -713,6 +745,8 @@ static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
     fd_set fdset;
     struct timeval tv;
 
+    // FD_SET indexes the descriptor set by descriptor value, so a descriptor at
+    // or above FD_SETSIZE writes past the end of the set.
     if (socket_io_instance->socket >= FD_SETSIZE)
     {
         LogError("Failure: socket %d is not below FD_SETSIZE.", socket_io_instance->socket);
@@ -720,13 +754,26 @@ static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
     }
     else
     {
-        FD_ZERO(&fdset);
-        FD_SET(socket_io_instance->socket, &fdset);
-        tv.tv_sec = CONNECT_TIMEOUT;
-        tv.tv_usec = 0;
+        struct timeval deadline;
 
+        (void)gettimeofday(&deadline, NULL);
+        deadline.tv_sec += CONNECT_TIMEOUT;
+
+        // select() may report EINTR before the connection is decided. Retrying
+        // against a fixed deadline bounds the total wait: platforms that leave
+        // the timeout untouched would otherwise restart it on every signal.
         do
         {
+            if (!get_time_remaining(&deadline, &tv))
+            {
+                // Deadline reached; report it the same way select() reports a timeout.
+                retval = 0;
+                break;
+            }
+
+            FD_ZERO(&fdset);
+            FD_SET(socket_io_instance->socket, &fdset);
+
             retval = select(socket_io_instance->socket + 1, NULL, &fdset, NULL, &tv);
 
             if (retval < 0)

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -20,7 +20,6 @@
 #endif
 
 #include <signal.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -101,7 +100,6 @@ typedef struct SOCKET_IO_INSTANCE_TAG
     SINGLYLINKEDLIST_HANDLE pending_io_list;
     unsigned char recv_bytes[XIO_RECEIVE_BUFFER_SIZE];
     DNSRESOLVER_HANDLE dns_resolver;
-    bool dns_resolver_stale;
 } SOCKET_IO_INSTANCE;
 
 typedef struct NETWORK_INTERFACE_DESCRIPTION_TAG
@@ -232,9 +230,11 @@ static void socketio_cleanup(SOCKET_IO_INSTANCE* socket_io_instance)
     socket_io_instance->socket = INVALID_SOCKET;
     socket_io_instance->io_state = IO_STATE_CLOSED;
 
-    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL)
+    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
+        socket_io_instance->dns_resolver != NULL)
     {
-        socket_io_instance->dns_resolver_stale = true;
+        dns_resolver_destroy(socket_io_instance->dns_resolver);
+        socket_io_instance->dns_resolver = NULL;
     }
 }
 
@@ -243,23 +243,13 @@ static int refresh_dns_resolver(SOCKET_IO_INSTANCE* socket_io_instance)
     int result = 0;
 
     if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
-        (socket_io_instance->dns_resolver == NULL || socket_io_instance->dns_resolver_stale))
+        socket_io_instance->dns_resolver == NULL)
     {
-        if (socket_io_instance->dns_resolver != NULL)
-        {
-            dns_resolver_destroy(socket_io_instance->dns_resolver);
-            socket_io_instance->dns_resolver = NULL;
-        }
-
         socket_io_instance->dns_resolver = dns_resolver_create(socket_io_instance->hostname, socket_io_instance->port, NULL);
         if (socket_io_instance->dns_resolver == NULL)
         {
             LogError("Failure: unable to create DNS resolver.");
             result = MU_FAILURE;
-        }
-        else
-        {
-            socket_io_instance->dns_resolver_stale = false;
         }
     }
 
@@ -976,7 +966,7 @@ int socketio_close(CONCRETE_IO_HANDLE socket_io, ON_IO_CLOSE_COMPLETE on_io_clos
     else
     {
         SOCKET_IO_INSTANCE* socket_io_instance = (SOCKET_IO_INSTANCE*)socket_io;
-        if (socket_io_instance->io_state != IO_STATE_CLOSING)
+        if ((socket_io_instance->io_state != IO_STATE_CLOSED) && (socket_io_instance->io_state != IO_STATE_CLOSING))
         {
             // Only shut down an active socket before cleanup.
             if (socket_io_instance->socket != INVALID_SOCKET)

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -238,6 +238,15 @@ static void socketio_cleanup(SOCKET_IO_INSTANCE* socket_io_instance)
     }
 }
 
+static void indicate_open_failure(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    socketio_cleanup(socket_io_instance);
+    if (socket_io_instance->on_io_error != NULL)
+    {
+        socket_io_instance->on_io_error(socket_io_instance->on_io_error_context);
+    }
+}
+
 static int refresh_dns_resolver(SOCKET_IO_INSTANCE* socket_io_instance)
 {
     int result = 0;
@@ -317,6 +326,11 @@ static int lookup_address(SOCKET_IO_INSTANCE* socket_io_instance)
         else if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
         {
             socket_io_instance->io_state = IO_STATE_OPENING;
+        }
+        else if (dns_resolver_get_addrInfo(socket_io_instance->dns_resolver) == NULL)
+        {
+            LogError("DNS resolution failed. Hostname:%s", socket_io_instance->hostname);
+            result = MU_FAILURE;
         }
         else
         {
@@ -659,18 +673,8 @@ static int initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
             {
                 // Async connect will return -1.
                 result = 0;
-                if (socket_io_instance->on_io_open_complete != NULL)
-                {
-                    socket_io_instance->on_io_open_complete(socket_io_instance->on_io_open_complete_context, IO_OPEN_OK /*: IO_OPEN_ERROR*/);
-                }
             }
         }
-
-    }
-
-    if (result != 0)
-    {
-        socketio_cleanup(socket_io_instance);
     }
 
     return result;
@@ -703,51 +707,54 @@ static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
     fd_set fdset;
     struct timeval tv;
 
-    FD_ZERO(&fdset);
-    FD_SET(socket_io_instance->socket, &fdset);
-    tv.tv_sec = CONNECT_TIMEOUT;
-    tv.tv_usec = 0;
-
-    do
+    if (socket_io_instance->socket >= FD_SETSIZE)
     {
-        retval = select(socket_io_instance->socket + 1, NULL, &fdset, NULL, &tv);
-
-        if (retval < 0)
-        {
-            select_errno = errno;
-        }
-    } while (retval < 0 && select_errno == EINTR);
-
-    if (retval != 1)
-    {
-        LogError("Failure: select failure.");
+        LogError("Failure: socket %d is not below FD_SETSIZE.", socket_io_instance->socket);
         result = MU_FAILURE;
     }
     else
     {
-        int so_error = 0;
-        socklen_t len = sizeof(so_error);
-        err = getsockopt(socket_io_instance->socket, SOL_SOCKET, SO_ERROR, &so_error, &len);
-        if (err != 0)
+        FD_ZERO(&fdset);
+        FD_SET(socket_io_instance->socket, &fdset);
+        tv.tv_sec = CONNECT_TIMEOUT;
+        tv.tv_usec = 0;
+
+        do
         {
-            LogError("Failure: getsockopt failure %d.", errno);
-            result = MU_FAILURE;
-        }
-        else if (so_error != 0)
+            retval = select(socket_io_instance->socket + 1, NULL, &fdset, NULL, &tv);
+
+            if (retval < 0)
+            {
+                select_errno = errno;
+            }
+        } while (retval < 0 && select_errno == EINTR);
+
+        if (retval != 1)
         {
-            err = so_error;
-            LogError("Failure: connect failure %d.", so_error);
+            LogError("Failure: select failure.");
             result = MU_FAILURE;
         }
         else
         {
-            result = 0;
+            int so_error = 0;
+            socklen_t len = sizeof(so_error);
+            err = getsockopt(socket_io_instance->socket, SOL_SOCKET, SO_ERROR, &so_error, &len);
+            if (err != 0)
+            {
+                LogError("Failure: getsockopt failure %d.", errno);
+                result = MU_FAILURE;
+            }
+            else if (so_error != 0)
+            {
+                err = so_error;
+                LogError("Failure: connect failure %d.", so_error);
+                result = MU_FAILURE;
+            }
+            else
+            {
+                result = 0;
+            }
         }
-    }
-
-    if (result != 0)
-    {
-        socketio_cleanup(socket_io_instance);
     }
 
     return result;
@@ -918,18 +925,16 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
 
             if ((result = refresh_dns_resolver(socket_io_instance)) != 0)
             {
-                socketio_cleanup(socket_io_instance);
+                LogError("refresh_dns_resolver failed");
             }
             else if ((result = lookup_address_and_initiate_socket_connection(socket_io_instance)) != 0)
             {
                 LogError("lookup_address_and_connect_socket failed");
-                socketio_cleanup(socket_io_instance);
             }
             else if ((socket_io_instance->io_state == IO_STATE_OPEN) && (result = wait_for_socket_connection(socket_io_instance)) != 0)
             {
                 LogError("wait_for_socket_connection failed");
-                socketio_cleanup(socket_io_instance);
-            } 
+            }
             else
             {
                 socket_io_instance->on_bytes_received = on_bytes_received;
@@ -940,6 +945,11 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
 
                 socket_io_instance->on_io_open_complete = on_io_open_complete;
                 socket_io_instance->on_io_open_complete_context = on_io_open_complete_context;
+            }
+
+            if (result != 0)
+            {
+                socketio_cleanup(socket_io_instance);
             }
         }
     }
@@ -1171,37 +1181,25 @@ void socketio_dowork(CONCRETE_IO_HANDLE socket_io)
                 if(lookup_address(socket_io_instance) != 0)
                 {
                     LogError("Socketio_Failure: lookup address failed");
-                    socketio_cleanup(socket_io_instance);
-                    if (socket_io_instance->on_io_error != NULL)
-                    {
-                        socket_io_instance->on_io_error(socket_io_instance->on_io_error_context);
-                    }
+                    indicate_open_failure(socket_io_instance);
                 }
-                else
+                else if (socket_io_instance->io_state == IO_STATE_OPEN)
                 {
-                    if(socket_io_instance->io_state == IO_STATE_OPEN)
+                    if (initiate_socket_connection(socket_io_instance) != 0)
                     {
-                        if (initiate_socket_connection(socket_io_instance) != 0)
-                        {
-                            LogError("Socketio_Failure: initiate_socket_connection failed");
-                            socketio_cleanup(socket_io_instance);
-                            if (socket_io_instance->on_io_error != NULL)
-                            {
-                                socket_io_instance->on_io_error(socket_io_instance->on_io_error_context);
-                            }
-                        }
-                        else if (wait_for_socket_connection(socket_io_instance) != 0)
-                        {
-                            LogError("Socketio_Failure: wait_for_socket_connection failed");
-                            socketio_cleanup(socket_io_instance);
-                            if (socket_io_instance->on_io_error != NULL)
-                            {
-                                socket_io_instance->on_io_error(socket_io_instance->on_io_error_context);
-                            }
-                        }
+                        LogError("Socketio_Failure: initiate_socket_connection failed");
+                        indicate_open_failure(socket_io_instance);
+                    }
+                    else if (wait_for_socket_connection(socket_io_instance) != 0)
+                    {
+                        LogError("Socketio_Failure: wait_for_socket_connection failed");
+                        indicate_open_failure(socket_io_instance);
+                    }
+                    else if (socket_io_instance->on_io_open_complete != NULL)
+                    {
+                        socket_io_instance->on_io_open_complete(socket_io_instance->on_io_open_complete_context, IO_OPEN_OK);
                     }
                 }
-
             }
         }
     }

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -20,6 +20,7 @@
 #endif
 
 #include <signal.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -100,6 +101,7 @@ typedef struct SOCKET_IO_INSTANCE_TAG
     SINGLYLINKEDLIST_HANDLE pending_io_list;
     unsigned char recv_bytes[XIO_RECEIVE_BUFFER_SIZE];
     DNSRESOLVER_HANDLE dns_resolver;
+    bool dns_resolver_stale;
 } SOCKET_IO_INSTANCE;
 
 typedef struct NETWORK_INTERFACE_DESCRIPTION_TAG
@@ -154,6 +156,8 @@ static void* socketio_CloneOption(const char* name, const void* value)
     }
     return result;
 }
+
+
 
 /*this function destroys an option previously created*/
 static void socketio_DestroyOption(const char* name, const void* value)
@@ -218,6 +222,50 @@ static void indicate_error(SOCKET_IO_INSTANCE* socket_io_instance)
     }
 }
 
+static void socketio_cleanup(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    if (socket_io_instance->socket != INVALID_SOCKET)
+    {
+        (void)close(socket_io_instance->socket);
+    }
+
+    socket_io_instance->socket = INVALID_SOCKET;
+    socket_io_instance->io_state = IO_STATE_CLOSED;
+
+    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL)
+    {
+        socket_io_instance->dns_resolver_stale = true;
+    }
+}
+
+static int refresh_dns_resolver(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    int result = 0;
+
+    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
+        (socket_io_instance->dns_resolver == NULL || socket_io_instance->dns_resolver_stale))
+    {
+        if (socket_io_instance->dns_resolver != NULL)
+        {
+            dns_resolver_destroy(socket_io_instance->dns_resolver);
+            socket_io_instance->dns_resolver = NULL;
+        }
+
+        socket_io_instance->dns_resolver = dns_resolver_create(socket_io_instance->hostname, socket_io_instance->port, NULL);
+        if (socket_io_instance->dns_resolver == NULL)
+        {
+            LogError("Failure: unable to create DNS resolver.");
+            result = MU_FAILURE;
+        }
+        else
+        {
+            socket_io_instance->dns_resolver_stale = false;
+        }
+    }
+
+    return result;
+}
+
 static int add_pending_io(SOCKET_IO_INSTANCE* socket_io_instance, const unsigned char* buffer, size_t size, ON_SEND_COMPLETE on_send_complete, void* callback_context)
 {
     int result;
@@ -271,7 +319,12 @@ static int lookup_address(SOCKET_IO_INSTANCE* socket_io_instance)
 
     if (socket_io_instance->address_type == ADDRESS_TYPE_IP)
     {
-        if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
+        if (socket_io_instance->dns_resolver == NULL)
+        {
+            LogError("DNS resolver is NULL.");
+            result = MU_FAILURE;
+        }
+        else if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
         {
             socket_io_instance->io_state = IO_STATE_OPENING;
         }
@@ -623,14 +676,11 @@ static int initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
             }
         }
 
-        if (result != 0)
-        {
-            if (socket_io_instance->socket >= SOCKET_SUCCESS)
-            {
-                close(socket_io_instance->socket);
-            }
-            socket_io_instance->socket = INVALID_SOCKET;
-        }
+    }
+
+    if (result != 0)
+    {
+        socketio_cleanup(socket_io_instance);
     }
 
     return result;
@@ -707,11 +757,7 @@ static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
 
     if (result != 0)
     {
-        if (socket_io_instance->socket >= SOCKET_SUCCESS)
-        {
-            close(socket_io_instance->socket);
-        }
-        socket_io_instance->socket = INVALID_SOCKET;
+        socketio_cleanup(socket_io_instance);
     }
 
     return result;
@@ -877,13 +923,22 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
         }
         else
         {
-            if ((result = lookup_address_and_initiate_socket_connection(socket_io_instance)) != 0)
+            socket_io_instance->on_io_open_complete = NULL;
+            socket_io_instance->on_io_open_complete_context = NULL;
+
+            if ((result = refresh_dns_resolver(socket_io_instance)) != 0)
+            {
+                socketio_cleanup(socket_io_instance);
+            }
+            else if ((result = lookup_address_and_initiate_socket_connection(socket_io_instance)) != 0)
             {
                 LogError("lookup_address_and_connect_socket failed");
+                socketio_cleanup(socket_io_instance);
             }
             else if ((socket_io_instance->io_state == IO_STATE_OPEN) && (result = wait_for_socket_connection(socket_io_instance)) != 0)
             {
                 LogError("wait_for_socket_connection failed");
+                socketio_cleanup(socket_io_instance);
             } 
             else
             {
@@ -899,7 +954,7 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
         }
     }
 
-    if (socket_io_instance->io_state != IO_STATE_OPENING)
+    if (socket_io_instance != NULL && socket_io_instance->io_state != IO_STATE_OPENING)
     {
         if (on_io_open_complete != NULL)
         {
@@ -921,13 +976,14 @@ int socketio_close(CONCRETE_IO_HANDLE socket_io, ON_IO_CLOSE_COMPLETE on_io_clos
     else
     {
         SOCKET_IO_INSTANCE* socket_io_instance = (SOCKET_IO_INSTANCE*)socket_io;
-        if ((socket_io_instance->io_state != IO_STATE_CLOSED) && (socket_io_instance->io_state != IO_STATE_CLOSING))
+        if (socket_io_instance->io_state != IO_STATE_CLOSING)
         {
-            // Only close if the socket isn't already in the closed or closing state
-            (void)shutdown(socket_io_instance->socket, SHUT_RDWR);
-            close(socket_io_instance->socket);
-            socket_io_instance->socket = INVALID_SOCKET;
-            socket_io_instance->io_state = IO_STATE_CLOSED;
+            // Only shut down an active socket before cleanup.
+            if (socket_io_instance->socket != INVALID_SOCKET)
+            {
+                (void)shutdown(socket_io_instance->socket, SHUT_RDWR);
+            }
+            socketio_cleanup(socket_io_instance);
         }
 
         if (on_io_close_complete != NULL)
@@ -1125,7 +1181,11 @@ void socketio_dowork(CONCRETE_IO_HANDLE socket_io)
                 if(lookup_address(socket_io_instance) != 0)
                 {
                     LogError("Socketio_Failure: lookup address failed");
-                    indicate_error(socket_io_instance);
+                    socketio_cleanup(socket_io_instance);
+                    if (socket_io_instance->on_io_error != NULL)
+                    {
+                        socket_io_instance->on_io_error(socket_io_instance->on_io_error_context);
+                    }
                 }
                 else
                 {
@@ -1134,12 +1194,20 @@ void socketio_dowork(CONCRETE_IO_HANDLE socket_io)
                         if (initiate_socket_connection(socket_io_instance) != 0)
                         {
                             LogError("Socketio_Failure: initiate_socket_connection failed");
-                            indicate_error(socket_io_instance);
+                            socketio_cleanup(socket_io_instance);
+                            if (socket_io_instance->on_io_error != NULL)
+                            {
+                                socket_io_instance->on_io_error(socket_io_instance->on_io_error_context);
+                            }
                         }
                         else if (wait_for_socket_connection(socket_io_instance) != 0)
                         {
                             LogError("Socketio_Failure: wait_for_socket_connection failed");
-                            indicate_error(socket_io_instance);
+                            socketio_cleanup(socket_io_instance);
+                            if (socket_io_instance->on_io_error != NULL)
+                            {
+                                socket_io_instance->on_io_error(socket_io_instance->on_io_error_context);
+                            }
                         }
                     }
                 }
@@ -1280,4 +1348,3 @@ const IO_INTERFACE_DESCRIPTION* socketio_get_interface_description(void)
 {
     return &socket_io_interface_description;
 }
-

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include <stdlib.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -56,7 +55,6 @@ typedef struct SOCKET_IO_INSTANCE_TAG
     unsigned char recv_bytes[XIO_RECEIVE_BUFFER_SIZE];
     DNSRESOLVER_HANDLE dns_resolver;
     struct addrinfo* addrInfo;
-    bool dns_resolver_stale;
 } SOCKET_IO_INSTANCE;
 
 /*this function will clone an option given by name and value*/
@@ -121,9 +119,11 @@ static void socketio_cleanup(SOCKET_IO_INSTANCE* socket_io_instance)
     socket_io_instance->socket = INVALID_SOCKET;
     socket_io_instance->io_state = IO_STATE_CLOSED;
 
-    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL)
+    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
+        socket_io_instance->dns_resolver != NULL)
     {
-        socket_io_instance->dns_resolver_stale = true;
+        dns_resolver_destroy(socket_io_instance->dns_resolver);
+        socket_io_instance->dns_resolver = NULL;
     }
 }
 
@@ -132,23 +132,13 @@ static int refresh_dns_resolver(SOCKET_IO_INSTANCE* socket_io_instance)
     int result = 0;
 
     if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
-        (socket_io_instance->dns_resolver == NULL || socket_io_instance->dns_resolver_stale))
+        socket_io_instance->dns_resolver == NULL)
     {
-        if (socket_io_instance->dns_resolver != NULL)
-        {
-            dns_resolver_destroy(socket_io_instance->dns_resolver);
-            socket_io_instance->dns_resolver = NULL;
-        }
-
         socket_io_instance->dns_resolver = dns_resolver_create(socket_io_instance->hostname, socket_io_instance->port, NULL);
         if (socket_io_instance->dns_resolver == NULL)
         {
             LogError("Failure: unable to create DNS resolver.");
             result = MU_FAILURE;
-        }
-        else
-        {
-            socket_io_instance->dns_resolver_stale = false;
         }
     }
 
@@ -582,7 +572,7 @@ int socketio_close(CONCRETE_IO_HANDLE socket_io, ON_IO_CLOSE_COMPLETE on_io_clos
     {
         SOCKET_IO_INSTANCE* socket_io_instance = (SOCKET_IO_INSTANCE*)socket_io;
 
-        if (socket_io_instance->io_state != IO_STATE_CLOSING)
+        if ((socket_io_instance->io_state != IO_STATE_CLOSED) && (socket_io_instance->io_state != IO_STATE_CLOSING))
         {
             socketio_cleanup(socket_io_instance);
         }

--- a/adapters/socketio_win32.c
+++ b/adapters/socketio_win32.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -55,6 +56,7 @@ typedef struct SOCKET_IO_INSTANCE_TAG
     unsigned char recv_bytes[XIO_RECEIVE_BUFFER_SIZE];
     DNSRESOLVER_HANDLE dns_resolver;
     struct addrinfo* addrInfo;
+    bool dns_resolver_stale;
 } SOCKET_IO_INSTANCE;
 
 /*this function will clone an option given by name and value*/
@@ -109,6 +111,50 @@ static void indicate_error(SOCKET_IO_INSTANCE* socket_io_instance)
     }
 }
 
+static void socketio_cleanup(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    if (socket_io_instance->socket != INVALID_SOCKET)
+    {
+        (void)closesocket(socket_io_instance->socket);
+    }
+
+    socket_io_instance->socket = INVALID_SOCKET;
+    socket_io_instance->io_state = IO_STATE_CLOSED;
+
+    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL)
+    {
+        socket_io_instance->dns_resolver_stale = true;
+    }
+}
+
+static int refresh_dns_resolver(SOCKET_IO_INSTANCE* socket_io_instance)
+{
+    int result = 0;
+
+    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
+        (socket_io_instance->dns_resolver == NULL || socket_io_instance->dns_resolver_stale))
+    {
+        if (socket_io_instance->dns_resolver != NULL)
+        {
+            dns_resolver_destroy(socket_io_instance->dns_resolver);
+            socket_io_instance->dns_resolver = NULL;
+        }
+
+        socket_io_instance->dns_resolver = dns_resolver_create(socket_io_instance->hostname, socket_io_instance->port, NULL);
+        if (socket_io_instance->dns_resolver == NULL)
+        {
+            LogError("Failure: unable to create DNS resolver.");
+            result = MU_FAILURE;
+        }
+        else
+        {
+            socket_io_instance->dns_resolver_stale = false;
+        }
+    }
+
+    return result;
+}
+
 static int add_pending_io(SOCKET_IO_INSTANCE* socket_io_instance, const unsigned char* buffer, size_t size, ON_SEND_COMPLETE on_send_complete, void* callback_context)
 {
     int result;
@@ -159,7 +205,12 @@ static int lookup_address(SOCKET_IO_INSTANCE* socket_io_instance)
     
     if (socket_io_instance->address_type == ADDRESS_TYPE_IP)
     {
-        if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
+        if (socket_io_instance->dns_resolver == NULL)
+        {
+            LogError("DNS resolver is NULL.");
+            result = MU_FAILURE;
+        }
+        else if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
         {
             socket_io_instance->io_state = IO_STATE_OPENING;
         }
@@ -405,7 +456,10 @@ void socketio_destroy(CONCRETE_IO_HANDLE socket_io)
     {
         SOCKET_IO_INSTANCE* socket_io_instance = (SOCKET_IO_INSTANCE*)socket_io;
         /* we cannot do much if the close fails, so just ignore the result */
-        (void)closesocket(socket_io_instance->socket);
+        if (socket_io_instance->socket != INVALID_SOCKET)
+        {
+            (void)closesocket(socket_io_instance->socket);
+        }
 
         /* clear allpending IOs */
 
@@ -458,6 +512,9 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
         }
         else
         {
+            socket_io_instance->on_io_open_complete = NULL;
+            socket_io_instance->on_io_open_complete_context = NULL;
+
 #ifdef AF_UNIX_ON_WINDOWS
             int addr_family = socket_io_instance->address_type == ADDRESS_TYPE_IP ? AF_INET : AF_UNIX;
 #else
@@ -467,20 +524,24 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
             if (socket_io_instance->socket == INVALID_SOCKET)
             {
                 LogError("Failure: socket create failure %d.", WSAGetLastError());
+                socketio_cleanup(socket_io_instance);
+                result = MU_FAILURE;
+            }
+            else if (refresh_dns_resolver(socket_io_instance) != 0)
+            {
+                socketio_cleanup(socket_io_instance);
                 result = MU_FAILURE;
             }
             else if (lookup_address(socket_io_instance) != 0)
             {
                 LogError("lookup_address failed");
-                (void)closesocket(socket_io_instance->socket);
-                socket_io_instance->socket = INVALID_SOCKET;
+                socketio_cleanup(socket_io_instance);
                 result = MU_FAILURE;
             }
             else if (socket_io_instance->io_state == IO_STATE_OPEN && initiate_socket_connection(socket_io_instance) != 0)
             {
                 LogError("initiate_socket_connection failed");
-                (void)closesocket(socket_io_instance->socket);
-                socket_io_instance->socket = INVALID_SOCKET;
+                socketio_cleanup(socket_io_instance);
                 result = MU_FAILURE;
             }
             else
@@ -521,12 +582,9 @@ int socketio_close(CONCRETE_IO_HANDLE socket_io, ON_IO_CLOSE_COMPLETE on_io_clos
     {
         SOCKET_IO_INSTANCE* socket_io_instance = (SOCKET_IO_INSTANCE*)socket_io;
 
-        if ((socket_io_instance->io_state != IO_STATE_CLOSING) &&
-            (socket_io_instance->io_state != IO_STATE_CLOSED))
+        if (socket_io_instance->io_state != IO_STATE_CLOSING)
         {
-            (void)closesocket(socket_io_instance->socket);
-            socket_io_instance->socket = INVALID_SOCKET;
-            socket_io_instance->io_state = IO_STATE_CLOSED;
+            socketio_cleanup(socket_io_instance);
         }
 
         if (on_io_close_complete != NULL)
@@ -712,16 +770,14 @@ void socketio_dowork(CONCRETE_IO_HANDLE socket_io)
                 if (lookup_address(socket_io_instance) != 0)
                 {
                     LogError("lookup_address failed");
-                    (void)closesocket(socket_io_instance->socket);
-                    socket_io_instance->socket = INVALID_SOCKET;
-                    socket_io_instance->io_state = IO_STATE_CLOSED;
+                    socketio_cleanup(socket_io_instance);
+                    indicate_error(socket_io_instance);
                 }
                 else if (socket_io_instance->io_state == IO_STATE_OPEN && initiate_socket_connection(socket_io_instance) != 0)
                 {
                     LogError("initialize_socket_connection failed");
-                    (void)closesocket(socket_io_instance->socket);
-                    socket_io_instance->socket = INVALID_SOCKET;
-                    socket_io_instance->io_state = IO_STATE_CLOSED;
+                    socketio_cleanup(socket_io_instance);
+                    indicate_error(socket_io_instance);
                 }
             }
         }

--- a/src/dns_resolver_sync.c
+++ b/src/dns_resolver_sync.c
@@ -162,7 +162,24 @@ bool dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE dns_in)
             else
             {
                 /* Codes_SRS_dns_resolver_30_033: [ If dns_resolver_is_create_complete has returned true and the lookup process has failed, dns_resolver_get_ipv4 shall return 0. ]*/
-                LogInfo("Failed DNS lookup for %s: %d", dns->hostname, getAddrResult);
+#ifdef EAI_SYSTEM
+                int saved_errno = errno;
+#endif
+#ifdef _WIN32
+                const char* gai_error = gai_strerrorA(getAddrResult);
+#else
+                const char* gai_error = gai_strerror(getAddrResult);
+#endif
+#ifdef EAI_SYSTEM
+                if (getAddrResult == EAI_SYSTEM)
+                {
+                    LogInfo("Failed DNS lookup for %s: %d (%s), errno=%d", dns->hostname, getAddrResult, gai_error, saved_errno);
+                }
+                else
+#endif
+                {
+                    LogInfo("Failed DNS lookup for %s: %d (%s)", dns->hostname, getAddrResult, gai_error);
+                }
                 dns->is_failed = true;
             }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,8 +43,7 @@ if(${run_unittests})
         add_subdirectory(platform_win32_ut)
         add_subdirectory(timer_win32_ut)
     else()
-        # socketio_berkeley_ut disabled: all tests are behind #if 0, and new ctest fails on zero test count
-        #add_subdirectory(socketio_berkeley_ut)
+        add_subdirectory(socketio_berkeley_ut)
     endif()
 
     #normally, with proper include paths, the below tests can be run under windows too.

--- a/tests/dns_resolver_ut/dns_resolver_ut.c
+++ b/tests/dns_resolver_ut/dns_resolver_ut.c
@@ -126,6 +126,8 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
  * This is necessary for the test suite, just keep as is.
  */
 static TEST_MUTEX_HANDLE g_testByTest;
+
+#ifndef NO_LOGGING
 static char g_log_message[4096];
 static LOGGER_CONFIG g_saved_logger_config;
 
@@ -141,6 +143,7 @@ static void test_log_sink(LOG_LEVEL log_level, LOG_CONTEXT_HANDLE log_context, c
 
 static const LOG_SINK_IF g_test_log_sink = { NULL, test_log_sink, NULL };
 static const LOG_SINK_IF* g_test_log_sinks[] = { &g_test_log_sink };
+#endif
 
 BEGIN_TEST_SUITE(dns_resolver_ut)
 
@@ -155,8 +158,10 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
+#ifndef NO_LOGGING
         g_saved_logger_config = logger_get_config();
         logger_set_config((LOGGER_CONFIG){ 1, g_test_log_sinks });
+#endif
 
         (void)umock_c_init(on_umock_c_error);
 
@@ -182,7 +187,9 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
      */
     TEST_SUITE_CLEANUP(TestClassCleanup)
     {
+#ifndef NO_LOGGING
         logger_set_config(g_saved_logger_config);
+#endif
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
@@ -200,7 +207,9 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
         }
 
         umock_c_reset_all_calls();
+#ifndef NO_LOGGING
         g_log_message[0] = '\0';
+#endif
     }
 
     /**
@@ -467,14 +476,15 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
 
         dns = dns_resolver_create("fake.com", 53, NULL);
         umock_c_reset_all_calls();
-        g_log_message[0] = '\0';
         STRICT_EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
             .SetReturn(EAI_NONAME);
 
         result = dns_resolver_is_lookup_complete(dns);
 
         ASSERT_IS_TRUE(result);
+#ifndef NO_LOGGING
         ASSERT_IS_NOT_NULL(strstr(g_log_message, gai_strerror(EAI_NONAME)));
+#endif
 
         dns_resolver_destroy(dns);
     }
@@ -487,7 +497,6 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
 
         dns = dns_resolver_create("fake.com", 53, NULL);
         umock_c_reset_all_calls();
-        g_log_message[0] = '\0';
         errno = EIO;
         STRICT_EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
             .SetReturn(EAI_SYSTEM);
@@ -495,8 +504,10 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
         result = dns_resolver_is_lookup_complete(dns);
 
         ASSERT_IS_TRUE(result);
+#ifndef NO_LOGGING
         ASSERT_IS_NOT_NULL(strstr(g_log_message, gai_strerror(EAI_SYSTEM)));
         ASSERT_IS_NOT_NULL(strstr(g_log_message, "errno=5"));
+#endif
 
         dns_resolver_destroy(dns);
     }

--- a/tests/dns_resolver_ut/dns_resolver_ut.c
+++ b/tests/dns_resolver_ut/dns_resolver_ut.c
@@ -6,6 +6,10 @@
 #endif
 
 #include <stdint.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 #include <cstdlib>
@@ -26,6 +30,7 @@
 #endif
 
 #include "macro_utils/macro_utils.h"
+#include "c_logging/logger.h"
 
 #include "dns_resolver.h"
 
@@ -121,6 +126,21 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
  * This is necessary for the test suite, just keep as is.
  */
 static TEST_MUTEX_HANDLE g_testByTest;
+static char g_log_message[4096];
+static LOGGER_CONFIG g_saved_logger_config;
+
+static void test_log_sink(LOG_LEVEL log_level, LOG_CONTEXT_HANDLE log_context, const char* file, const char* func, int line, const char* message_format, va_list args)
+{
+    (void)log_level;
+    (void)log_context;
+    (void)file;
+    (void)func;
+    (void)line;
+    (void)vsnprintf(g_log_message, sizeof(g_log_message), message_format, args);
+}
+
+static const LOG_SINK_IF g_test_log_sink = { NULL, test_log_sink, NULL };
+static const LOG_SINK_IF* g_test_log_sinks[] = { &g_test_log_sink };
 
 BEGIN_TEST_SUITE(dns_resolver_ut)
 
@@ -134,6 +154,9 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
         int result;
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
+
+        g_saved_logger_config = logger_get_config();
+        logger_set_config((LOGGER_CONFIG){ 1, g_test_log_sinks });
 
         (void)umock_c_init(on_umock_c_error);
 
@@ -159,6 +182,7 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
      */
     TEST_SUITE_CLEANUP(TestClassCleanup)
     {
+        logger_set_config(g_saved_logger_config);
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
@@ -176,6 +200,7 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
         }
 
         umock_c_reset_all_calls();
+        g_log_message[0] = '\0';
     }
 
     /**
@@ -434,6 +459,48 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
         ///assert
         ASSERT_IS_NULL(result, "Unexpected success with NULL hostname");
     }
+
+    TEST_FUNCTION(dns_resolver_getaddrinfo_failure_logs_gai_strerror)
+    {
+        DNSRESOLVER_HANDLE dns;
+        bool result;
+
+        dns = dns_resolver_create("fake.com", 53, NULL);
+        umock_c_reset_all_calls();
+        g_log_message[0] = '\0';
+        STRICT_EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+            .SetReturn(EAI_NONAME);
+
+        result = dns_resolver_is_lookup_complete(dns);
+
+        ASSERT_IS_TRUE(result);
+        ASSERT_IS_NOT_NULL(strstr(g_log_message, gai_strerror(EAI_NONAME)));
+
+        dns_resolver_destroy(dns);
+    }
+
+#ifdef EAI_SYSTEM
+    TEST_FUNCTION(dns_resolver_getaddrinfo_eai_system_logs_error)
+    {
+        DNSRESOLVER_HANDLE dns;
+        bool result;
+
+        dns = dns_resolver_create("fake.com", 53, NULL);
+        umock_c_reset_all_calls();
+        g_log_message[0] = '\0';
+        errno = EIO;
+        STRICT_EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+            .SetReturn(EAI_SYSTEM);
+
+        result = dns_resolver_is_lookup_complete(dns);
+
+        ASSERT_IS_TRUE(result);
+        ASSERT_IS_NOT_NULL(strstr(g_log_message, gai_strerror(EAI_SYSTEM)));
+        ASSERT_IS_NOT_NULL(strstr(g_log_message, "errno=5"));
+
+        dns_resolver_destroy(dns);
+    }
+#endif
 
 
 END_TEST_SUITE(dns_resolver_ut)

--- a/tests/dns_resolver_ut/win32_fake_linux/socket_async_os.h
+++ b/tests/dns_resolver_ut/win32_fake_linux/socket_async_os.h
@@ -19,37 +19,6 @@ extern "C" {
 #define    SOCK_STREAM    1
 #define IPPROTO_TCP     6
 
-#ifndef EAI_AGAIN
-#define EAI_AGAIN       11002
-#endif
-
-#ifndef EAI_NONAME
-#define EAI_NONAME      11001
-#endif
-
-#ifndef EAI_SYSTEM
-#define EAI_SYSTEM      11
-#endif
-
-static const char* test_gai_strerror(int error_code)
-{
-    switch (error_code)
-    {
-    case EAI_AGAIN:
-        return "temporary failure in name resolution";
-    case EAI_NONAME:
-        return "name or service not known";
-    case EAI_SYSTEM:
-        return "system error";
-    default:
-        return "unknown address error";
-    }
-}
-
-#ifndef gai_strerror
-#define gai_strerror test_gai_strerror
-#endif
-
 
 #define htons(x) x
 

--- a/tests/dns_resolver_ut/win32_fake_linux/socket_async_os.h
+++ b/tests/dns_resolver_ut/win32_fake_linux/socket_async_os.h
@@ -19,6 +19,37 @@ extern "C" {
 #define    SOCK_STREAM    1
 #define IPPROTO_TCP     6
 
+#ifndef EAI_AGAIN
+#define EAI_AGAIN       11002
+#endif
+
+#ifndef EAI_NONAME
+#define EAI_NONAME      11001
+#endif
+
+#ifndef EAI_SYSTEM
+#define EAI_SYSTEM      11
+#endif
+
+static const char* test_gai_strerror(int error_code)
+{
+    switch (error_code)
+    {
+    case EAI_AGAIN:
+        return "temporary failure in name resolution";
+    case EAI_NONAME:
+        return "name or service not known";
+    case EAI_SYSTEM:
+        return "system error";
+    default:
+        return "unknown address error";
+    }
+}
+
+#ifndef gai_strerror
+#define gai_strerror test_gai_strerror
+#endif
+
 
 #define htons(x) x
 

--- a/tests/socketio_berkeley_ut/CMakeLists.txt
+++ b/tests/socketio_berkeley_ut/CMakeLists.txt
@@ -14,7 +14,6 @@ generate_cppunittest_wrapper(${theseTestsName})
 
 set(${theseTestsName}_c_files
 ../../adapters/socketio_berkeley.c
-../../src/dns_resolver_sync.c
 ../../src/crt_abstractions.c
 )
 

--- a/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
+++ b/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
@@ -1,666 +1,631 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#ifdef __cplusplus
-#include <cstdint>
-#else
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#ifndef __APPLE__
+#include <net/if.h>
+#include <sys/ioctl.h>
 #endif
 
 #include "testrunnerswitcher.h"
 
+static void* real_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+static void* real_calloc(size_t count, size_t size)
+{
+    return calloc(count, size);
+}
+
+static void real_free(void* pointer)
+{
+    free(pointer);
+}
+
 #define ENABLE_MOCKS
-
-#include "azure_c_shared_utility/singlylinkedlist.h"
 #include "azure_c_shared_utility/gballoc.h"
+#include "azure_c_shared_utility/singlylinkedlist.h"
 #include "azure_c_shared_utility/optionhandler.h"
-
+#include "azure_c_shared_utility/dns_resolver.h"
 #undef ENABLE_MOCKS
 
 #include "azure_c_shared_utility/socketio.h"
+#include "azure_c_shared_utility/shared_util_options.h"
 
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
+#define TEST_HOSTNAME "hostname"
+#define TEST_PORT 23456
+#define TEST_SOCKET_FIRST 42
+#define TEST_MAC_ADDRESS "AA:BB:CC:DD:EE:FF"
 
-TEST_MUTEX_HANDLE test_serialize_mutex;
+static TEST_MUTEX_HANDLE g_testByTest;
 
-BEGIN_TEST_SUITE(socketio_berkeley_unittests)
+static int g_resolver_call_count;
+static int g_resolver_failures;
+static int g_resolver_failure_code;
+static int g_resolver_pending;
+static int g_socket_call_count;
+static int g_socket_failures;
+static int g_close_call_count;
+static int g_shutdown_call_count;
+static int g_fcntl_call_count;
+static int g_fcntl_failures;
+static int g_connect_call_count;
+static int g_connect_failures;
+static int g_connect_einprogress;
+static int g_select_call_count;
+static int g_select_failures;
+static int g_getsockopt_call_count;
+static int g_getsockopt_failures;
+static int g_ioctl_call_count;
+static int g_ioctl_failures;
+static int g_next_socket;
+static int g_open_callback_count;
+static IO_OPEN_RESULT g_last_open_result;
+static int g_error_callback_count;
+static bool g_error_callback_saw_invalid_socket;
 
-#if 0
+static struct sockaddr_in g_test_sockaddr;
+static struct addrinfo g_test_addrinfo;
 
-// SOCKETIO_SETOPTION TESTS WERE WORKING BEFORE SWITCH TO umock_c...need to finish the conversion
-
-// socketio_setoption tests
-
-static CONCRETE_IO_HANDLE setup_socket()
+static void reset_fake_network(void)
 {
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-    int result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext,
-        test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
-    ASSERT_ARE_EQUAL(int, 0, result);
-    return ioHandle;
+    (void)memset(&g_test_sockaddr, 0, sizeof(g_test_sockaddr));
+    g_test_sockaddr.sin_family = AF_INET;
+    g_test_sockaddr.sin_port = htons(TEST_PORT);
+    g_test_sockaddr.sin_addr.s_addr = 0x0100007FU;
+
+    (void)memset(&g_test_addrinfo, 0, sizeof(g_test_addrinfo));
+    g_test_addrinfo.ai_family = AF_INET;
+    g_test_addrinfo.ai_socktype = SOCK_STREAM;
+    g_test_addrinfo.ai_protocol = IPPROTO_TCP;
+    g_test_addrinfo.ai_addrlen = sizeof(g_test_sockaddr);
+    g_test_addrinfo.ai_addr = (struct sockaddr*)&g_test_sockaddr;
+
+    g_resolver_call_count = 0;
+    g_resolver_failures = 0;
+    g_resolver_failure_code = EAI_AGAIN;
+    g_resolver_pending = 0;
+    g_socket_call_count = 0;
+    g_socket_failures = 0;
+    g_close_call_count = 0;
+    g_shutdown_call_count = 0;
+    g_fcntl_call_count = 0;
+    g_fcntl_failures = 0;
+    g_connect_call_count = 0;
+    g_connect_failures = 0;
+    g_connect_einprogress = 0;
+    g_select_call_count = 0;
+    g_select_failures = 0;
+    g_getsockopt_call_count = 0;
+    g_getsockopt_failures = 0;
+    g_ioctl_call_count = 0;
+    g_ioctl_failures = 0;
+    g_next_socket = TEST_SOCKET_FIRST;
+    g_open_callback_count = 0;
+    g_last_open_result = IO_OPEN_ERROR;
+    g_error_callback_count = 0;
+    g_error_callback_saw_invalid_socket = false;
 }
 
-static void verify_mocks_and_destroy_socket(CONCRETE_IO_HANDLE ioHandle)
+static DNSRESOLVER_HANDLE fake_dns_resolver_create(const char* hostname, int port, const DNSRESOLVER_OPTIONS* options)
 {
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    socketio_destroy(ioHandle);
+    static int resolver_state;
+
+    (void)hostname;
+    (void)port;
+    (void)options;
+    g_resolver_call_count++;
+    return &resolver_state;
 }
 
-TEST_FUNCTION(socketio_setoption_fails_when_handle_is_null)
+static bool fake_dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE resolver)
 {
-    // arrange
-    int irrelevant = 1;
+    (void)resolver;
+    if (g_resolver_pending > 0)
+    {
+        g_resolver_pending--;
+        return false;
+    }
 
-    // act
-    int result = socketio_setoption(NULL, "tcp_keepalive", &irrelevant);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    return true;
 }
 
-TEST_FUNCTION(socketio_setoption_fails_when_option_name_is_null)
+static uint32_t fake_dns_resolver_get_ipv4(DNSRESOLVER_HANDLE resolver)
 {
-    // arrange
-    int irrelevant = 1;
-
-    CONCRETE_IO_HANDLE ioHandle = setup_socket();
-
-    umock_c_reset_all_calls();
-
-    // act
-    int result = socketio_setoption(ioHandle, NULL, &irrelevant);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-    verify_mocks_and_destroy_socket(ioHandle);
+    (void)resolver;
+    return g_test_sockaddr.sin_addr.s_addr;
 }
 
-TEST_FUNCTION(socketio_setoption_fails_when_value_is_null)
+static struct addrinfo* fake_dns_resolver_get_addr_info(DNSRESOLVER_HANDLE resolver)
 {
-    // arrange
-    CONCRETE_IO_HANDLE ioHandle = setup_socket();
-
-    umock_c_reset_all_calls();
-
-    // act
-    int result = socketio_setoption(ioHandle, "tcp_keepalive", NULL);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-    verify_mocks_and_destroy_socket(ioHandle);
+    (void)resolver;
+    if (g_resolver_failures > 0)
+    {
+        g_resolver_failures--;
+        (void)g_resolver_failure_code;
+        return NULL;
+    }
+    return &g_test_addrinfo;
 }
 
-TEST_FUNCTION(socketio_setoption_fails_when_it_receives_an_unsupported_option)
+static void fake_dns_resolver_destroy(DNSRESOLVER_HANDLE resolver)
 {
-    // arrange
-    int irrelevant = 1;
-
-    CONCRETE_IO_HANDLE ioHandle = setup_socket();
-
-    umock_c_reset_all_calls();
-
-    // act
-    int result = socketio_setoption(ioHandle, "unsupported_option_name", &irrelevant);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-    verify_mocks_and_destroy_socket(ioHandle);
+    (void)resolver;
 }
 
-TEST_FUNCTION(socketio_setoption_passes_tcp_keepalive_to_setsockopt)
+int socket(int domain, int type, int protocol)
 {
-    // arrange
-    CONCRETE_IO_HANDLE ioHandle = setup_socket();
-
-    umock_c_reset_all_calls();
-
-    int onoff = -42;
-
-    STRICT_EXPECTED_CALL(setsockopt(*(int*)ioHandle, SOL_SOCKET, SO_KEEPALIVE,
-        &onoff, sizeof(int)));
-
-    // act
-    int result = socketio_setoption(ioHandle, "tcp_keepalive", &onoff);
-
-    // assert
-    ASSERT_ARE_EQUAL(int, 0, result);
-    verify_mocks_and_destroy_socket(ioHandle);
+    (void)domain;
+    (void)type;
+    (void)protocol;
+    g_socket_call_count++;
+    if (g_socket_failures > 0)
+    {
+        g_socket_failures--;
+        return -1;
+    }
+    return g_next_socket++;
 }
 
-TEST_FUNCTION(socketio_setoption_passes_tcp_keepalive_time_to_setsockopt)
+int close(int descriptor)
 {
-    // arrange
-    CONCRETE_IO_HANDLE ioHandle = setup_socket();
-
-    umock_c_reset_all_calls();
-
-    int time = 3;
-
-    STRICT_EXPECTED_CALL(setsockopt(*(int*)ioHandle, SOL_TCP, TCP_KEEPIDLE,
-        &time, sizeof(int)));
-
-    // act
-    int result = socketio_setoption(ioHandle, "tcp_keepalive_time", &time);
-
-    // assert
-    ASSERT_ARE_EQUAL(int, 0, result);
-    verify_mocks_and_destroy_socket(ioHandle);
+    (void)descriptor;
+    g_close_call_count++;
+    return 0;
 }
 
-TEST_FUNCTION(socketio_setoption_passes_tcp_keepalive_interval_to_setsockopt)
+int shutdown(int descriptor, int how)
 {
-    // arrange
-    CONCRETE_IO_HANDLE ioHandle = setup_socket();
-
-    umock_c_reset_all_calls();
-
-    int interval = 15;
-
-    STRICT_EXPECTED_CALL(setsockopt(*(int*)ioHandle, SOL_TCP, TCP_KEEPINTVL,
-        &interval, sizeof(int)));
-
-    // act
-    int result = socketio_setoption(ioHandle, "tcp_keepalive_interval", &interval);
-
-    // assert
-    ASSERT_ARE_EQUAL(int, 0, result);
-    verify_mocks_and_destroy_socket(ioHandle);
+    (void)descriptor;
+    (void)how;
+    g_shutdown_call_count++;
+    return 0;
 }
 
+int fcntl(int descriptor, int command, ...)
+{
+    (void)descriptor;
+    (void)command;
+    g_fcntl_call_count++;
+    if (g_fcntl_failures > 0)
+    {
+        g_fcntl_failures--;
+        return -1;
+    }
+    return 0;
+}
+
+int connect(int descriptor, const struct sockaddr* address, socklen_t address_length)
+{
+    (void)descriptor;
+    (void)address;
+    (void)address_length;
+    g_connect_call_count++;
+    if (g_connect_einprogress > 0)
+    {
+        g_connect_einprogress--;
+        errno = EINPROGRESS;
+        return -1;
+    }
+    if (g_connect_failures > 0)
+    {
+        g_connect_failures--;
+        errno = ECONNREFUSED;
+        return -1;
+    }
+    return 0;
+}
+
+int select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, struct timeval* timeout)
+{
+    (void)nfds;
+    (void)readfds;
+    (void)writefds;
+    (void)exceptfds;
+    (void)timeout;
+    g_select_call_count++;
+    if (g_select_failures > 0)
+    {
+        g_select_failures--;
+        errno = EIO;
+        return -1;
+    }
+    return 1;
+}
+
+int getsockopt(int descriptor, int level, int option, void* value, socklen_t* value_length)
+{
+    (void)descriptor;
+    (void)level;
+    (void)option;
+    g_getsockopt_call_count++;
+    if (g_getsockopt_failures > 0)
+    {
+        g_getsockopt_failures--;
+        errno = EIO;
+        return -1;
+    }
+    *(int*)value = 0;
+    *value_length = sizeof(int);
+    return 0;
+}
+
+int setsockopt(int descriptor, int level, int option, const void* value, socklen_t value_length)
+{
+    (void)descriptor;
+    (void)level;
+    (void)option;
+    (void)value;
+    (void)value_length;
+    return 0;
+}
+
+ssize_t send(int descriptor, const void* buffer, size_t length, int flags)
+{
+    (void)descriptor;
+    (void)buffer;
+    (void)flags;
+    return (ssize_t)length;
+}
+
+ssize_t recv(int descriptor, void* buffer, size_t length, int flags)
+{
+    (void)descriptor;
+    (void)buffer;
+    (void)length;
+    (void)flags;
+    errno = EAGAIN;
+    return -1;
+}
+
+#ifndef __APPLE__
+int ioctl(int descriptor, unsigned long request, ...)
+{
+    va_list arguments;
+    void* argument;
+
+    (void)descriptor;
+    g_ioctl_call_count++;
+    va_start(arguments, request);
+    argument = va_arg(arguments, void*);
+    va_end(arguments);
+
+    if (g_ioctl_failures > 0)
+    {
+        g_ioctl_failures--;
+        errno = EIO;
+        return -1;
+    }
+
+    if (request == SIOCGIFCONF)
+    {
+        struct ifconf* interface_configuration = (struct ifconf*)argument;
+        struct ifreq* interface_request = (struct ifreq*)interface_configuration->ifc_buf;
+        (void)memset(interface_request, 0, sizeof(*interface_request));
+        (void)strcpy(interface_request->ifr_name, "eth0");
+        interface_configuration->ifc_len = sizeof(*interface_request);
+    }
+    else
+    {
+        struct ifreq* interface_request = (struct ifreq*)argument;
+        (void)strcpy(interface_request->ifr_name, "eth0");
+        if (request == SIOCGIFHWADDR)
+        {
+            const unsigned char mac_address[] = { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+            (void)memcpy(interface_request->ifr_hwaddr.sa_data, mac_address, sizeof(mac_address));
+        }
+        else if (request == SIOCGIFADDR)
+        {
+            ((struct sockaddr_in*)&interface_request->ifr_addr)->sin_addr.s_addr = 0x0100007FU;
+        }
+    }
+    return 0;
+}
 #endif
 
-/* Seems like the below tests require a full blown rewrite */
-
-#if 0
-
-TEST_SUITE_INITIALIZE(suite_init)
+static void on_open_complete(void* context, IO_OPEN_RESULT open_result)
 {
-    test_serialize_mutex = MicroMockCreateMutex();
-    ASSERT_IS_NOT_NULL(test_serialize_mutex);
+    (void)context;
+    g_open_callback_count++;
+    g_last_open_result = open_result;
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
-{
-    MicroMockDestroyMutex(test_serialize_mutex);
-}
-
-TEST_FUNCTION_INITIALIZE(method_init)
-{
-    if (!MicroMockAcquireMutex(test_serialize_mutex))
-    {
-        ASSERT_FAIL("Could not acquire test serialization mutex.");
-    }
-    list_head_count = 0;
-    list_add_called = false;
-    g_addrinfo_call_fail = false;
-    //g_socket_send_size_value = -1;
-    g_socket_recv_size_value = -1;
-}
-
-TEST_FUNCTION_CLEANUP(method_cleanup)
-{
-    if (!MicroMockReleaseMutex(test_serialize_mutex))
-    {
-        ASSERT_FAIL("Could not release test serialization mutex.");
-    }
-}
-
-static void OnBytesReceived(void* context, const unsigned char* buffer, size_t size)
+static void on_bytes_received(void* context, const unsigned char* buffer, size_t size)
 {
     (void)context;
     (void)buffer;
     (void)size;
 }
 
-static void PrintLogFunction(unsigned int options, char* format, ...)
+static void on_io_error(void* context)
 {
-    (void)options;
-    (void)format;
+    g_error_callback_count++;
+    if (context != NULL)
+    {
+        g_error_callback_saw_invalid_socket = (*(int*)context == -1);
+    }
 }
 
-static void OnSendComplete(void* context, IO_SEND_RESULT send_result)
+static CONCRETE_IO_HANDLE create_socketio(void)
 {
-    (void)context;
-    (void)send_result;
+    SOCKETIO_CONFIG config = { TEST_HOSTNAME, TEST_PORT, NULL };
+    CONCRETE_IO_HANDLE result = socketio_create(&config);
+    ASSERT_IS_NOT_NULL(result);
+    return result;
 }
 
-/* socketio_win32_create */
-TEST_FUNCTION(socketio_create_io_create_parameters_NULL_fails)
+static int open_socketio(CONCRETE_IO_HANDLE socket_io, void* error_context)
 {
-    // arrange
-    socketio_mocks mocks;
-
-    // act
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(NULL, PrintLogFunction);
-
-    // assert
-    ASSERT_IS_NULL(ioHandle);
+    return socketio_open(socket_io, on_open_complete, NULL, on_bytes_received, NULL, on_io_error, error_context);
 }
 
-TEST_FUNCTION(socketio_create_list_create_fails)
+BEGIN_TEST_SUITE(socketio_berkeley_unittests)
+
+TEST_SUITE_INITIALIZE(suite_init)
 {
-    // arrange
-    socketio_mocks mocks;
-
-    EXPECTED_CALL(mocks, gballoc_malloc(IGNORED_ARG));
-    EXPECTED_CALL(mocks, singlylinkedlist_create()).SetReturn((SINGLYLINKEDLIST_HANDLE)NULL);
-    EXPECTED_CALL(mocks, gballoc_free(IGNORED_ARG));
-
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-
-    // act
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    // assert
-    ASSERT_IS_NULL(ioHandle);
+    (void)umock_c_init(NULL);
+    REGISTER_UMOCK_ALIAS_TYPE(SINGLYLINKEDLIST_HANDLE, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(LIST_ITEM_HANDLE, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(OPTIONHANDLER_HANDLE, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(DNSRESOLVER_HANDLE, void*);
+    REGISTER_GLOBAL_MOCK_HOOK(gballoc_malloc, real_malloc);
+    REGISTER_GLOBAL_MOCK_HOOK(gballoc_calloc, real_calloc);
+    REGISTER_GLOBAL_MOCK_HOOK(gballoc_free, real_free);
+    REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_create, fake_dns_resolver_create);
+    REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_is_lookup_complete, fake_dns_resolver_is_lookup_complete);
+    REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_get_ipv4, fake_dns_resolver_get_ipv4);
+    REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_get_addrInfo, fake_dns_resolver_get_addr_info);
+    REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_destroy, fake_dns_resolver_destroy);
+    REGISTER_GLOBAL_MOCK_RETURN(singlylinkedlist_create, (SINGLYLINKEDLIST_HANDLE)0x4242);
+    REGISTER_GLOBAL_MOCK_RETURN(singlylinkedlist_get_head_item, NULL);
+    REGISTER_GLOBAL_MOCK_RETURN(singlylinkedlist_remove, 0);
+    REGISTER_GLOBAL_MOCK_RETURN(OptionHandler_Create, (OPTIONHANDLER_HANDLE)0x4243);
+    REGISTER_GLOBAL_MOCK_RETURN(OptionHandler_AddOption, OPTIONHANDLER_OK);
+    g_testByTest = TEST_MUTEX_CREATE();
+    ASSERT_IS_NOT_NULL(g_testByTest);
 }
 
-TEST_FUNCTION(socketio_create_succeeds)
+TEST_SUITE_CLEANUP(suite_cleanup)
 {
-    // arrange
-    socketio_mocks mocks;
-
-    EXPECTED_CALL(mocks, gballoc_malloc(IGNORED_ARG));
-    EXPECTED_CALL(mocks, singlylinkedlist_create());
-    EXPECTED_CALL(mocks, gballoc_malloc(IGNORED_ARG));
-
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-
-    // act
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    // assert
-    ASSERT_IS_NOT_NULL(ioHandle);
-    mocks.AssertActualAndExpectedCalls();
-
-    socketio_destroy(ioHandle);
+    TEST_MUTEX_DESTROY(g_testByTest);
+    umock_c_deinit();
 }
 
-// socketio_win32_destroy
-TEST_FUNCTION(socketio_destroy_socket_io_NULL_succeeds)
+TEST_FUNCTION_INITIALIZE(test_init)
 {
-    // arrange
-    socketio_mocks mocks;
-
-    // act
-    socketio_destroy(NULL);
-
-    // assert
+    if (TEST_MUTEX_ACQUIRE(g_testByTest))
+    {
+        ASSERT_FAIL("Could not acquire test serialization mutex.");
+    }
+    reset_fake_network();
 }
 
-TEST_FUNCTION(socketio_destroy_socket_succeeds)
+TEST_FUNCTION_CLEANUP(test_cleanup)
 {
-    // arrange
-    socketio_mocks mocks;
-
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    mocks.ResetAllCalls();
-
-    EXPECTED_CALL(mocks, close(IGNORED_ARG));
-    EXPECTED_CALL(mocks, singlylinkedlist_get_head_item(IGNORED_ARG))
-        .ExpectedAtLeastTimes(2);
-    EXPECTED_CALL(mocks, singlylinkedlist_item_get_value(IGNORED_ARG));
-    EXPECTED_CALL(mocks, singlylinkedlist_remove(IGNORED_ARG, IGNORED_ARG));
-    EXPECTED_CALL(mocks, singlylinkedlist_destroy(IGNORED_ARG));
-    EXPECTED_CALL(mocks, gballoc_free(IGNORED_ARG));
-    EXPECTED_CALL(mocks, gballoc_free(IGNORED_ARG));
-
-    list_head_count = 1;
-
-    // act
-    socketio_destroy(ioHandle);
-
-    // assert
+    TEST_MUTEX_RELEASE(g_testByTest);
 }
 
-TEST_FUNCTION(socketio_open_socket_io_NULL_fails)
+TEST_FUNCTION(socketio_open_dns_failure_is_retryable)
 {
-    // arrange
-    socketio_mocks mocks;
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
 
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
+    g_resolver_failures = 1;
+    g_resolver_failure_code = EAI_AGAIN;
 
-    mocks.ResetAllCalls();
-
-    // act
-    int result = socketio_open(NULL, OnBytesReceived, OnIoStateChanged, &callbackContext);
-
-    // assert
+    result = open_socketio(socket_io, NULL);
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
-}
+    ASSERT_ARE_EQUAL(int, (int)IO_OPEN_ERROR, (int)g_last_open_result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
 
-TEST_FUNCTION(socketio_open_socket_fails)
-{
-    // arrange
-    socketio_mocks mocks;
-
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    mocks.ResetAllCalls();
-
-    EXPECTED_CALL(mocks, socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-        .SetReturn(-1);
-
-    // act
-    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-    mocks.AssertActualAndExpectedCalls();
-
-    socketio_destroy(ioHandle);
-}
-
-
-TEST_FUNCTION(socketio_open_getaddrinfo_fails)
-{
-    // arrange
-    socketio_mocks mocks;
-
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    mocks.ResetAllCalls();
-
-    g_addrinfo_call_fail = true;
-    EXPECTED_CALL(mocks, socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-    EXPECTED_CALL(mocks, getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-    EXPECTED_CALL(mocks, close(IGNORED_ARG));
-
-    // act
-    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-    mocks.AssertActualAndExpectedCalls();
-
-    socketio_destroy(ioHandle);
-}
-
-TEST_FUNCTION(socketio_open_connect_fails)
-{
-    // arrange
-    socketio_mocks mocks;
-
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    mocks.ResetAllCalls();
-
-    EXPECTED_CALL(mocks, socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-    EXPECTED_CALL(mocks, getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-    EXPECTED_CALL(mocks, connect(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-        .SetReturn(-1);
-    EXPECTED_CALL(mocks, close(IGNORED_ARG));
-    EXPECTED_CALL(mocks, freeaddrinfo(IGNORED_ARG));
-
-    // act
-    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-    mocks.AssertActualAndExpectedCalls();
-
-    socketio_destroy(ioHandle);
-}
-
-TEST_FUNCTION(socketio_open_ioctlsocket_fails)
-{
-    // arrange
-    socketio_mocks mocks;
-
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    mocks.ResetAllCalls();
-
-    EXPECTED_CALL(mocks, socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-    EXPECTED_CALL(mocks, getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-    EXPECTED_CALL(mocks, connect(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-    //EXPECTED_CALL(mocks, fcntl(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-    //    .SetReturn(-1);
-    EXPECTED_CALL(mocks, freeaddrinfo(IGNORED_ARG));
-    EXPECTED_CALL(mocks, close(IGNORED_ARG));
-
-    // act
-    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-    mocks.AssertActualAndExpectedCalls();
-
-    socketio_destroy(ioHandle);
-}
-
-//TEST_FUNCTION(socketio_open_succeeds)
-//{
-//    // arrange
-//    socketio_mocks mocks;
-//
-//    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-//    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-//
-//    mocks.ResetAllCalls();
-//
-//    EXPECTED_CALL(mocks, socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-//    EXPECTED_CALL(mocks, getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-//    EXPECTED_CALL(mocks, connect(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-//    EXPECTED_CALL(mocks, freeaddrinfo(IGNORED_ARG));
-//
-//    // act
-//    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-//
-//    // assert
-//    ASSERT_ARE_EQUAL(int, 0, result);
-//    mocks.AssertActualAndExpectedCalls();
-//
-//    socketio_destroy(ioHandle);
-//}
-
-TEST_FUNCTION(socketio_close_socket_io_NULL_fails)
-{
-    // arrange
-    socketio_mocks mocks;
-
-    // act
-    int result = socketio_close(NULL);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-}
-
-TEST_FUNCTION(socketio_close_Succeeds)
-{
-    // arrange
-    socketio_mocks mocks;
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-
-    mocks.ResetAllCalls();
-
-    EXPECTED_CALL(mocks, close(IGNORED_ARG));
-
-    // act
-    result = socketio_close(ioHandle);
-
-    // assert
+    result = open_socketio(socket_io, NULL);
     ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_resolver_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_socket_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_fcntl_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_connect_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_select_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_getsockopt_call_count);
+
+    socketio_destroy(socket_io);
 }
 
-TEST_FUNCTION(socketio_send_socket_io_fails)
+TEST_FUNCTION(socketio_open_socket_failure_is_retryable)
 {
-    // arrange
-    socketio_mocks mocks;
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
 
-    // act
-    int result = socketio_send(NULL, (const void*)TEST_BUFFER_VALUE, TEST_BUFFER_SIZE, OnSendComplete, (void*)TEST_CALLBACK_CONTEXT);
+    g_socket_failures = 1;
 
-    // assert
+    result = open_socketio(socket_io, NULL);
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_fcntl_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_connect_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_select_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_getsockopt_call_count);
+
+    socketio_destroy(socket_io);
 }
 
-TEST_FUNCTION(socketio_send_buffer_NULL_fails)
+#ifndef __APPLE__
+TEST_FUNCTION(socketio_open_interface_setup_failure_is_retryable)
 {
-    // arrange
-    socketio_mocks mocks;
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
 
-    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
+    result = socketio_setoption(socket_io, OPTION_NET_INT_MAC_ADDRESS, TEST_MAC_ADDRESS);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    g_ioctl_failures = 1;
 
-    mocks.ResetAllCalls();
-
-    // act
-    result = socketio_send(ioHandle, NULL, TEST_BUFFER_SIZE, OnSendComplete, (void*)TEST_CALLBACK_CONTEXT);
-
-    // assert
+    result = open_socketio(socket_io, NULL);
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_close_call_count);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_connect_call_count);
+
+    socketio_destroy(socket_io);
 }
-
-TEST_FUNCTION(socketio_send_size_zero_fails)
-{
-    // arrange
-    socketio_mocks mocks;
-    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-
-    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-
-    mocks.ResetAllCalls();
-
-    // act
-    result = socketio_send(ioHandle, (const void*)TEST_BUFFER_VALUE, 0, OnSendComplete, (void*)TEST_CALLBACK_CONTEXT);
-
-    // assert
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
-}
-
-// TBD:  To be implemented when fcntl is mocked
-//TEST_FUNCTION(socketio_send_succeeds)
-//{
-//    // arrange
-//    socketio_mocks mocks;
-//    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-//    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-//
-//    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-//
-//    mocks.ResetAllCalls();
-//
-//    EXPECTED_CALL(mocks, singlylinkedlist_get_head_item(IGNORED_ARG));
-//    EXPECTED_CALL(mocks, send(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-//
-//    // act
-//    result = socketio_send(ioHandle, (const void*)TEST_BUFFER_VALUE, TEST_BUFFER_SIZE, OnSendComplete, (void*)TEST_CALLBACK_CONTEXT);
-//
-//    // assert
-//    ASSERT_ARE_EQUAL(int, 0, result);
-//    mocks.AssertActualAndExpectedCalls();
-//
-//    socketio_destroy(ioHandle);
-//}
-
-// TBD:  To be implemented when fcntl is mocked
-//TEST_FUNCTION(socketio_send_returns_1_succeeds)
-//{
-//    // arrange
-//    socketio_mocks mocks;
-//    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-//    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-//
-//    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-//    ASSERT_ARE_EQUAL(int, 0, result);
-//
-//    mocks.ResetAllCalls();
-//
-//    EXPECTED_CALL(mocks, singlylinkedlist_get_head_item(IGNORED_ARG));
-//    EXPECTED_CALL(mocks, send(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG)).SetReturn(1);
-//    EXPECTED_CALL(mocks, gballoc_malloc(IGNORED_ARG));
-//    EXPECTED_CALL(mocks, gballoc_malloc(IGNORED_ARG));
-//    EXPECTED_CALL(mocks, singlylinkedlist_add(IGNORED_ARG, IGNORED_ARG));
-//
-//    // act
-//    result = socketio_send(ioHandle, (const void*)TEST_BUFFER_VALUE, TEST_BUFFER_SIZE, OnSendComplete, (void*)TEST_CALLBACK_CONTEXT);
-//
-//    // assert
-//    ASSERT_ARE_EQUAL(int, 0, result);
-//    mocks.AssertActualAndExpectedCalls();
-//
-//    socketio_destroy(ioHandle);
-//}
-
-TEST_FUNCTION(socketio_dowork_socket_io_NULL_fails)
-{
-    // arrange
-    socketio_mocks mocks;
-
-    // act
-    socketio_dowork(NULL);
-
-    // assert
-}
-
-// TBD:  To be implemented when fcntl is mocked
-//TEST_FUNCTION(socketio_dowork_succeeds)
-//{
-//    // arrange
-//    socketio_mocks mocks;
-//    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-//    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-//
-//    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-//
-//    mocks.ResetAllCalls();
-//
-//    EXPECTED_CALL(mocks, singlylinkedlist_get_head_item(IGNORED_ARG));
-//    EXPECTED_CALL(mocks, recv(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-//
-//    // act
-//    socketio_dowork(ioHandle);
-//
-//    // assert
-//    mocks.AssertActualAndExpectedCalls();
-//
-//    socketio_destroy(ioHandle);
-//}
-
-// TBD:  To be implemented when fcntl is mocked
-//TEST_FUNCTION(socketio_dowork_recv_bytes_succeeds)
-//{
-//    // arrange
-//    socketio_mocks mocks;
-//    SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
-//    CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig, PrintLogFunction);
-//
-//    int result = socketio_open(ioHandle, OnBytesReceived, OnIoStateChanged, &callbackContext);
-//
-//    mocks.ResetAllCalls();
-//
-//    EXPECTED_CALL(mocks, singlylinkedlist_get_head_item(IGNORED_ARG));
-//    EXPECTED_CALL(mocks, recv(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-//        .CopyOutArgumentBuffer(2, "t", 1)
-//        .SetReturn(1);
-//    EXPECTED_CALL(mocks, recv(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-//
-//    // act
-//    socketio_dowork(ioHandle);
-//
-//    // assert
-//    mocks.AssertActualAndExpectedCalls();
-//
-//    socketio_destroy(ioHandle);
-//}
-
 #endif
 
-END_TEST_SUITE(socketio_berkeley_unittests)
+TEST_FUNCTION(socketio_open_fcntl_failure_is_retryable)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
 
+    g_fcntl_failures = 1;
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_close_call_count);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_connect_call_count);
+
+    socketio_destroy(socket_io);
+}
+
+TEST_FUNCTION(socketio_open_connect_failure_is_retryable_and_refreshes_resolver)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    g_connect_failures = 1;
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_close_call_count);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_resolver_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
+
+    socketio_destroy(socket_io);
+}
+
+TEST_FUNCTION(socketio_open_select_failure_is_retryable)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    g_connect_einprogress = 1;
+    g_select_failures = 1;
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_close_call_count);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_select_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_getsockopt_call_count);
+
+    socketio_destroy(socket_io);
+}
+
+TEST_FUNCTION(socketio_open_getsockopt_failure_is_retryable)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    g_connect_einprogress = 1;
+    g_getsockopt_failures = 1;
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_close_call_count);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_getsockopt_call_count);
+
+    socketio_destroy(socket_io);
+}
+
+TEST_FUNCTION(socketio_dowork_opening_failure_is_retryable)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    g_resolver_pending = 1;
+    g_socket_failures = 1;
+
+    result = open_socketio(socket_io, socket_io);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+
+    socketio_dowork(socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_error_callback_count);
+    ASSERT_IS_TRUE(g_error_callback_saw_invalid_socket);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+
+    socketio_destroy(socket_io);
+}
+
+TEST_FUNCTION(socketio_close_recreates_resolver)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 1, g_resolver_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_socket_call_count);
+
+    result = socketio_close(socket_io, NULL, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 2, g_resolver_call_count);
+    ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
+
+    socketio_destroy(socket_io);
+}
+
+END_TEST_SUITE(socketio_berkeley_unittests)

--- a/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
+++ b/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#ifndef __APPLE__
+// glibc keeps struct ifreq/ifconf behind __USE_MISC, which the build's
+// _POSIX_C_SOURCE/_XOPEN_SOURCE settings would otherwise hide.
+#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
+#endif
+
 #include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
+++ b/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
@@ -57,7 +57,6 @@ static TEST_MUTEX_HANDLE g_testByTest;
 
 static int g_resolver_call_count;
 static int g_resolver_failures;
-static int g_resolver_failure_code;
 static int g_resolver_pending;
 static int g_socket_call_count;
 static int g_socket_failures;
@@ -99,7 +98,6 @@ static void reset_fake_network(void)
 
     g_resolver_call_count = 0;
     g_resolver_failures = 0;
-    g_resolver_failure_code = EAI_AGAIN;
     g_resolver_pending = 0;
     g_socket_call_count = 0;
     g_socket_failures = 0;
@@ -125,13 +123,11 @@ static void reset_fake_network(void)
 
 static DNSRESOLVER_HANDLE fake_dns_resolver_create(const char* hostname, int port, const DNSRESOLVER_OPTIONS* options)
 {
-    static int resolver_state;
-
     (void)hostname;
     (void)port;
     (void)options;
     g_resolver_call_count++;
-    return &resolver_state;
+    return (DNSRESOLVER_HANDLE)real_malloc(sizeof(int));
 }
 
 static bool fake_dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE resolver)
@@ -146,19 +142,12 @@ static bool fake_dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE resolver)
     return true;
 }
 
-static uint32_t fake_dns_resolver_get_ipv4(DNSRESOLVER_HANDLE resolver)
-{
-    (void)resolver;
-    return g_test_sockaddr.sin_addr.s_addr;
-}
-
 static struct addrinfo* fake_dns_resolver_get_addr_info(DNSRESOLVER_HANDLE resolver)
 {
     (void)resolver;
     if (g_resolver_failures > 0)
     {
         g_resolver_failures--;
-        (void)g_resolver_failure_code;
         return NULL;
     }
     return &g_test_addrinfo;
@@ -166,7 +155,8 @@ static struct addrinfo* fake_dns_resolver_get_addr_info(DNSRESOLVER_HANDLE resol
 
 static void fake_dns_resolver_destroy(DNSRESOLVER_HANDLE resolver)
 {
-    (void)resolver;
+    ASSERT_IS_NOT_NULL(resolver);
+    real_free(resolver);
 }
 
 int socket(int domain, int type, int protocol)
@@ -362,6 +352,11 @@ static void on_io_error(void* context)
     }
 }
 
+static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
+{
+    ASSERT_FAIL("umock_c reported error %d", (int)error_code);
+}
+
 static CONCRETE_IO_HANDLE create_socketio(void)
 {
     SOCKETIO_CONFIG config = { TEST_HOSTNAME, TEST_PORT, NULL };
@@ -379,7 +374,7 @@ BEGIN_TEST_SUITE(socketio_berkeley_unittests)
 
 TEST_SUITE_INITIALIZE(suite_init)
 {
-    (void)umock_c_init(NULL);
+    ASSERT_ARE_EQUAL(int, 0, umock_c_init(on_umock_c_error));
     REGISTER_UMOCK_ALIAS_TYPE(SINGLYLINKEDLIST_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(LIST_ITEM_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(OPTIONHANDLER_HANDLE, void*);
@@ -389,7 +384,6 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_GLOBAL_MOCK_HOOK(gballoc_free, real_free);
     REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_create, fake_dns_resolver_create);
     REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_is_lookup_complete, fake_dns_resolver_is_lookup_complete);
-    REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_get_ipv4, fake_dns_resolver_get_ipv4);
     REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_get_addrInfo, fake_dns_resolver_get_addr_info);
     REGISTER_GLOBAL_MOCK_HOOK(dns_resolver_destroy, fake_dns_resolver_destroy);
     REGISTER_GLOBAL_MOCK_RETURN(singlylinkedlist_create, (SINGLYLINKEDLIST_HANDLE)0x4242);
@@ -427,7 +421,6 @@ TEST_FUNCTION(socketio_open_dns_failure_is_retryable)
     int result;
 
     g_resolver_failures = 1;
-    g_resolver_failure_code = EAI_AGAIN;
 
     result = open_socketio(socket_io, NULL);
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -488,8 +481,9 @@ TEST_FUNCTION(socketio_open_interface_setup_failure_is_retryable)
     result = open_socketio(socket_io, NULL);
     ASSERT_ARE_EQUAL(int, 0, result);
     ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_resolver_call_count);
     ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
-    ASSERT_ARE_EQUAL(int, 2, g_connect_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_connect_call_count);
 
     socketio_destroy(socket_io);
 }
@@ -602,6 +596,59 @@ TEST_FUNCTION(socketio_dowork_opening_failure_is_retryable)
     result = open_socketio(socket_io, NULL);
     ASSERT_ARE_EQUAL(int, 0, result);
     ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+
+    socketio_destroy(socket_io);
+}
+
+TEST_FUNCTION(socketio_dowork_reports_open_after_connect_wait)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    g_resolver_pending = 1;
+    g_connect_einprogress = 1;
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 0, g_open_callback_count);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+
+    socketio_dowork(socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_open_callback_count);
+    ASSERT_ARE_EQUAL(int, (int)IO_OPEN_OK, (int)g_last_open_result);
+    ASSERT_ARE_EQUAL(int, 0, g_error_callback_count);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_connect_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_select_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_getsockopt_call_count);
+
+    socketio_destroy(socket_io);
+}
+
+TEST_FUNCTION(socketio_dowork_lookup_failure_is_retryable)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    g_resolver_pending = 1;
+    g_resolver_failures = 1;
+
+    result = open_socketio(socket_io, socket_io);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 0, g_open_callback_count);
+
+    socketio_dowork(socket_io);
+    ASSERT_ARE_EQUAL(int, 1, g_error_callback_count);
+    ASSERT_IS_TRUE(g_error_callback_saw_invalid_socket);
+    ASSERT_ARE_EQUAL(int, 0, g_open_callback_count);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 0, g_socket_call_count);
+
+    result = open_socketio(socket_io, NULL);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 2, g_resolver_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_socket_call_count);
 
     socketio_destroy(socket_io);
 }

--- a/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
+++ b/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
@@ -76,6 +76,7 @@ static int g_connect_failures;
 static int g_connect_einprogress;
 static int g_select_call_count;
 static int g_select_failures;
+static int g_select_eintr;
 static int g_getsockopt_call_count;
 static int g_getsockopt_failures;
 static int g_ioctl_call_count;
@@ -117,6 +118,7 @@ static void reset_fake_network(void)
     g_connect_einprogress = 0;
     g_select_call_count = 0;
     g_select_failures = 0;
+    g_select_eintr = 0;
     g_getsockopt_call_count = 0;
     g_getsockopt_failures = 0;
     g_ioctl_call_count = 0;
@@ -237,6 +239,15 @@ int select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, struc
     (void)exceptfds;
     (void)timeout;
     g_select_call_count++;
+    if (g_select_eintr != 0)
+    {
+        if (g_select_eintr > 0)
+        {
+            g_select_eintr--;
+        }
+        errno = EINTR;
+        return -1;
+    }
     if (g_select_failures > 0)
     {
         g_select_failures--;
@@ -534,6 +545,46 @@ TEST_FUNCTION(socketio_open_connect_failure_is_retryable_and_refreshes_resolver)
     ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
     ASSERT_ARE_EQUAL(int, 2, g_resolver_call_count);
     ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
+
+    socketio_destroy(socket_io);
+}
+
+TEST_FUNCTION(socketio_open_select_eintr_is_retried_within_the_connect_deadline)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    g_connect_einprogress = 1;
+    g_select_eintr = 2;
+
+    result = open_socketio(socket_io, NULL);
+
+    // The interrupted waits are retried rather than reported as a failure.
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_ARE_EQUAL(int, 3, g_select_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_getsockopt_call_count);
+    ASSERT_ARE_EQUAL(int, 0, g_select_eintr);
+
+    socketio_destroy(socket_io);
+}
+
+// Guards against an unbounded retry loop: a sustained EINTR storm must still be
+// cut off by the connect deadline. g_select_eintr < 0 interrupts every wait.
+TEST_FUNCTION(socketio_open_uninterrupted_select_eintr_stops_at_the_connect_deadline)
+{
+    CONCRETE_IO_HANDLE socket_io = create_socketio();
+    int result;
+
+    g_connect_einprogress = 1;
+    g_select_eintr = -1;
+
+    result = open_socketio(socket_io, NULL);
+
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, -1, *(int*)socket_io);
+    ASSERT_IS_TRUE(g_select_call_count > 1);
+    ASSERT_ARE_EQUAL(int, 0, g_getsockopt_call_count);
 
     socketio_destroy(socket_io);
 }

--- a/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
+++ b/tests/socketio_berkeley_ut/socketio_berkeley_ut.c
@@ -463,9 +463,9 @@ TEST_FUNCTION(socketio_open_socket_failure_is_retryable)
     ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
     ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
     ASSERT_ARE_EQUAL(int, 2, g_fcntl_call_count);
-    ASSERT_ARE_EQUAL(int, 2, g_connect_call_count);
-    ASSERT_ARE_EQUAL(int, 2, g_select_call_count);
-    ASSERT_ARE_EQUAL(int, 2, g_getsockopt_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_connect_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_select_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_getsockopt_call_count);
 
     socketio_destroy(socket_io);
 }
@@ -511,7 +511,7 @@ TEST_FUNCTION(socketio_open_fcntl_failure_is_retryable)
     ASSERT_ARE_EQUAL(int, 0, result);
     ASSERT_ARE_NOT_EQUAL(int, -1, *(int*)socket_io);
     ASSERT_ARE_EQUAL(int, 2, g_socket_call_count);
-    ASSERT_ARE_EQUAL(int, 2, g_connect_call_count);
+    ASSERT_ARE_EQUAL(int, 1, g_connect_call_count);
 
     socketio_destroy(socket_io);
 }

--- a/tests/socketio_win32_ut/socketio_win32_ut.c
+++ b/tests/socketio_win32_ut/socketio_win32_ut.c
@@ -94,7 +94,6 @@ void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "azure_c_shared_utility/singlylinkedlist.h"
-static bool g_addrinfo_call_fail;
 static size_t g_addrinfo_call_count;
 static size_t g_addrinfo_failure_count;
 static int g_addrinfo_failure_code;
@@ -145,7 +144,7 @@ MOCK_FUNCTION_END(len)
 MOCK_FUNCTION_WITH_CODE(WSAAPI, INT, getaddrinfo, PCSTR, pNodeName, PCSTR, pServiceName, const ADDRINFOA*, pHints, PADDRINFOA*, ppResult)
 int callFail;
 g_addrinfo_call_count++;
-if (!g_addrinfo_call_fail && g_addrinfo_failure_count == 0)
+if (g_addrinfo_failure_count == 0)
 {
     *ppResult = (PADDRINFOA)malloc(sizeof(ADDRINFOA));
     memcpy(*ppResult, &TEST_ADDR_INFO, sizeof(ADDRINFOA));
@@ -154,15 +153,8 @@ if (!g_addrinfo_call_fail && g_addrinfo_failure_count == 0)
 else
 {
     *ppResult = NULL;
-    if (g_addrinfo_failure_count > 0)
-    {
-        g_addrinfo_failure_count--;
-        callFail = g_addrinfo_failure_code;
-    }
-    else
-    {
-        callFail = MU_FAILURE;
-    }
+    g_addrinfo_failure_count--;
+    callFail = g_addrinfo_failure_code;
 }
 MOCK_FUNCTION_END(callFail)
 MOCK_FUNCTION_WITH_CODE(WSAAPI, void, freeaddrinfo, PADDRINFOA, pResult)
@@ -393,6 +385,26 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
     ASSERT_FAIL("umock_c reported error :%" PRI_MU_ENUM "", MU_ENUM_VALUE(UMOCK_C_ERROR_CODE, error_code));
 }
 
+// A reopen after cleanup creates a new resolver, so it allocates twice.
+static void reopen_and_assert_success(CONCRETE_IO_HANDLE ioHandle)
+{
+    int result;
+
+    umock_c_reset_all_calls();
+    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+        .SetReturn((SOCKET)0x4244);
+    EXPECTED_CALL(gballoc_calloc(IGNORED_ARG, IGNORED_ARG));
+    EXPECTED_CALL(gballoc_malloc(IGNORED_ARG));
+    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
+    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
+    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
 BEGIN_TEST_SUITE(socketio_win32_unittests)
 
 TEST_SUITE_INITIALIZE(suite_init)
@@ -459,7 +471,6 @@ TEST_FUNCTION_INITIALIZE(method_init)
     whenShallcalloc_fail = 0;
     list_head_count = 0;
     singlylinkedlist_add_called = false;
-    g_addrinfo_call_fail = false;
     g_addrinfo_call_count = 0;
     g_addrinfo_failure_count = 0;
     g_addrinfo_failure_code = EAI_AGAIN;
@@ -613,6 +624,9 @@ TEST_FUNCTION(socketio_open_socket_fails)
     EXPECTED_CALL(WSAGetLastError());
 #endif
 
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+
     // act
     result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
@@ -621,17 +635,7 @@ TEST_FUNCTION(socketio_open_socket_fails)
     ASSERT_ARE_EQUAL(size_t, (size_t)INVALID_SOCKET, (size_t)*(SOCKET*)ioHandle);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
-    umock_c_reset_all_calls();
-    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-        .SetReturn((SOCKET)0x4244);
-    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
-    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
-    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-
-    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
-    ASSERT_ARE_EQUAL(int, 0, result);
-    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    reopen_and_assert_success(ioHandle);
 
     // cleanup
     socketio_destroy(ioHandle);
@@ -656,6 +660,8 @@ TEST_FUNCTION(socketio_open_getaddrinfo_fails)
 #endif
 
     EXPECTED_CALL(closesocket(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
 
     // act
     result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
@@ -665,18 +671,8 @@ TEST_FUNCTION(socketio_open_getaddrinfo_fails)
     ASSERT_ARE_EQUAL(size_t, (size_t)INVALID_SOCKET, (size_t)*(SOCKET*)ioHandle);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
-    umock_c_reset_all_calls();
-    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-        .SetReturn((SOCKET)0x4244);
-    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
-    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
-    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-
-    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
-    ASSERT_ARE_EQUAL(int, 0, result);
-    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
+    reopen_and_assert_success(ioHandle);
     ASSERT_ARE_EQUAL(size_t, 2, g_addrinfo_call_count);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
     socketio_destroy(ioHandle);
@@ -701,26 +697,20 @@ TEST_FUNCTION(socketio_open_connect_fails)
 #endif
 
     EXPECTED_CALL(closesocket(IGNORED_ARG));
+    EXPECTED_CALL(freeaddrinfo(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
 
     // act
     result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, (size_t)INVALID_SOCKET, (size_t)*(SOCKET*)ioHandle);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
-    umock_c_reset_all_calls();
-    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-        .SetReturn((SOCKET)0x4244);
-    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
-    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
-    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-
-    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
-    ASSERT_ARE_EQUAL(int, 0, result);
+    reopen_and_assert_success(ioHandle);
     ASSERT_ARE_EQUAL(size_t, 2, g_addrinfo_call_count);
-    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
     socketio_destroy(ioHandle);
@@ -732,7 +722,6 @@ TEST_FUNCTION(socketio_open_ioctlsocket_fails)
     int result;
     SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
     CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
-    static ADDRINFO addrInfo = { AI_PASSIVE, AF_INET, SOCK_STREAM, IPPROTO_TCP, 128, NULL, (struct sockaddr*)0x11, NULL };
 
     umock_c_reset_all_calls();
 
@@ -747,26 +736,20 @@ TEST_FUNCTION(socketio_open_ioctlsocket_fails)
 #endif
 
     EXPECTED_CALL(closesocket(IGNORED_ARG));
+    EXPECTED_CALL(freeaddrinfo(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
 
     // act
     result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, (size_t)INVALID_SOCKET, (size_t)*(SOCKET*)ioHandle);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
-    umock_c_reset_all_calls();
-    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-        .SetReturn((SOCKET)0x4244);
-    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
-    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
-    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-
-    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
-    ASSERT_ARE_EQUAL(int, 0, result);
+    reopen_and_assert_success(ioHandle);
     ASSERT_ARE_EQUAL(size_t, 2, g_addrinfo_call_count);
-    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
     socketio_destroy(ioHandle);
@@ -867,34 +850,27 @@ TEST_FUNCTION(socketio_close_Succeeds)
     // arrange
     SOCKETIO_CONFIG socketConfig = { HOSTNAME_ARG, PORT_NUM, NULL };
     CONCRETE_IO_HANDLE ioHandle = socketio_create(&socketConfig);
-    static ADDRINFO addrInfo = { AI_PASSIVE, AF_INET, SOCK_STREAM, IPPROTO_TCP, 128, NULL, (struct sockaddr*)0x11, NULL };
 
     int result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
 
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(closesocket(IGNORED_ARG));
+    EXPECTED_CALL(freeaddrinfo(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    EXPECTED_CALL(gballoc_free(IGNORED_ARG));
 
     // act
     result = socketio_close(ioHandle, test_on_io_close_complete, (void*)0x4242);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
-
+    ASSERT_ARE_EQUAL(size_t, (size_t)INVALID_SOCKET, (size_t)*(SOCKET*)ioHandle);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_EQUAL(size_t, 1, g_addrinfo_call_count);
 
-    umock_c_reset_all_calls();
-    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
-        .SetReturn((SOCKET)0x4244);
-    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
-    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
-    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
-
-    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
-    ASSERT_ARE_EQUAL(int, 0, result);
+    reopen_and_assert_success(ioHandle);
     ASSERT_ARE_EQUAL(size_t, 2, g_addrinfo_call_count);
-    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
     socketio_destroy(ioHandle);

--- a/tests/socketio_win32_ut/socketio_win32_ut.c
+++ b/tests/socketio_win32_ut/socketio_win32_ut.c
@@ -95,6 +95,9 @@ void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_charptr.h"
 #include "azure_c_shared_utility/singlylinkedlist.h"
 static bool g_addrinfo_call_fail;
+static size_t g_addrinfo_call_count;
+static size_t g_addrinfo_failure_count;
+static int g_addrinfo_failure_code;
 //static int g_socket_send_size_value;
 static int g_socket_recv_size_value;
 
@@ -141,7 +144,8 @@ len = g_socket_send_size_value;
 MOCK_FUNCTION_END(len)
 MOCK_FUNCTION_WITH_CODE(WSAAPI, INT, getaddrinfo, PCSTR, pNodeName, PCSTR, pServiceName, const ADDRINFOA*, pHints, PADDRINFOA*, ppResult)
 int callFail;
-if (!g_addrinfo_call_fail)
+g_addrinfo_call_count++;
+if (!g_addrinfo_call_fail && g_addrinfo_failure_count == 0)
 {
     *ppResult = (PADDRINFOA)malloc(sizeof(ADDRINFOA));
     memcpy(*ppResult, &TEST_ADDR_INFO, sizeof(ADDRINFOA));
@@ -150,7 +154,15 @@ if (!g_addrinfo_call_fail)
 else
 {
     *ppResult = NULL;
-    callFail = MU_FAILURE;
+    if (g_addrinfo_failure_count > 0)
+    {
+        g_addrinfo_failure_count--;
+        callFail = g_addrinfo_failure_code;
+    }
+    else
+    {
+        callFail = MU_FAILURE;
+    }
 }
 MOCK_FUNCTION_END(callFail)
 MOCK_FUNCTION_WITH_CODE(WSAAPI, void, freeaddrinfo, PADDRINFOA, pResult)
@@ -448,6 +460,9 @@ TEST_FUNCTION_INITIALIZE(method_init)
     list_head_count = 0;
     singlylinkedlist_add_called = false;
     g_addrinfo_call_fail = false;
+    g_addrinfo_call_count = 0;
+    g_addrinfo_failure_count = 0;
+    g_addrinfo_failure_code = EAI_AGAIN;
     //g_socket_send_size_value = -1;
     g_socket_recv_size_value = -1;
 }
@@ -603,6 +618,19 @@ TEST_FUNCTION(socketio_open_socket_fails)
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, (size_t)INVALID_SOCKET, (size_t)*(SOCKET*)ioHandle);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    umock_c_reset_all_calls();
+    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+        .SetReturn((SOCKET)0x4244);
+    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
+    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
+    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
@@ -618,7 +646,8 @@ TEST_FUNCTION(socketio_open_getaddrinfo_fails)
 
     umock_c_reset_all_calls();
 
-    g_addrinfo_call_fail = true;
+    g_addrinfo_failure_count = 1;
+    g_addrinfo_failure_code = EAI_AGAIN;
     EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
 
@@ -633,6 +662,20 @@ TEST_FUNCTION(socketio_open_getaddrinfo_fails)
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, (size_t)INVALID_SOCKET, (size_t)*(SOCKET*)ioHandle);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    umock_c_reset_all_calls();
+    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+        .SetReturn((SOCKET)0x4244);
+    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
+    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
+    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
+    ASSERT_ARE_EQUAL(size_t, 2, g_addrinfo_call_count);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
@@ -666,6 +709,19 @@ TEST_FUNCTION(socketio_open_connect_fails)
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
+    umock_c_reset_all_calls();
+    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+        .SetReturn((SOCKET)0x4244);
+    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
+    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
+    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, 2, g_addrinfo_call_count);
+    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
     // cleanup
     socketio_destroy(ioHandle);
 }
@@ -697,6 +753,19 @@ TEST_FUNCTION(socketio_open_ioctlsocket_fails)
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    umock_c_reset_all_calls();
+    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+        .SetReturn((SOCKET)0x4244);
+    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
+    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
+    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, 2, g_addrinfo_call_count);
+    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
@@ -811,6 +880,21 @@ TEST_FUNCTION(socketio_close_Succeeds)
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
+
+    ASSERT_ARE_EQUAL(size_t, 1, g_addrinfo_call_count);
+
+    umock_c_reset_all_calls();
+    EXPECTED_CALL(socket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+        .SetReturn((SOCKET)0x4244);
+    EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, &TEST_ADDR_INFO, IGNORED_ARG));
+    EXPECTED_CALL(connect(IGNORED_ARG, (const struct sockaddr*)&test_sock_addr, IGNORED_ARG));
+    EXPECTED_CALL(ioctlsocket(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+
+    result = socketio_open(ioHandle, test_on_io_open_complete, &callbackContext, test_on_bytes_received, &callbackContext, test_on_io_error, &callbackContext);
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(size_t, 2, g_addrinfo_call_count);
+    ASSERT_ARE_EQUAL(size_t, (size_t)0x4244, (size_t)*(SOCKET*)ioHandle);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
     socketio_destroy(ioHandle);


### PR DESCRIPTION
## Summary

Transient Berkeley and Win32 socketio failures leave the adapter with a stale socket or a resolver that caches the failed lookup, so a later open on the same handle cannot recover.

## Motivation

The synchronous resolver marks a failed lookup as complete and never retries it. The failed open paths do not restore `IO_STATE_CLOSED`. A retry on the same XIO stack then fails before it tries DNS again.

## Changes

- Destroys the resolver in `socketio_cleanup` and creates it again on the next open, in both adapters.
- Restores `IO_STATE_CLOSED` on every failed open path, with one cleanup layer per adapter.
- Keeps `socketio_close` a no-op in `IO_STATE_CLOSED`, so an unopened accepted socket keeps its descriptor.
- Reports `IO_OPEN_OK` from the Berkeley dowork path only after the connect wait succeeds.
- Fails the Berkeley `lookup_address` on a completed lookup with no address, and rejects descriptors at or above `FD_SETSIZE`.
- Logs `gai_strerror` text, and `errno` for `EAI_SYSTEM`, in the synchronous resolver.
- Re-enables `socketio_berkeley_ut` and adds retry coverage for both adapters and for the resolver diagnostics.

## Test plan

- `build_all/linux/build.sh --run-unittests` on macOS: 45 of 45 suites pass, including 10 of 10 Berkeley retry tests.
- `dns_resolver_ut` in a `LINUX=1` tree on macOS: 16 of 16 tests pass.
- `git diff --check` passes.
- The Linux-only interface test and the `no_logging` build were checked by trace only; the Linux CI jobs run them.
- The Win32 suite was traced by hand against the adapter and needs the Windows CI job.

Fixes #682