### PR TITLE
Call explicit ANSI Win32/SSPI entry points instead of TCHAR-neutral macros

### DIFF
--- a/adapters/condition_win32.c
+++ b/adapters/condition_win32.c
@@ -26,7 +26,7 @@ COND_HANDLE Condition_Init(void)
     if (cond != NULL)
     {
         (void)memset(cond, 0, sizeof(CONDITION));
-        cond->event_handle = CreateEvent(NULL, FALSE, FALSE, NULL);
+        cond->event_handle = CreateEventA(NULL, FALSE, FALSE, NULL);
 
         if (cond->event_handle == NULL)
         {

--- a/adapters/platform_win32.c
+++ b/adapters/platform_win32.c
@@ -143,7 +143,7 @@ STRING_HANDLE platform_get_platform_info(PLATFORM_INFO_OPTION options)
     // Expected format: "(<runtime name>; <operating system name>; <platform>)"
     STRING_HANDLE result;
     SYSTEM_INFO sys_info;
-    OSVERSIONINFO osvi;
+    OSVERSIONINFOA osvi;
     char *arch;
     GetSystemInfo(&sys_info);
 
@@ -176,7 +176,7 @@ STRING_HANDLE platform_get_platform_info(PLATFORM_INFO_OPTION options)
 #ifdef _MSC_VER
 #pragma warning(disable:4996 28159)  // GetVersionEx is deprecated 
 #endif
-    if (GetVersionEx(&osvi))
+    if (GetVersionExA(&osvi))
     {
         DWORD product_type;
         if (GetProductInfo(osvi.dwMajorVersion, osvi.dwMinorVersion, 0, 0, &product_type))

--- a/adapters/string_utils.c
+++ b/adapters/string_utils.c
@@ -139,7 +139,7 @@ char* FILETIME_toAsciiArray(const FILETIME* fileTime)
             else
             {
                 char localDate[255];
-                if (GetDateFormat(LOCALE_USER_DEFAULT, DATE_LONGDATE, &systemTime, NULL, localDate, sizeof(localDate)/sizeof(localDate[0])) == 0)
+                if (GetDateFormatA(LOCALE_USER_DEFAULT, DATE_LONGDATE, &systemTime, NULL, localDate, sizeof(localDate)/sizeof(localDate[0])) == 0)
                 {
                     LogLastError("failure in GetDateFormat");
                     result = NULL;
@@ -147,7 +147,7 @@ char* FILETIME_toAsciiArray(const FILETIME* fileTime)
                 else
                 {
                     char localTime[255];
-                    if (GetTimeFormat(LOCALE_USER_DEFAULT, 0, &systemTime, NULL, localTime, sizeof(localTime)/sizeof(localTime[0])) == 0)
+                    if (GetTimeFormatA(LOCALE_USER_DEFAULT, 0, &systemTime, NULL, localTime, sizeof(localTime)/sizeof(localTime[0])) == 0)
                     {
                         LogLastError("failure in GetTimeFormat");
                         result = NULL;

--- a/adapters/tlsio_schannel.c
+++ b/adapters/tlsio_schannel.c
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #define SECURITY_WIN32
-#define SEC_TCHAR   SEC_CHAR
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -57,7 +56,7 @@ typedef struct TLS_IO_INSTANCE_TAG
     void* on_io_error_context;
     CtxtHandle security_context;
     TLSIO_STATE tlsio_state;
-    SEC_TCHAR* host_name;
+    SEC_CHAR* host_name;
     CredHandle credential_handle;
     bool credential_handle_allocated;
     bool ignore_server_name_check;
@@ -339,7 +338,7 @@ static void send_client_hello(TLS_IO_INSTANCE* tls_io_instance)
         auth_data.dwFlags |= SCH_CRED_MANUAL_CRED_VALIDATION;
     }
 
-    status = AcquireCredentialsHandle(NULL, UNISP_NAME, SECPKG_CRED_OUTBOUND, NULL,
+    status = AcquireCredentialsHandleA(NULL, UNISP_NAME_A, SECPKG_CRED_OUTBOUND, NULL,
         &auth_data, NULL, NULL, &tls_io_instance->credential_handle, NULL);
     if (status != SEC_E_OK)
     {
@@ -362,7 +361,7 @@ static void send_client_hello(TLS_IO_INSTANCE* tls_io_instance)
         security_buffers_desc.pBuffers = init_security_buffers;
         security_buffers_desc.ulVersion = SECBUFFER_VERSION;
 
-        status = InitializeSecurityContext(&tls_io_instance->credential_handle,
+        status = InitializeSecurityContextA(&tls_io_instance->credential_handle,
             NULL, tls_io_instance->host_name, ISC_REQ_EXTENDED_ERROR | ISC_REQ_STREAM | ISC_REQ_ALLOCATE_MEMORY | ISC_REQ_USE_SUPPLIED_CREDS, 0, 0, NULL, 0,
             &tls_io_instance->security_context, &security_buffers_desc,
             &context_attributes, NULL);
@@ -441,7 +440,7 @@ static int verify_custom_certificate_if_needed(TLS_IO_INSTANCE* tls_io_instance)
     {
         PCERT_CONTEXT serverCertificateToVerify = NULL;
 
-        SECURITY_STATUS status = QueryContextAttributes(&tls_io_instance->security_context, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &serverCertificateToVerify);
+        SECURITY_STATUS status = QueryContextAttributesA(&tls_io_instance->security_context, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &serverCertificateToVerify);
         if (status != SEC_E_OK)
         {
             LogError("QueryContextAttributes failed: %x", status);
@@ -508,7 +507,7 @@ static int send_chunk(CONCRETE_IO_HANDLE tls_io, const void* buffer, size_t size
         else
         {
             SecPkgContext_StreamSizes  sizes;
-            SECURITY_STATUS status = QueryContextAttributes(&tls_io_instance->security_context, SECPKG_ATTR_STREAM_SIZES, &sizes);
+            SECURITY_STATUS status = QueryContextAttributesA(&tls_io_instance->security_context, SECPKG_ATTR_STREAM_SIZES, &sizes);
             if (status != SEC_E_OK)
             {
                 LogError("QueryContextAttributes failed: %x", status);
@@ -667,7 +666,7 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                 output_buffers_desc.ulVersion = SECBUFFER_VERSION;
 
                 flags = ISC_REQ_EXTENDED_ERROR | ISC_REQ_STREAM | ISC_REQ_ALLOCATE_MEMORY | ISC_REQ_USE_SUPPLIED_CREDS;
-                status = InitializeSecurityContext(&tls_io_instance->credential_handle,
+                status = InitializeSecurityContextA(&tls_io_instance->credential_handle,
                     &tls_io_instance->security_context, tls_io_instance->host_name, flags, 0, 0, &input_buffers_desc, 0,
                     &tls_io_instance->security_context, &output_buffers_desc,
                     &context_attributes, NULL);
@@ -824,10 +823,10 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                 default:
                     {
                         LPVOID srcText = NULL;
-                        if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
-                            status, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&srcText, 0, NULL) > 0)
+                        if (FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+                            status, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&srcText, 0, NULL) > 0)
                         {
-                            LogError("[%#x] %s", status, (LPTSTR)srcText);
+                            LogError("[%#x] %s", status, (LPSTR)srcText);
                             LocalFree(srcText);
                         }
                         else
@@ -963,7 +962,7 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                     output_buffers_desc.ulVersion = SECBUFFER_VERSION;
 
                     flags = ISC_REQ_EXTENDED_ERROR | ISC_REQ_STREAM | ISC_REQ_ALLOCATE_MEMORY | ISC_REQ_USE_SUPPLIED_CREDS;
-                    status = InitializeSecurityContext(&tls_io_instance->credential_handle,
+                    status = InitializeSecurityContextA(&tls_io_instance->credential_handle,
                         &tls_io_instance->security_context, tls_io_instance->host_name, flags, 0, 0, &input_buffers_desc, 0,
                         &tls_io_instance->security_context, &output_buffers_desc,
                         &context_attributes, NULL);
@@ -1010,10 +1009,10 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                 default:
                     {
                         LPVOID srcText = NULL;
-                        if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
-                            status, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&srcText, 0, NULL) > 0)
+                        if (FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+                            status, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&srcText, 0, NULL) > 0)
                         {
-                            LogError("[%#x] %s", status, (LPTSTR)srcText);
+                            LogError("[%#x] %s", status, (LPSTR)srcText);
                             LocalFree(srcText);
                         }
                         else
@@ -1095,9 +1094,9 @@ CONCRETE_IO_HANDLE tlsio_schannel_create(void* io_create_parameters)
             (void)memset(result, 0, sizeof(TLS_IO_INSTANCE));
 
             size_t malloc_size = safe_add_size_t(strlen(tls_io_config->hostname), 1);
-            malloc_size = safe_multiply_size_t(malloc_size, sizeof(SEC_TCHAR));
+            malloc_size = safe_multiply_size_t(malloc_size, sizeof(SEC_CHAR));
             if (malloc_size == SIZE_MAX ||
-                (result->host_name = (SEC_TCHAR*)malloc(malloc_size)) == NULL)
+                (result->host_name = (SEC_CHAR*)malloc(malloc_size)) == NULL)
             {
                 LogError("malloc failed, size:%zu", malloc_size);
                 free(result);

--- a/adapters/x509_schannel.c
+++ b/adapters/x509_schannel.c
@@ -261,7 +261,7 @@ static int set_rsa_certificate_info(X509_SCHANNEL_HANDLE_DATA* x509_handle, unsi
     int result;
     /*Codes_SRS_X509_SCHANNEL_02_005: [ x509_schannel_create shall call CryptAcquireContext. ]*/
     /*at this moment, both the private key and the certificate are decoded for further usage*/
-    if (!CryptAcquireContext(&(x509_handle->hProv), NULL, MS_ENH_RSA_AES_PROV, PROV_RSA_AES, CRYPT_VERIFYCONTEXT))
+    if (!CryptAcquireContextA(&(x509_handle->hProv), NULL, MS_ENH_RSA_AES_PROV_A, PROV_RSA_AES, CRYPT_VERIFYCONTEXT))
     {
         /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
         LogErrorWinHTTPWithGetLastErrorAsString("CryptAcquireContext failed");

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -68,7 +68,7 @@ static char* lastErrorToString(DWORD lastError)
     else
     {
         char temp[MESSAGE_BUFFER_SIZE];
-        if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, lastError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), temp, MESSAGE_BUFFER_SIZE, NULL) == 0)
+        if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, lastError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), temp, MESSAGE_BUFFER_SIZE, NULL) == 0)
         {
             result = printf_alloc("GetLastError()=0X%x", lastError);
             if (result == NULL)

--- a/src/etwlogger_driver.c
+++ b/src/etwlogger_driver.c
@@ -75,7 +75,7 @@ static char* lastErrorToString(DWORD lastError)
     else
     {
         char temp[MESSAGE_BUFFER_SIZE];
-        if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, lastError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), temp, MESSAGE_BUFFER_SIZE, NULL) == 0)
+        if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, lastError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), temp, MESSAGE_BUFFER_SIZE, NULL) == 0)
         {
             result = printf_alloc("GetLastError()=0X%x", lastError);
             if (result == NULL)

--- a/src/xlogging.c
+++ b/src/xlogging.c
@@ -120,11 +120,11 @@ void xlogging_LogErrorWinHTTPWithGetLastErrorAsStringFormatter(int errorMessageI
     }
     else
     {
-        int size = FormatMessage(FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_IGNORE_INSERTS,
-            GetModuleHandle("WinHttp"), errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), messageBuffer, MESSAGE_BUFFER_SIZE, NULL);
+        int size = FormatMessageA(FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_IGNORE_INSERTS,
+            GetModuleHandleA("WinHttp"), errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), messageBuffer, MESSAGE_BUFFER_SIZE, NULL);
         if (size == 0)
         {
-            size = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), messageBuffer, MESSAGE_BUFFER_SIZE, NULL);
+            size = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), messageBuffer, MESSAGE_BUFFER_SIZE, NULL);
             if (size == 0)
             {
                 LogError("GetLastError Code: %d. ", errorMessageID);

--- a/tests/x509_schannel_ut/x509_schannel_ut.c
+++ b/tests/x509_schannel_ut/x509_schannel_ut.c
@@ -601,7 +601,7 @@ static void setup_x509_schannel_create_mocks(void)
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is allocating space for the decoded private key*/
     STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_RSA_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, IGNORED_ARG, IGNORED_ARG)); /*this is asking "how big is the decoded private key? (from binary)*/
     STRICT_EXPECTED_CALL(CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, IGNORED_ARG, IGNORED_ARG)); /*create a certificate context from an encoded certificate*/
