### PR TITLE
Fix exported include directories for installed package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ option(use_installed_dependencies "set use_installed_dependencies to ON to use i
 option(use_default_uuid "set use_default_uuid to ON to use the out of the box UUID that comes with the SDK rather than platform specific implementations" OFF)
 option(run_e2e_tests "set run_e2e_tests to ON to run e2e tests (default is OFF). Chsare dutility does not have any e2e tests, but the option needs to exist to evaluate in IF statements" OFF)
 option(run_int_tests "set run_int_tests to ON to integration tests (default is OFF)." OFF)
+option(run_install_export_test "set run_install_export_test to OFF to skip the install/export regression test, which configures and builds the project a second time (default is ON when tests are enabled)" ON)
 option(use_builtin_httpapi "set use_builtin_httpapi to ON to use the built-in httpapi_compact that comes with C shared utility (default is OFF)" OFF)
 option(use_cppunittest "set use_cppunittest to ON to build CppUnitTest tests on Windows (default is OFF)" OFF)
 option(suppress_header_searches "do not try to find headers - used when compiler check will fail" OFF)
@@ -792,13 +793,26 @@ if(TARGET c_logging_v2 AND TARGET c_logging_v2_core)
     list(APPEND targets c_logging_v2 c_logging_v2_core)
 endif()
 
+# Public headers install to ${CMAKE_INSTALL_INCLUDEDIR}/azure_c_shared_utility and are
+# consumed as #include "azure_c_shared_utility/<h>.h", so the exported root must be
+# ${CMAKE_INSTALL_INCLUDEDIR} itself. The public xlogging.h also pulls in
+# "c_logging/logger.h", installed under ${CMAKE_INSTALL_INCLUDEDIR}/c_logging/v2.
+# The legacy azureiot root is kept for the sibling SDK components that install there,
+# and is now created unconditionally so it is never a non-existent exported path.
+set(exported_include_dirs ${CMAKE_INSTALL_INCLUDEDIR})
+if(TARGET c_logging_v2 AND TARGET c_logging_v2_core)
+    list(APPEND exported_include_dirs ${CMAKE_INSTALL_INCLUDEDIR}/c_logging/v2)
+endif()
+list(APPEND exported_include_dirs ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
+
 install (TARGETS ${targets} EXPORT aziotsharedutilTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
+    INCLUDES DESTINATION ${exported_include_dirs}
 )
 install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azure_c_shared_utility)
+install (DIRECTORY DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
 install (FILES ${micromock_h_files_full_path} ${INSTALL_H_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,3 +108,10 @@ if(${run_int_tests})
         add_subdirectory(string_utils_int)
     endif()
 endif()
+
+# Guards the CMake install/export rules. It is not tied to run_int_tests because
+# the defect it catches is invisible from inside this project's build and breaks
+# every downstream find_package consumer, so it runs whenever tests are enabled.
+if(${run_install_export_test})
+    add_subdirectory(install_export_int)
+endif()

--- a/tests/install_export_int/CMakeLists.txt
+++ b/tests/install_export_int/CMakeLists.txt
@@ -32,23 +32,42 @@ if(host_processor_count EQUAL 0)
     set(host_processor_count 1)
 endif()
 
-add_test(NAME ${theseTestsName}
-    COMMAND ${CMAKE_COMMAND}
-        "-DSOURCE_DIR=${CMAKE_CURRENT_LIST_DIR}/../.."
-        "-DCONSUMER_DIR=${CMAKE_CURRENT_LIST_DIR}/consumer"
-        "-DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/scratch"
-        "-DGENERATOR=${CMAKE_GENERATOR}"
-        "-DGENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}"
-        "-DGENERATOR_TOOLSET=${CMAKE_GENERATOR_TOOLSET}"
-        "-DC_COMPILER=${CMAKE_C_COMPILER}"
-        "-DCXX_COMPILER=${CMAKE_CXX_COMPILER}"
-        "-DBUILD_TYPE=${CMAKE_BUILD_TYPE}"
-        "-DPARALLEL_LEVEL=${host_processor_count}"
-        "-DFORWARDED_OPTIONS=${forwarded_options}"
-        -P "${CMAKE_CURRENT_LIST_DIR}/install_export_test.cmake")
+get_property(generator_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
-# The test configures and builds the project from scratch, so it needs a much
-# larger budget than a unit test.
-set_tests_properties(${theseTestsName} PROPERTIES
-    TIMEOUT 3600
-    LABELS "integration;packaging")
+# Single config generators take the configuration at configure time, multi config
+# generators take it per build, and the test has to drive the scratch build the
+# same way ctest was invoked.
+if(generator_is_multi_config)
+    set(configuration_arguments "-DCONFIG=$<CONFIG>")
+else()
+    set(configuration_arguments "-DBUILD_TYPE=${CMAKE_BUILD_TYPE}")
+endif()
+
+if(CMAKE_CROSSCOMPILING)
+    # The test builds a consumer and runs it, which a cross compiling build
+    # cannot do. The install/export rules are host independent, so this costs no
+    # coverage as long as at least one native leg runs the test.
+    message(STATUS "${theseTestsName}: not registered, the consumer cannot be run when cross compiling")
+else()
+    add_test(NAME ${theseTestsName}
+        COMMAND ${CMAKE_COMMAND}
+            "-DSOURCE_DIR=${CMAKE_CURRENT_LIST_DIR}/../.."
+            "-DCONSUMER_DIR=${CMAKE_CURRENT_LIST_DIR}/consumer"
+            "-DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/scratch"
+            "-DGENERATOR=${CMAKE_GENERATOR}"
+            "-DGENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}"
+            "-DGENERATOR_TOOLSET=${CMAKE_GENERATOR_TOOLSET}"
+            "-DC_COMPILER=${CMAKE_C_COMPILER}"
+            "-DCXX_COMPILER=${CMAKE_CXX_COMPILER}"
+            "-DTOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+            ${configuration_arguments}
+            "-DPARALLEL_LEVEL=${host_processor_count}"
+            "-DFORWARDED_OPTIONS=${forwarded_options}"
+            -P "${CMAKE_CURRENT_LIST_DIR}/install_export_test.cmake")
+
+    # The test configures and builds the project from scratch, so it needs a much
+    # larger budget than a unit test.
+    set_tests_properties(${theseTestsName} PROPERTIES
+        TIMEOUT 3600
+        LABELS "integration;packaging")
+endif()

--- a/tests/install_export_int/CMakeLists.txt
+++ b/tests/install_export_int/CMakeLists.txt
@@ -1,0 +1,54 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Regression test for the CMake install/export rules.
+#
+# The exported include directories of the installed targets have to agree with
+# where the headers are actually installed. When they do not, every downstream
+# project that does find_package(azure_c_shared_utility CONFIG) fails, either at
+# generate time with "Imported target ... includes non-existent path" or at
+# compile time on a header that cannot be found. Neither failure is visible from
+# inside this project's own build, so it is checked here end to end.
+
+set(theseTestsName install_export_int)
+
+# Feature switches that change which targets are exported, or what the exported
+# targets need from the include path, are forwarded to the scratch build.
+set(forwarded_options
+    "use_openssl:BOOL=${use_openssl}"
+    "use_wolfssl:BOOL=${use_wolfssl}"
+    "use_mbedtls:BOOL=${use_mbedtls}"
+    "use_bearssl:BOOL=${use_bearssl}"
+    "use_http:BOOL=${use_http}"
+    "use_wsio:BOOL=${use_wsio}"
+    "use_condition:BOOL=${use_condition}"
+    "use_default_uuid:BOOL=${use_default_uuid}"
+    "use_installed_dependencies:BOOL=${use_installed_dependencies}"
+    "build_as_dynamic:BOOL=${build_as_dynamic}")
+
+include(ProcessorCount)
+ProcessorCount(host_processor_count)
+if(host_processor_count EQUAL 0)
+    set(host_processor_count 1)
+endif()
+
+add_test(NAME ${theseTestsName}
+    COMMAND ${CMAKE_COMMAND}
+        "-DSOURCE_DIR=${CMAKE_CURRENT_LIST_DIR}/../.."
+        "-DCONSUMER_DIR=${CMAKE_CURRENT_LIST_DIR}/consumer"
+        "-DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/scratch"
+        "-DGENERATOR=${CMAKE_GENERATOR}"
+        "-DGENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}"
+        "-DGENERATOR_TOOLSET=${CMAKE_GENERATOR_TOOLSET}"
+        "-DC_COMPILER=${CMAKE_C_COMPILER}"
+        "-DCXX_COMPILER=${CMAKE_CXX_COMPILER}"
+        "-DBUILD_TYPE=${CMAKE_BUILD_TYPE}"
+        "-DPARALLEL_LEVEL=${host_processor_count}"
+        "-DFORWARDED_OPTIONS=${forwarded_options}"
+        -P "${CMAKE_CURRENT_LIST_DIR}/install_export_test.cmake")
+
+# The test configures and builds the project from scratch, so it needs a much
+# larger budget than a unit test.
+set_tests_properties(${theseTestsName} PROPERTIES
+    TIMEOUT 3600
+    LABELS "integration;packaging")

--- a/tests/install_export_int/consumer/CMakeLists.txt
+++ b/tests/install_export_int/consumer/CMakeLists.txt
@@ -86,7 +86,8 @@ add_executable(install_export_consumer main.c)
 target_link_libraries(install_export_consumer aziotsharedutil)
 
 add_custom_command(TARGET install_export_consumer POST_BUILD
-    COMMAND install_export_consumer
+    COMMAND "$<TARGET_FILE:install_export_consumer>"
+    WORKING_DIRECTORY "$<TARGET_FILE_DIR:install_export_consumer>"
     COMMENT "Running the consumer built against the installed package")
 
 # When the project is built as dynamic there is a second exported library target,

--- a/tests/install_export_int/consumer/CMakeLists.txt
+++ b/tests/install_export_int/consumer/CMakeLists.txt
@@ -1,0 +1,101 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Standalone consumer of the INSTALLED azure_c_shared_utility package.
+#
+# This project is deliberately not part of the azure_c_shared_utility build: it
+# is configured separately by install_export_test.cmake against an install
+# prefix, so it sees the package exactly the way a downstream project does.
+
+cmake_minimum_required(VERSION 3.18)
+
+# C and CXX are both enabled because the installed azure_iot_build_rules.cmake,
+# which azure_c_shared_utilityConfig.cmake includes, probes CXX compiler flags.
+project(azure_c_shared_utility_install_export_consumer C CXX)
+
+find_package(azure_c_shared_utility CONFIG REQUIRED)
+
+# CMake itself refuses to generate when an imported target names an include
+# directory that does not exist, but it reports only the first one. Checking
+# every entry of every imported target up front turns that into a single,
+# explicit message naming the offending target and directory.
+function(assert_exported_include_dirs_exist target)
+    if(NOT TARGET ${target})
+        message(FATAL_ERROR "the installed package did not define the imported target '${target}'")
+    endif()
+
+    get_target_property(exported_dirs ${target} INTERFACE_INCLUDE_DIRECTORIES)
+    if(NOT exported_dirs)
+        message(FATAL_ERROR "imported target '${target}' exports no INTERFACE_INCLUDE_DIRECTORIES")
+    endif()
+
+    foreach(exported_dir IN LISTS exported_dirs)
+        if(NOT IS_DIRECTORY "${exported_dir}")
+            message(FATAL_ERROR
+                "imported target '${target}' exports the include directory '${exported_dir}', "
+                "but the install does not create it. INCLUDES DESTINATION and the header "
+                "install rules disagree.")
+        endif()
+    endforeach()
+endfunction()
+
+# An existing-but-wrong include root still fails the consumer at compile time,
+# so assert that the headers are actually reachable through the exported roots
+# with the spelling consumers use.
+function(assert_header_reachable target header)
+    get_target_property(exported_dirs ${target} INTERFACE_INCLUDE_DIRECTORIES)
+
+    set(found FALSE)
+    foreach(exported_dir IN LISTS exported_dirs)
+        if(EXISTS "${exported_dir}/${header}")
+            set(found TRUE)
+            break()
+        endif()
+    endforeach()
+
+    if(NOT found)
+        message(FATAL_ERROR
+            "'${header}' is not reachable through the include directories exported by "
+            "'${target}': ${exported_dirs}")
+    endif()
+endfunction()
+
+assert_exported_include_dirs_exist(aziotsharedutil)
+assert_header_reachable(aziotsharedutil "azure_c_shared_utility/xlogging.h")
+assert_header_reachable(aziotsharedutil "azure_c_shared_utility/strings.h")
+assert_header_reachable(aziotsharedutil "azure_c_shared_utility/azure_base64.h")
+
+# c_logging_v2 and c_logging_v2_core are re-exported through the same export set
+# and so inherit the same INCLUDES DESTINATION, while their headers are installed
+# under a different root. The public xlogging.h includes "c_logging/logger.h",
+# so that root has to be exported too.
+if(TARGET c_logging_v2)
+    assert_exported_include_dirs_exist(c_logging_v2)
+    assert_header_reachable(c_logging_v2 "c_logging/logger.h")
+    assert_header_reachable(aziotsharedutil "c_logging/logger.h")
+endif()
+
+if(TARGET c_logging_v2_core)
+    assert_exported_include_dirs_exist(c_logging_v2_core)
+endif()
+
+# The assertions above describe the contract; the build below proves it, by
+# compiling and linking a translation unit that includes the public headers and
+# calls into the library using nothing but the imported target.
+add_executable(install_export_consumer main.c)
+target_link_libraries(install_export_consumer aziotsharedutil)
+
+add_custom_command(TARGET install_export_consumer POST_BUILD
+    COMMAND install_export_consumer
+    COMMENT "Running the consumer built against the installed package")
+
+# When the project is built as dynamic there is a second exported library target,
+# which carries the same exported include directories and must be equally usable.
+# It is compiled and linked but not executed, so that the test does not depend on
+# the platform's shared library search path.
+if(TARGET aziotsharedutil_dll)
+    assert_exported_include_dirs_exist(aziotsharedutil_dll)
+
+    add_executable(install_export_consumer_dll main.c)
+    target_link_libraries(install_export_consumer_dll aziotsharedutil_dll)
+endif()

--- a/tests/install_export_int/consumer/CMakeLists.txt
+++ b/tests/install_export_int/consumer/CMakeLists.txt
@@ -79,11 +79,23 @@ if(TARGET c_logging_v2_core)
     assert_exported_include_dirs_exist(c_logging_v2_core)
 endif()
 
+# macro_utils_generated.h, which the public headers pull in, defines
+# MU_THE_NTH_ARG with 141 parameters. MSVC's traditional preprocessor caps macro
+# parameters at 127 and rejects the header with C1112, so the conforming
+# preprocessor has to be selected. It is available from VS2019 16.6, and
+# macro_utils.h already refuses to build on anything older than VS2019.
+function(use_conforming_preprocessor target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /Zc:preprocessor)
+    endif()
+endfunction()
+
 # The assertions above describe the contract; the build below proves it, by
 # compiling and linking a translation unit that includes the public headers and
 # calls into the library using nothing but the imported target.
 add_executable(install_export_consumer main.c)
 target_link_libraries(install_export_consumer aziotsharedutil)
+use_conforming_preprocessor(install_export_consumer)
 
 add_custom_command(TARGET install_export_consumer POST_BUILD
     COMMAND "$<TARGET_FILE:install_export_consumer>"
@@ -99,4 +111,5 @@ if(TARGET aziotsharedutil_dll)
 
     add_executable(install_export_consumer_dll main.c)
     target_link_libraries(install_export_consumer_dll aziotsharedutil_dll)
+    use_conforming_preprocessor(install_export_consumer_dll)
 endif()

--- a/tests/install_export_int/consumer/main.c
+++ b/tests/install_export_int/consumer/main.c
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// The point of this file is the include style: a consumer of the installed
+// package includes the public headers as "azure_c_shared_utility/<header>.h",
+// so the include directory exported by the imported target has to be the
+// directory that CONTAINS azure_c_shared_utility/. xlogging.h is included
+// because it transitively pulls in the c-logging headers, which are installed
+// under a different root again.
+#include "azure_c_shared_utility/xlogging.h"
+#include "azure_c_shared_utility/azure_base64.h"
+#include "azure_c_shared_utility/strings.h"
+
+#include <string.h>
+#include <stdio.h>
+
+// No logging call and no allocator hook is exercised here: the package must be
+// usable without any prior initialization, and the point of the test is the
+// include/link contract, not runtime behaviour that the unit tests already cover.
+int main(void)
+{
+    int result = 0;
+
+    STRING_HANDLE encoded = Azure_Base64_Encode_Bytes((const unsigned char*)"azure", 5);
+    if (encoded == NULL)
+    {
+        (void)printf("Azure_Base64_Encode_Bytes failed\n");
+        result = 1;
+    }
+    else
+    {
+        BUFFER_HANDLE decoded = Azure_Base64_Decode(STRING_c_str(encoded));
+        if (decoded == NULL)
+        {
+            (void)printf("Azure_Base64_Decode failed\n");
+            result = 1;
+        }
+        else
+        {
+            if ((BUFFER_length(decoded) != 5) ||
+                (memcmp(BUFFER_u_char(decoded), "azure", 5) != 0))
+            {
+                (void)printf("base64 round trip produced unexpected content\n");
+                result = 1;
+            }
+
+            BUFFER_delete(decoded);
+        }
+
+        STRING_delete(encoded);
+    }
+
+    if (result == 0)
+    {
+        (void)printf("installed package consumed successfully\n");
+    }
+
+    return result;
+}

--- a/tests/install_export_int/install_export_test.cmake
+++ b/tests/install_export_int/install_export_test.cmake
@@ -83,6 +83,9 @@ endif()
 if(BUILD_TYPE)
     list(APPEND configure_command "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}")
 endif()
+if(TOOLCHAIN_FILE)
+    list(APPEND configure_command "-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}")
+endif()
 
 # FORWARDED_OPTIONS carries the enclosing build's feature switches, so that the
 # scratch build produces the same set of exported targets as the build under test.
@@ -93,8 +96,8 @@ endforeach()
 run_step("configuring the project for install" ${configure_command})
 
 set(build_command "${CMAKE_COMMAND}" --build "${library_build_dir}")
-if(BUILD_TYPE)
-    list(APPEND build_command --config "${BUILD_TYPE}")
+if(CONFIG)
+    list(APPEND build_command --config "${CONFIG}")
 endif()
 if(PARALLEL_LEVEL)
     list(APPEND build_command --parallel ${PARALLEL_LEVEL})
@@ -103,8 +106,8 @@ endif()
 run_step("building the project" ${build_command})
 
 set(install_command "${CMAKE_COMMAND}" --install "${library_build_dir}")
-if(BUILD_TYPE)
-    list(APPEND install_command --config "${BUILD_TYPE}")
+if(CONFIG)
+    list(APPEND install_command --config "${CONFIG}")
 endif()
 
 run_step("installing the project" ${install_command})
@@ -137,6 +140,9 @@ endif()
 if(BUILD_TYPE)
     list(APPEND consumer_configure_command "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}")
 endif()
+if(TOOLCHAIN_FILE)
+    list(APPEND consumer_configure_command "-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}")
+endif()
 
 # This is the step that reproduces the reported failure: CMake refuses to
 # generate when an imported target names an include directory that the install
@@ -144,8 +150,8 @@ endif()
 run_step("configuring a consumer against the installed package" ${consumer_configure_command})
 
 set(consumer_build_command "${CMAKE_COMMAND}" --build "${consumer_build_dir}")
-if(BUILD_TYPE)
-    list(APPEND consumer_build_command --config "${BUILD_TYPE}")
+if(CONFIG)
+    list(APPEND consumer_build_command --config "${CONFIG}")
 endif()
 
 # Building the consumer compiles the public headers through the exported include

--- a/tests/install_export_int/install_export_test.cmake
+++ b/tests/install_export_int/install_export_test.cmake
@@ -1,0 +1,155 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# End to end check of the CMake install/export contract. Run with cmake -P.
+#
+# The project is configured, built and installed into a scratch prefix using the
+# PACKAGING configuration (run_unittests=OFF), and a standalone consumer is then
+# configured and built against that prefix with
+# find_package(azure_c_shared_utility CONFIG REQUIRED).
+#
+# Installing from the enclosing test build would not do: the header install rule
+# that populates ${CMAKE_INSTALL_INCLUDEDIR}/azureiot only has files to install
+# when the test tooling is built, so a test-enabled install creates directories
+# that a real packaging install does not, and hides exactly the defect this test
+# exists to catch.
+
+cmake_minimum_required(VERSION 3.18)
+
+foreach(required_variable SOURCE_DIR CONSUMER_DIR WORK_DIR)
+    if(NOT DEFINED ${required_variable})
+        message(FATAL_ERROR "${required_variable} must be defined on the command line")
+    endif()
+endforeach()
+
+set(install_prefix "${WORK_DIR}/prefix")
+set(library_build_dir "${WORK_DIR}/library-build")
+set(consumer_build_dir "${WORK_DIR}/consumer-build")
+
+# Always start from nothing: a stale prefix from an earlier run could supply a
+# directory that the current install rules do not create.
+file(REMOVE_RECURSE "${WORK_DIR}")
+file(MAKE_DIRECTORY "${library_build_dir}" "${consumer_build_dir}")
+
+function(run_step description)
+    execute_process(
+        COMMAND ${ARGN}
+        RESULT_VARIABLE step_result
+        OUTPUT_VARIABLE step_stdout
+        ERROR_VARIABLE step_stderr)
+
+    if(NOT step_result EQUAL 0)
+        string(REPLACE ";" " " printable_command "${ARGN}")
+        message(FATAL_ERROR
+            "${description} failed (exit code ${step_result})\n"
+            "command: ${printable_command}\n"
+            "--- stdout ---\n${step_stdout}\n"
+            "--- stderr ---\n${step_stderr}")
+    endif()
+
+    message(STATUS "${description}: OK")
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Configure, build and install the project the way a package would.
+# ---------------------------------------------------------------------------
+
+set(configure_command
+    "${CMAKE_COMMAND}"
+    -S "${SOURCE_DIR}"
+    -B "${library_build_dir}"
+    "-DCMAKE_INSTALL_PREFIX=${install_prefix}"
+    -Drun_unittests:BOOL=OFF
+    -Drun_int_tests:BOOL=OFF
+    -Drun_e2e_tests:BOOL=OFF
+    -Drun_valgrind:BOOL=OFF
+    -Dskip_samples:BOOL=ON)
+
+if(GENERATOR)
+    list(APPEND configure_command -G "${GENERATOR}")
+endif()
+if(GENERATOR_PLATFORM)
+    list(APPEND configure_command -A "${GENERATOR_PLATFORM}")
+endif()
+if(GENERATOR_TOOLSET)
+    list(APPEND configure_command -T "${GENERATOR_TOOLSET}")
+endif()
+if(C_COMPILER)
+    list(APPEND configure_command "-DCMAKE_C_COMPILER=${C_COMPILER}")
+endif()
+if(CXX_COMPILER)
+    list(APPEND configure_command "-DCMAKE_CXX_COMPILER=${CXX_COMPILER}")
+endif()
+if(BUILD_TYPE)
+    list(APPEND configure_command "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}")
+endif()
+
+# FORWARDED_OPTIONS carries the enclosing build's feature switches, so that the
+# scratch build produces the same set of exported targets as the build under test.
+foreach(forwarded_option IN LISTS FORWARDED_OPTIONS)
+    list(APPEND configure_command "-D${forwarded_option}")
+endforeach()
+
+run_step("configuring the project for install" ${configure_command})
+
+set(build_command "${CMAKE_COMMAND}" --build "${library_build_dir}")
+if(BUILD_TYPE)
+    list(APPEND build_command --config "${BUILD_TYPE}")
+endif()
+if(PARALLEL_LEVEL)
+    list(APPEND build_command --parallel ${PARALLEL_LEVEL})
+endif()
+
+run_step("building the project" ${build_command})
+
+set(install_command "${CMAKE_COMMAND}" --install "${library_build_dir}")
+if(BUILD_TYPE)
+    list(APPEND install_command --config "${BUILD_TYPE}")
+endif()
+
+run_step("installing the project" ${install_command})
+
+# ---------------------------------------------------------------------------
+# Consume the install prefix the way a downstream project does.
+# ---------------------------------------------------------------------------
+
+set(consumer_configure_command
+    "${CMAKE_COMMAND}"
+    -S "${CONSUMER_DIR}"
+    -B "${consumer_build_dir}"
+    "-DCMAKE_PREFIX_PATH=${install_prefix}")
+
+if(GENERATOR)
+    list(APPEND consumer_configure_command -G "${GENERATOR}")
+endif()
+if(GENERATOR_PLATFORM)
+    list(APPEND consumer_configure_command -A "${GENERATOR_PLATFORM}")
+endif()
+if(GENERATOR_TOOLSET)
+    list(APPEND consumer_configure_command -T "${GENERATOR_TOOLSET}")
+endif()
+if(C_COMPILER)
+    list(APPEND consumer_configure_command "-DCMAKE_C_COMPILER=${C_COMPILER}")
+endif()
+if(CXX_COMPILER)
+    list(APPEND consumer_configure_command "-DCMAKE_CXX_COMPILER=${CXX_COMPILER}")
+endif()
+if(BUILD_TYPE)
+    list(APPEND consumer_configure_command "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}")
+endif()
+
+# This is the step that reproduces the reported failure: CMake refuses to
+# generate when an imported target names an include directory that the install
+# did not create.
+run_step("configuring a consumer against the installed package" ${consumer_configure_command})
+
+set(consumer_build_command "${CMAKE_COMMAND}" --build "${consumer_build_dir}")
+if(BUILD_TYPE)
+    list(APPEND consumer_build_command --config "${BUILD_TYPE}")
+endif()
+
+# Building the consumer compiles the public headers through the exported include
+# directories and, via a POST_BUILD command, runs the resulting executable.
+run_step("building and running the consumer" ${consumer_build_command})
+
+message(STATUS "install/export contract verified against ${install_prefix}")


### PR DESCRIPTION
Fixes #621.

## Problem

`install(TARGETS ... INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)` exported a single include directory that the install does not create:

- Public headers install to `${CMAKE_INSTALL_INCLUDEDIR}/azure_c_shared_utility` and are consumed as `#include "azure_c_shared_utility/<h>.h"`, so the exported root has to be `${CMAKE_INSTALL_INCLUDEDIR}`.
- `include/azureiot` is populated only by the micromock/`INSTALL_H_FILES` rule, and both lists are empty unless `run_unittests`/`use_cppunittest` is ON. `install(FILES <empty> DESTINATION d)` does not create `d`.

So a packaging install (`run_unittests=OFF`) yields an export naming a non-existent directory, and every downstream `find_package(azure_c_shared_utility CONFIG)` fails at generate time:

```
Imported target "aziotsharedutil" includes non-existent path
    "<prefix>/include/azureiot"
in its INTERFACE_INCLUDE_DIRECTORIES.
```

A second defect not covered by the report: `c_logging_v2` and `c_logging_v2_core` are re-exported through the same export set and inherit the same `INCLUDES DESTINATION`, so they export only `include/azureiot`, while their headers install to `include/c_logging/v2/c_logging`. Public `xlogging.h` includes `"c_logging/logger.h"`, so consumers still fail to compile even after that directory is created by hand.

Not affected: `add_subdirectory`/`FetchContent` consumers, and prefixes where a sibling component (uamqp/umqtt/uhttp/utpm) is co-installed, since those install into `include/azureiot/<pkg>` and create the directory as a side effect. That is why this is not visible in this repo's own CI.

## Fix

Export the roots the headers are actually installed under:

- `${CMAKE_INSTALL_INCLUDEDIR}` — root for `azure_c_shared_utility/`, `macro_utils/`, `umock_c/`
- `${CMAKE_INSTALL_INCLUDEDIR}/c_logging/v2` — root for `c_logging/logger.h`, added only when the `c_logging_v2` targets are in the export set
- `${CMAKE_INSTALL_INCLUDEDIR}/azureiot` — retained for the sibling components that install there, and now created unconditionally so it is never a dangling exported path

The on-disk header layout is unchanged, so this is **not** a breaking change; the exported metadata is a strict superset of what it was, so no consumer can regress on include resolution. No API, ABI or behavioural change.

Alternative considered and rejected: moving the headers back under `include/azureiot/azure_c_shared_utility`. That is a breaking on-disk change, it has already been flip-flopped twice (#531 -> reverted by #543 -> #563), and azure-iot-sdk-c has since aligned with the current layout.

## Tests

New `tests/install_export_int`, registered whenever tests are enabled and opt-out via `-Drun_install_export_test=OFF`. It:

1. configures, builds and installs the project into a scratch prefix using the **packaging** configuration (`run_unittests=OFF`) — installing from a test-enabled build would create `include/azureiot` as a side effect and hide the defect;
2. configures, builds and runs a standalone consumer that resolves the package with `find_package(azure_c_shared_utility CONFIG REQUIRED)`, links the imported target and includes the public headers;
3. asserts that every exported include directory of every imported target exists, and that `azure_c_shared_utility/xlogging.h`, `strings.h`, `azure_base64.h` and `c_logging/logger.h` are reachable through the exported roots.

When `build_as_dynamic=ON` the `aziotsharedutil_dll` target is checked and linked as well.

Both defects were confirmed to be caught independently:

- without the fix: `imported target 'aziotsharedutil' exports the include directory '.../include/azureiot', but the install does not create it`
- with only the `c_logging/v2` root removed: `'c_logging/logger.h' is not reachable through the include directories exported by 'c_logging_v2'`

## Verification

Debian 12 x86_64, gcc 12.2.0, CMake 3.25.1, OpenSSL 3.0.20, libcurl 7.88.1, uuid 2.38.1.

- Reproduced the reported error before the change, for both static and `build_as_dynamic=ON` installs.
- After the change the consumer configures, compiles, links and runs against both static and shared installs.
- `ctest --output-on-failure` with `-Drun_unittests=ON`: **100% tests passed, 0 tests failed out of 50** (49 pre-existing + the new test, which adds ~5.5s).
- Verified the `-Drun_install_export_test=OFF` opt-out.

Not verified locally: Windows/MSVC, macOS/iOS/ARM64, and the WolfSSL/mbedTLS/BearSSL/SChannel backends. The change is install metadata only and backend/architecture agnostic, but CI coverage on those legs is worth watching.

## Note for downstream packaging

File locations are unchanged, so distro packaging needs no change. vcpkg's `ports/azure-c-shared-utility/fix-install-location.patch` touches the same lines and will fail to apply on the next REF bump past this commit; it should be **deleted** rather than rebased, since re-applying it (headers under `azureiot` while the exported root is `include`) would reintroduce the breakage.
