### PR TITLE
fix: read interface hardware and IP addresses from separate ifreq, and release addrinfo on failed lookups

### DIFF
--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -324,7 +324,9 @@ static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struc
     NETWORK_INTERFACE_DESCRIPTION* result;
     size_t malloc_size;
 
-    if ((result = (NETWORK_INTERFACE_DESCRIPTION*)malloc(sizeof(NETWORK_INTERFACE_DESCRIPTION))) == NULL)
+    // calloc so that every pointer member is NULL and destroy_network_interface_descriptions
+    // stays safe if the description is only partially constructed.
+    if ((result = (NETWORK_INTERFACE_DESCRIPTION*)calloc(1, sizeof(NETWORK_INTERFACE_DESCRIPTION))) == NULL)
     {
         LogError("Failed allocating NETWORK_INTERFACE_DESCRIPTION");
     }

--- a/adapters/socketio_berkeley.c
+++ b/adapters/socketio_berkeley.c
@@ -317,7 +317,9 @@ static void destroy_network_interface_descriptions(NETWORK_INTERFACE_DESCRIPTION
     }
 }
 
-static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struct ifreq *ifr, NETWORK_INTERFACE_DESCRIPTION* previous_nid)
+// ifr_hwaddr and ifr_addr are members of the same union, so the hardware address
+// and the IP address must be read from separate struct ifreq instances.
+static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struct ifreq *ifr_hw, struct ifreq *ifr_ip, NETWORK_INTERFACE_DESCRIPTION* previous_nid)
 {
     NETWORK_INTERFACE_DESCRIPTION* result;
     size_t malloc_size;
@@ -326,7 +328,7 @@ static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struc
     {
         LogError("Failed allocating NETWORK_INTERFACE_DESCRIPTION");
     }
-    else if ((malloc_size = safe_multiply_size_t(safe_add_size_t(strlen(ifr->ifr_name), 1), sizeof(char))) == SIZE_MAX)
+    else if ((malloc_size = safe_multiply_size_t(safe_add_size_t(strlen(ifr_hw->ifr_name), 1), sizeof(char))) == SIZE_MAX)
     {
         LogError("invalid malloc size");
         destroy_network_interface_descriptions(result);
@@ -340,10 +342,10 @@ static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struc
     }
     else
     {
-        strcpy(result->name, ifr->ifr_name);
+        strcpy(result->name, ifr_hw->ifr_name);
 
         char* ip_address;
-        unsigned char* mac = (unsigned char*)ifr->ifr_hwaddr.sa_data;
+        unsigned char* mac = (unsigned char*)ifr_hw->ifr_hwaddr.sa_data;
         size_t malloc_size = safe_multiply_size_t(sizeof(char), MAC_ADDRESS_STRING_LENGTH);
 
         if (malloc_size == SIZE_MAX ||
@@ -359,7 +361,7 @@ static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struc
             destroy_network_interface_descriptions(result);
             result = NULL;
         }
-        else if ((ip_address = inet_ntoa(((struct sockaddr_in*)&ifr->ifr_addr)->sin_addr)) == NULL)
+        else if ((ip_address = inet_ntoa(((struct sockaddr_in*)&ifr_ip->ifr_addr)->sin_addr)) == NULL)
         {
             LogError("failed setting the ip address (inet_ntoa failed)");
             destroy_network_interface_descriptions(result);
@@ -396,7 +398,8 @@ static int get_network_interface_descriptions(int socket, NETWORK_INTERFACE_DESC
 {
     int result;
 
-    struct ifreq ifr;
+    struct ifreq ifr_hw;
+    struct ifreq ifr_ip;
     struct ifconf ifc;
     char buf[IFREQ_BUFFER_SIZE];
 
@@ -420,27 +423,28 @@ static int get_network_interface_descriptions(int socket, NETWORK_INTERFACE_DESC
 
         for (; it != end; ++it)
         {
-            strcpy(ifr.ifr_name, it->ifr_name);
+            strcpy(ifr_hw.ifr_name, it->ifr_name);
+            strcpy(ifr_ip.ifr_name, it->ifr_name);
 
-            if (ioctl(socket, SIOCGIFFLAGS, &ifr) != 0)
+            if (ioctl(socket, SIOCGIFFLAGS, &ifr_ip) != 0)
             {
                 LogError("ioctl failed querying socket (SIOCGIFFLAGS, errno=%d)", errno);
                 result = MU_FAILURE;
                 break;
             }
-            else if (ioctl(socket, SIOCGIFHWADDR, &ifr) != 0)
+            else if (ioctl(socket, SIOCGIFHWADDR, &ifr_hw) != 0)
             {
                 LogError("ioctl failed querying socket (SIOCGIFHWADDR, errno=%d)", errno);
                 result = MU_FAILURE;
                 break;
             }
-            else if (ioctl(socket, SIOCGIFADDR, &ifr) != 0)
+            else if (ioctl(socket, SIOCGIFADDR, &ifr_ip) != 0)
             {
                 LogError("ioctl failed querying socket (SIOCGIFADDR, errno=%d)", errno);
                 result = MU_FAILURE;
                 break;
             }
-            else if ((new_nid = create_network_interface_description(&ifr, new_nid)) == NULL)
+            else if ((new_nid = create_network_interface_description(&ifr_hw, &ifr_ip, new_nid)) == NULL)
             {
                 LogError("Failed creating network interface description");
                 result = MU_FAILURE;

--- a/src/dns_resolver_sync.c
+++ b/src/dns_resolver_sync.c
@@ -192,9 +192,12 @@ void dns_resolver_destroy(DNSRESOLVER_HANDLE dns_in)
     else
     {
         /* Codes_SRS_dns_resolver_30_051: [ dns_resolver_destroy shall delete all acquired resources and delete the DNSRESOLVER_HANDLE. ]*/
-        if(dns->is_complete && !dns->is_failed && dns->addrInfo != NULL)
+        // addrInfo is only set when getaddrinfo succeeded, so it must be released even
+        // when the lookup was then marked failed for holding no usable address.
+        if (dns->addrInfo != NULL)
         {
             freeaddrinfo(dns->addrInfo);
+            dns->addrInfo = NULL;
         }
 
         if(dns->hostname != NULL)

--- a/tests/dns_resolver_ut/dns_resolver_ut.c
+++ b/tests/dns_resolver_ut/dns_resolver_ut.c
@@ -70,9 +70,12 @@ MOCKABLE_FUNCTION(, int, getaddrinfo, const char*, node, const char*, service, c
 
 #undef ENABLE_MOCKS
 
+static int g_freeaddrinfo_call_count = 0;
+
 void freeaddrinfo(struct addrinfo* ai)
 {
     (void)ai;
+    g_freeaddrinfo_call_count++;
 }
 
 
@@ -92,6 +95,21 @@ int my_getaddrinfo(const char *node, const char *service, const struct addrinfo 
     fake_addrinfo.ai_family = AF_INET;
     fake_addrinfo.ai_addr = (struct sockaddr*)(&fake_good_addr);
     ((struct sockaddr_in *) fake_addrinfo.ai_addr)->sin_addr.s_addr = FAKE_GOOD_IP_ADDR;
+    *res = &fake_addrinfo;
+    return 0;
+}
+
+// getaddrinfo succeeds but returns no address of a family this build extracts,
+// which makes the lookup complete and failed while still owning the addrinfo list.
+int my_getaddrinfo_no_usable_address(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res)
+{
+    (void)node;
+    (void)service;
+    (void)hints;
+    fake_addrinfo.ai_next = NULL;
+    fake_addrinfo.ai_family = AF_UNSPEC;
+    fake_addrinfo.ai_addr = (struct sockaddr*)(&fake_good_addr);
+    ((struct sockaddr_in *) fake_addrinfo.ai_addr)->sin_addr.s_addr = 0;
     *res = &fake_addrinfo;
     return 0;
 }
@@ -176,6 +194,7 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
         }
 
         umock_c_reset_all_calls();
+        g_freeaddrinfo_call_count = 0;
     }
 
     /**
@@ -301,6 +320,67 @@ BEGIN_TEST_SUITE(dns_resolver_ut)
 
         ///cleanup
         dns_resolver_destroy(dns);
+    }
+
+    /* Tests_SRS_dns_resolver_30_051: [ dns_resolver_destroy shall delete all acquired resources and delete the DNSRESOLVER_HANDLE. ]*/
+    TEST_FUNCTION(dns_resolver__destroy_after_successful_lookup__frees_addrinfo)
+    {
+        ///arrange
+        bool result;
+        DNSRESOLVER_HANDLE dns = dns_resolver_create("fake.com", 53, NULL);
+        umock_c_reset_all_calls();
+        STRICT_EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+        result = dns_resolver_is_lookup_complete(dns);
+        ASSERT_IS_TRUE(result, "Unexpected non-completion");
+
+        ///act
+        dns_resolver_destroy(dns);
+
+        ///assert
+        ASSERT_ARE_EQUAL(int, 1, g_freeaddrinfo_call_count, "addrinfo was not released");
+    }
+
+    /* Tests_SRS_dns_resolver_30_051: [ dns_resolver_destroy shall delete all acquired resources and delete the DNSRESOLVER_HANDLE. ]*/
+    TEST_FUNCTION(dns_resolver__destroy_when_lookup_returned_no_usable_address__frees_addrinfo)
+    {
+        ///arrange
+        bool result;
+        uint32_t ipv4;
+        DNSRESOLVER_HANDLE dns = dns_resolver_create("fake.com", 53, NULL);
+        umock_c_reset_all_calls();
+        REGISTER_GLOBAL_MOCK_HOOK(getaddrinfo, my_getaddrinfo_no_usable_address);
+        STRICT_EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+        result = dns_resolver_is_lookup_complete(dns);
+        ASSERT_IS_TRUE(result, "Unexpected non-completion");
+        ipv4 = dns_resolver_get_ipv4(dns);
+        ASSERT_ARE_EQUAL(uint32_t, 0, ipv4, "Unexpected non-zero IP");
+
+        ///act
+        dns_resolver_destroy(dns);
+
+        ///assert
+        ASSERT_ARE_EQUAL(int, 1, g_freeaddrinfo_call_count, "addrinfo leaked on a completed lookup holding no usable address");
+
+        ///cleanup
+        REGISTER_GLOBAL_MOCK_HOOK(getaddrinfo, my_getaddrinfo);
+    }
+
+    /* Tests_SRS_dns_resolver_30_051: [ dns_resolver_destroy shall delete all acquired resources and delete the DNSRESOLVER_HANDLE. ]*/
+    TEST_FUNCTION(dns_resolver__destroy_after_failed_lookup__does_not_free_addrinfo)
+    {
+        ///arrange
+        bool result;
+        DNSRESOLVER_HANDLE dns = dns_resolver_create("fake.com", 53, NULL);
+        umock_c_reset_all_calls();
+        STRICT_EXPECTED_CALL(getaddrinfo(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG)).SetReturn(GETADDRINFO_FAIL);
+        result = dns_resolver_is_lookup_complete(dns);
+        ASSERT_IS_TRUE(result, "Unexpected non-completion");
+
+        ///act
+        dns_resolver_destroy(dns);
+
+        ///assert
+        ASSERT_ARE_EQUAL(int, 0, g_freeaddrinfo_call_count, "addrinfo released when getaddrinfo never returned one");
     }
 
     /* Tests_SRS_dns_resolver_30_020: [ If the dns parameter is NULL, dns_resolver_is_create_complete shall log an error and return false. ]*/


### PR DESCRIPTION
## Summary

Two product bugs found while verifying #682/#683, plus resolver teardown test coverage. Independent of #683; deliberately does not touch `socketio_berkeley_ut` or `tests/CMakeLists.txt`, which #683 rewrites.

## 1. `struct ifreq` union aliasing breaks `OPTION_NET_INT_MAC_ADDRESS` on Linux

`ifr_hwaddr` and `ifr_addr` are the same `ifr_ifru` union member (both at offset 16), so `ioctl(SIOCGIFADDR)` overwrites the hardware address that `ioctl(SIOCGIFHWADDR)` just wrote into the same `struct ifreq`. `create_network_interface_description` then formats the IP bytes as the MAC.

Measured against a real interface:
```
eth0 after SIOCGIFHWADDR: F2:2B:D7:E2:57:86
eth0 after SIOCGIFADDR  : 00:00:AC:13:00:0C   <- value that was being formatted
```

So the option never matched and every open failed:
```
set_target_network_interface: Did not find a network interface matching MAC ADDRESS
initiate_socket_connection: Failure: failed selecting target network interface (MACADDR=...)
```

Fix: query the two addresses into separate `struct ifreq` instances.

Verified end to end with the real MAC of a local interface. Before: `Did not find a network interface matching MAC ADDRESS`. After: the interface matches, `SO_BINDTODEVICE` succeeds, and the attempt proceeds to `connect()`.

macOS `struct ifreq` does not alias this way, so this is Linux-specific.

## 2. `addrinfo` leak in `dns_resolver_destroy`

`freeaddrinfo` was called only when `is_complete && !is_failed`. When `getaddrinfo` succeeds but returns no address of the family this build extracts, `is_failed` is set while `addrInfo` is non-NULL, and the list leaks. `addrInfo` is only ever assigned when `getaddrinfo` returned 0, so releasing it whenever it is non-NULL is sufficient and safe.

This is once per resolver today. #683 recreates the resolver on every open attempt, which would turn it into once per retry.

## Tests

Three `dns_resolver_ut` cases covering resolver teardown: successful lookup frees, completed-but-no-usable-address frees (fails without this change), failed `getaddrinfo` does not free.

## Test plan

- Linux x86-64, glibc, gcc 12, `run_unittests=ON`: **48/48 suites pass**, `dns_resolver_ut` 17/17.
- `git diff --check` clean.
- The MAC path was exercised against real interfaces as described above.
- Windows is not covered locally; `dns_resolver_ut` change needs the Windows CI job. The `ifreq` code is `#ifndef __APPLE__` and Linux-only, so it does not affect the Win32 adapter.