-    STRICT_EXPECTED_CALL(CryptAcquireContextA(IGNORED_ARG, NULL, MS_ENH_RSA_AES_PROV, PROV_RSA_AES, CRYPT_VERIFYCONTEXT)); /*this is acquire a handle to a key container within a cryptographic service provider*/
+    STRICT_EXPECTED_CALL(CryptAcquireContextA(IGNORED_ARG, NULL, MS_ENH_RSA_AES_PROV_A, PROV_RSA_AES, CRYPT_VERIFYCONTEXT)); /*this is acquire a handle to a key container within a cryptographic service provider*/
     STRICT_EXPECTED_CALL(CryptImportKey((HCRYPTPROV)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, (HCRYPTKEY)NULL, 0, IGNORED_ARG)) /*tranferring the key from the blob to the cryptrographic key provider*/
         .IgnoreArgument_hProv();
     STRICT_EXPECTED_CALL(CertSetCertificateContextProperty(IGNORED_ARG, CERT_KEY_PROV_HANDLE_PROP_ID, 0, IGNORED_ARG)); /*give the private key*/


### PR DESCRIPTION
Fixes #668.

## Problem

Windows sources call Win32/SSPI/wincrypt entry points by their unsuffixed (TCHAR-neutral) names while passing narrow `char` buffers. When `UNICODE` is defined the SDK maps those names to the `...W` variants, so `char*` is passed where `LPWSTR` is expected.

