### PR TITLE
ci: run the Windows tests from the directory they are built in

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -50,7 +50,7 @@ jobs:
       call jenkins\windows_c.cmd
     displayName: 'Build'
   - script: |
-      call jenkins\windows_c_VsDevCmd.cmd x86 && cd cmake && ctest -T test --no-compress-output -C Debug -V -j 16 --schedule-random
+      call jenkins\windows_c_VsDevCmd.cmd x86 && cd cmake\shared-util_Win32 && ctest -T test --no-compress-output -C Debug -V -j 16 --schedule-random --no-tests=error
     displayName: 'Run Tests'
   - task: PublishTestResults@2
     displayName: 'Publish Windows x86 Results'
@@ -81,7 +81,7 @@ jobs:
   - task: CodeQL3000Finalize@0
     condition: always()
   - script: |
-      call jenkins\windows_c_VsDevCmd.cmd x64 && cd cmake && ctest -T test --no-compress-output -C Debug -V -j 16 --schedule-random
+      call jenkins\windows_c_VsDevCmd.cmd x64 && cd cmake\shared-util_x64 && ctest -T test --no-compress-output -C Debug -V -j 16 --schedule-random --no-tests=error
     displayName: 'Run Tests'
   - task: PublishTestResults@2
     displayName: 'Publish Windows x64 Results'

--- a/tests/socketio_win32_ut/socketio_win32_ut.c
+++ b/tests/socketio_win32_ut/socketio_win32_ut.c
@@ -260,7 +260,15 @@ char* umocktypes_stringify_const_ADDRINFOA_ptr(const ADDRINFOA** value)
     char temp_buffer[256];
     int length;
 
-    length = sprintf(temp_buffer, "{ ai_flags = %d, ai_family = %d, ai_socktype = %d, ai_protocol = %d, ai_addrlen = %u, ai_canonname = %s", (*value)->ai_flags, (*value)->ai_family, (*value)->ai_socktype, (*value)->ai_protocol, (unsigned int)((*value)->ai_addrlen), (*value)->ai_canonname);
+    if (*value == NULL)
+    {
+        length = sprintf(temp_buffer, "NULL");
+    }
+    else
+    {
+        const char* canonname = ((*value)->ai_canonname == NULL) ? "NULL" : (*value)->ai_canonname;
+        length = sprintf(temp_buffer, "{ ai_flags = %d, ai_family = %d, ai_socktype = %d, ai_protocol = %d, ai_addrlen = %u, ai_canonname = %s", (*value)->ai_flags, (*value)->ai_family, (*value)->ai_socktype, (*value)->ai_protocol, (unsigned int)((*value)->ai_addrlen), canonname);
+    }
     if (length > 0)
     {
         result = (char*)malloc(strlen(temp_buffer) + 1);
@@ -276,12 +284,16 @@ char* umocktypes_stringify_const_ADDRINFOA_ptr(const ADDRINFOA** value)
 int umocktypes_are_equal_const_ADDRINFOA_ptr(const ADDRINFOA** left, const ADDRINFOA** right)
 {
     int result = 1;
-    if (((*left)->ai_flags != (*right)->ai_flags) ||
+    if ((*left == NULL) || (*right == NULL))
+    {
+        result = (*left == *right);
+    }
+    else if (((*left)->ai_flags != (*right)->ai_flags) ||
         ((*left)->ai_family != (*right)->ai_family) ||
         ((*left)->ai_socktype != (*right)->ai_socktype) ||
         ((*left)->ai_protocol != (*right)->ai_protocol) ||
-        ((((*left)->ai_canonname == NULL) || ((*right)->ai_canonname == NULL)) && ((*left)->ai_canonname != (*right)->ai_canonname)) ||
-        (strcmp((*left)->ai_canonname, (*right)->ai_canonname) != 0))
+        (((*left)->ai_canonname == NULL) != ((*right)->ai_canonname == NULL)) ||
+        (((*left)->ai_canonname != NULL) && (strcmp((*left)->ai_canonname, (*right)->ai_canonname) != 0)))
     {
         result = 0;
     }
@@ -293,20 +305,28 @@ int umocktypes_copy_const_ADDRINFOA_ptr(ADDRINFOA** destination, const ADDRINFOA
 {
     int result;
 
-    *destination = (ADDRINFOA*)malloc(sizeof(ADDRINFOA));
-    if (*destination == NULL)
+    if (*source == NULL)
     {
-        result = MU_FAILURE;
+        *destination = NULL;
+        result = 0;
     }
     else
     {
-        (*destination)->ai_flags = (*source)->ai_flags;
-        (*destination)->ai_family = (*source)->ai_family;
-        (*destination)->ai_socktype = (*source)->ai_socktype;
-        (*destination)->ai_protocol = (*source)->ai_protocol;
-        (*destination)->ai_canonname = (*source)->ai_canonname;
+        *destination = (ADDRINFOA*)malloc(sizeof(ADDRINFOA));
+        if (*destination == NULL)
+        {
+            result = MU_FAILURE;
+        }
+        else
+        {
+            (*destination)->ai_flags = (*source)->ai_flags;
+            (*destination)->ai_family = (*source)->ai_family;
+            (*destination)->ai_socktype = (*source)->ai_socktype;
+            (*destination)->ai_protocol = (*source)->ai_protocol;
+            (*destination)->ai_canonname = (*source)->ai_canonname;
 
-        result = 0;
+            result = 0;
+        }
     }
 
     return result;


### PR DESCRIPTION
The Windows build scripts configure into `cmake\shared-util_<platform>` (`build_all/windows/build.cmd`), but the Run Tests step did `cd cmake` and ran ctest there. That directory has no `CTestTestfile.cmake`, so ctest printed `No tests were found!!!` and **exited 0** — the step passed without running anything.

Net effect: the Windows jobs have been building the test binaries and never executing them. This predates the recent pipeline work (the step has looked like this since 71d6f52).

Changes, both Windows jobs:
- `cd cmake\shared-util_x64` / `cd cmake\shared-util_Win32` so ctest runs where the tests are.
- `--no-tests=error`, so an empty test list fails the step instead of passing silently.

Verified locally (ctest 3.25.1): with no tests present, plain `ctest` exits `0`; `ctest --no-tests=error` exits `8`. The Windows run itself could not be executed locally — no Windows host available — so this needs the pipeline to confirm.

Expect this to surface pre-existing Windows test failures, since these suites have not run in CI for a long time. I will follow up on whatever it reports.

Note the x86 job is currently `condition: false`, so only the x64 job changes behaviour now; the x86 step is corrected the same way for when it is re-enabled.