The trigger is `UNICODE`, not `_UNICODE`. `_UNICODE` selects the CRT `tchar.h` mappings (`_T`, `_tcs*`), which this library does not use anywhere in `src/`, `inc/`, `adapters/` or `pal/`. MSVC and Xbox project templates define both together, which is why the report cites `_UNICODE`.

Impact beyond the reported warnings: the buffer size arguments of these APIs are counted in `TCHAR`s, so the `W` variants write up to twice the bytes the narrow buffers reserve (`FormatMessage` in the loggers, `GetDateFormat`/`GetTimeFormat` in `string_utils.c`). `InitializeSecurityContextW` reads the narrow host name as UTF-16, so it reads past the allocation and supplies a wrong target name to the TLS handshake.

Not affected: Linux/POSIX, mbed, FreeRTOS, TI-RTOS, Azure Sphere, and Windows builds without `UNICODE`. CI builds Windows without `UNICODE`, which is why this was not caught.

## Change

Call the explicit `...A` entry points and use the matching `..._A` string constants at every such site:

- `src/consolelogger.c`, `src/etwlogger_driver.c`, `src/xlogging.c` — `FormatMessageA`, `GetModuleHandleA`
- `adapters/string_utils.c` — `GetDateFormatA`, `GetTimeFormatA`
- `adapters/platform_win32.c` — `OSVERSIONINFOA`, `GetVersionExA`
- `adapters/condition_win32.c` — `CreateEventA`
- `adapters/x509_schannel.c` — `CryptAcquireContextA`, `MS_ENH_RSA_AES_PROV_A`
- `adapters/tlsio_schannel.c` — `AcquireCredentialsHandleA`/`UNISP_NAME_A`, `InitializeSecurityContextA`, `QueryContextAttributesA`, `FormatMessageA`, `LPTSTR` casts to `LPSTR`, and removal of the file-local `#define SEC_TCHAR SEC_CHAR` that shadowed the SDK macro (`SEC_CHAR` is now used directly)
- `tests/x509_schannel_ut/x509_schannel_ut.c` — expected argument updated to `MS_ENH_RSA_AES_PROV_A` so the `STRICT_EXPECTED_CALL` keeps matching; the mock was already declared as `CryptAcquireContextA`

Some converted sites (`CreateEvent` with a `NULL` name, `GetVersionEx`/`OSVERSIONINFO`, `CryptAcquireContext`) were type-consistent either way and are changed for consistency with no behaviour change.

To confirm the survey was complete, every A/W-mapped identifier declared by the Windows headers (2925 names) was intersected with every identifier in `src/`, `inc/`, `adapters/` and `pal/`. After this change the intersection contains only occurrences inside comments and log message literals.

No public header change. No API or ABI change: `SEC_TCHAR` was a file-local macro in a `.c` file and `host_name` is a private struct member. Existing non-`UNICODE` Windows builds are unaffected — every changed call already resolved to the same `...A` symbol.

## Verification

- Linux, gcc 12.2.0, cmake 3.25.1, `-Duse_openssl=ON -Drun_unittests=ON -Dskip_samples=ON`: builds clean, `ctest` reports 100% tests passed, 0 failed out of 49.
- Windows cross-compile with mingw-w64 10.0.0 / gcc 12, 17 Windows translation units, with `-D_UNICODE -DUNICODE` and `-Werror=incompatible-pointer-types -Werror=int-conversion`:
  - before: 4 fail to compile (`etwlogger_driver.c`, `xlogging.c`, `string_utils.c`, `tlsio_schannel.c`), 11 A/W diagnostics matching the reported lines
  - after: 17/17 compile, 0 diagnostics
- `src/consolelogger.c` is inside `#if defined(_MSC_VER)`; compiled separately with `_MSC_VER` forced, it reproduces the reported `consolelogger.c(71)` diagnostic before and is clean after.
- Without `UNICODE`, before and after are both clean, confirming no change for current consumers.

Not verified here, and worth a reviewer's attention:

- CI covers MSVC (Windows x64 and Windows Dynamic legs pass), but only without `UNICODE` defined. No MSVC build with `UNICODE` was run, so the warning numbers C4133/C4477/C4005 remain inferred from the equivalent gcc diagnostics; mingw-w64 headers are an independent implementation.
- Locally, no Windows binary was linked or run. The Windows CI legs build the Windows-only targets (`x509_schannel_ut`, `platform_win32_ut`, `socketio_win32_ut`, `timer_win32_ut`); no live SChannel handshake was exercised in any case.
- Xbox GDK was not available. The GDK restricts the callable Win32 surface, so please confirm `GetVersionExA`, `CreateEventA`, `GetDateFormatA`, `GetTimeFormatA`, `GetModuleHandleA`, `CryptAcquireContextA` and `MS_ENH_RSA_AES_PROV_A` all link on that target.

## Notes

- The `...A` variants use the process ANSI code page rather than UTF-8. For the log and platform-info text this is pre-existing behaviour, identical to what non-`UNICODE` builds already produce, and is unchanged here. For the SChannel host name it means non-ASCII/IDN names are interpreted in the ANSI code page; making that UTF-8-correct requires converting explicitly and moving the whole SSPI credential/context family to the `W` variants, which needs Windows-side testing and is left for a separate change.
- Separately noticed, not changed here: `adapters/httpapi_winhttp.c` converts narrow strings to wide for the wide-only WinHTTP API using `CP_ACP` instead of `CP_UTF8` (request path, host name, headers, and the reverse conversion of the response token), and converts proxy credentials with locale-dependent `mbstowcs_s`. HTTP targets and header values should be UTF-8. This is a plausible cause of file uploads failing when the destination file name contains non-ASCII characters on a non-Latin code page host. It needs its own change, with a Windows host and a live endpoint to validate.
- There is no CI configuration that defines `UNICODE`, so nothing prevents this from recurring. A Windows CI leg with `/D UNICODE /D _UNICODE` would be worth adding.

