### PR TITLE
Support PKCS#8 private keys in the SChannel x509 adapter

### DIFF
--- a/adapters/x509_schannel.c
+++ b/adapters/x509_schannel.c
@@ -3,6 +3,8 @@
 
 #include "windows.h"
 
+#include <string.h>
+
 #include "azure_c_shared_utility/gballoc.h"
 #include "azure_c_shared_utility/x509_schannel.h"
 #include "azure_c_shared_utility/xlogging.h"
@@ -30,6 +32,26 @@ typedef struct X509_SCHANNEL_HANDLE_DATA_TAG
     PCCERT_CONTEXT x509certificate_context;
     x509_CERT_TYPE cert_type;
 } X509_SCHANNEL_HANDLE_DATA;
+
+/* The CryptDecodeObjectEx structure types are integers cast to LPCSTR, which MSVC flags as C4306
+   on 64 bit builds. They are materialized once here so that the suppression stays in one place. */
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4306)
+#endif // _MSC_VER
+
+static const LPCSTR pkcs1_rsa_private_key_type = PKCS_RSA_PRIVATE_KEY;
+static const LPCSTR pkcs8_private_key_info_type = PKCS_PRIVATE_KEY_INFO;
+static const LPCSTR pkcs8_encrypted_private_key_info_type = PKCS_ENCRYPTED_PRIVATE_KEY_INFO;
+#if _MSC_VER > 1500
+static const LPCSTR sec1_ecc_private_key_type = X509_ECC_PRIVATE_KEY;
+static const LPCSTR sequence_of_any_type = X509_SEQUENCE_OF_ANY;
+static const LPCSTR octet_string_type = X509_OCTET_STRING;
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
 
 static const char end_certificate_in_pem[] = "-----END CERTIFICATE-----";
 static const size_t end_certificate_in_pem_length = sizeof(end_certificate_in_pem) - 1;
@@ -75,48 +97,230 @@ static unsigned char* convert_cert_to_binary(const char* crypt_value, DWORD cryp
     return result;
 }
 
-static unsigned char* decode_crypt_object(unsigned char* private_key, DWORD key_length, DWORD* blob_size, x509_CERT_TYPE* cert_type)
+/* Decodes a DER encoded private key of a known structure type (PKCS_RSA_PRIVATE_KEY or
+   X509_ECC_PRIVATE_KEY) into the key blob consumed further down by CryptImportKey/NCryptImportKey.
+   The size of the resulting blob is returned in blob_size (when not NULL). */
+static unsigned char* decode_private_key_blob(LPCSTR key_type, const unsigned char* private_key, DWORD key_length, DWORD* blob_size)
 {
     unsigned char* result;
-    
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4306)
-#endif // _MSC_VER
-
-    LPCSTR key_type = PKCS_RSA_PRIVATE_KEY;
-    
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif // _MSC_VER
-
     DWORD private_key_blob_size = 0;
 
     /*Codes_SRS_X509_SCHANNEL_02_004: [ x509_schannel_create shall decode the private key by calling CryptDecodeObjectEx. ]*/
     if (!CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, key_type, private_key, key_length, 0, NULL, NULL, &private_key_blob_size))
     {
-#if _MSC_VER > 1500
-        key_type = X509_ECC_PRIVATE_KEY;
-        if (!CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, key_type, private_key, key_length, 0, NULL, NULL, &private_key_blob_size))
-        {
-            /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
-            LogErrorWinHTTPWithGetLastErrorAsString("Failed to CryptDecodeObjectEx x509 private key");
-            *cert_type = x509_TYPE_UNKNOWN;
-        }
-        else
-        {
-            *cert_type = x509_TYPE_ECC;
-        }
-#else
+        /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+        result = NULL;
+    }
+    else if ((result = (unsigned char*)malloc(private_key_blob_size)) == NULL)
+    {
+        /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+        LogError("unable to malloc for x509 private key blob");
+    }
+    else if (!CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, key_type, private_key, key_length, 0, NULL, result, &private_key_blob_size))
+    {
         /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
         LogErrorWinHTTPWithGetLastErrorAsString("Failed to CryptDecodeObjectEx x509 private key");
-        *cert_type = x509_TYPE_UNKNOWN;
-#endif
+        free(result);
+        result = NULL;
+    }
+    else if (blob_size != NULL)
+    {
+        *blob_size = private_key_blob_size;
+    }
+
+    return result;
+}
+
+#if _MSC_VER > 1500
+/* RFC 5915 says the ECPrivateKey "parameters [0]" field MUST be omitted when the key is carried
+   inside a PKCS#8 PrivateKeyInfo (the curve lives in the outer AlgorithmIdentifier), and that is
+   what OpenSSL emits. Should the ASN.1 decoder reject that shape, rebuild the
+   CRYPT_ECC_PRIVATE_KEY_INFO from the raw ECPrivateKey SEQUENCE instead: only the private key
+   scalar is consumed downstream, the public point is taken from the certificate and the curve is
+   derived from the scalar length. */
+static unsigned char* decode_ecc_private_key_without_curve_oid(const unsigned char* ecc_private_key, DWORD ecc_private_key_length, DWORD* blob_size)
+{
+    unsigned char* result;
+    CRYPT_SEQUENCE_OF_ANY* sequence = NULL;
+    DWORD sequence_size = 0;
+
+    if (!CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, sequence_of_any_type, ecc_private_key, ecc_private_key_length, CRYPT_DECODE_ALLOC_FLAG, NULL, &sequence, &sequence_size))
+    {
+        LogErrorWinHTTPWithGetLastErrorAsString("Failed to CryptDecodeObjectEx the ECC private key sequence");
+        result = NULL;
+    }
+    else if (sequence == NULL)
+    {
+        LogError("CryptDecodeObjectEx returned a NULL ECC private key sequence");
+        result = NULL;
     }
     else
     {
+        /*ECPrivateKey ::= SEQUENCE { version INTEGER, privateKey OCTET STRING, ... }*/
+        CRYPT_DATA_BLOB* private_key_octets = NULL;
+        DWORD private_key_octets_size = 0;
+
+        if (sequence->cValue < 2)
+        {
+            LogError("ECC private key sequence has %u elements, at least 2 are required", (unsigned int)sequence->cValue);
+            result = NULL;
+        }
+        else if (!CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, octet_string_type, sequence->rgValue[1].pbData, sequence->rgValue[1].cbData, CRYPT_DECODE_ALLOC_FLAG, NULL, &private_key_octets, &private_key_octets_size) ||
+            (private_key_octets == NULL))
+        {
+            LogErrorWinHTTPWithGetLastErrorAsString("Failed to CryptDecodeObjectEx the ECC private key scalar");
+            result = NULL;
+        }
+        else
+        {
+            size_t key_info_size = safe_add_size_t(sizeof(CRYPT_ECC_PRIVATE_KEY_INFO), private_key_octets->cbData);
+
+            if ((key_info_size == SIZE_MAX) || (key_info_size > MAXDWORD) ||
+                ((result = (unsigned char*)malloc(key_info_size)) == NULL))
+            {
+                LogError("unable to malloc for the ECC private key info, size:%zu", key_info_size);
+                result = NULL;
+            }
+            else
+            {
+                CRYPT_ECC_PRIVATE_KEY_INFO* key_info = (CRYPT_ECC_PRIVATE_KEY_INFO*)result;
+                memset(key_info, 0, sizeof(CRYPT_ECC_PRIVATE_KEY_INFO));
+                key_info->dwVersion = CRYPT_ECC_PRIVATE_KEY_INFO_v1;
+                key_info->PrivateKey.cbData = private_key_octets->cbData;
+                key_info->PrivateKey.pbData = result + sizeof(CRYPT_ECC_PRIVATE_KEY_INFO);
+                (void)memcpy(key_info->PrivateKey.pbData, private_key_octets->pbData, private_key_octets->cbData);
+
+                if (blob_size != NULL)
+                {
+                    *blob_size = (DWORD)key_info_size;
+                }
+            }
+            (void)LocalFree(private_key_octets);
+        }
+        (void)LocalFree(sequence);
+    }
+
+    return result;
+}
+#endif
+
+/* Handles a PKCS#8 PrivateKeyInfo ("-----BEGIN PRIVATE KEY-----"). The inner, algorithm specific
+   private key is unwrapped and then decoded as PKCS#1 (RSA) or RFC 5915 (ECC).
+   Returns NULL without logging when the input is not a PKCS#8 PrivateKeyInfo at all. */
+static unsigned char* decode_pkcs8_private_key(const unsigned char* private_key, DWORD key_length, DWORD* blob_size, x509_CERT_TYPE* cert_type)
+{
+    unsigned char* result;
+    CRYPT_PRIVATE_KEY_INFO* key_info = NULL;
+    DWORD key_info_size = 0;
+
+    *cert_type = x509_TYPE_UNKNOWN;
+
+    if (!CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, pkcs8_private_key_info_type, private_key, key_length, CRYPT_DECODE_ALLOC_FLAG, NULL, &key_info, &key_info_size))
+    {
+        /*not a PKCS#8 PrivateKeyInfo, it is up to the caller to report this*/
+        result = NULL;
+    }
+    else if (key_info == NULL)
+    {
+        LogError("CryptDecodeObjectEx returned a NULL PKCS#8 private key info");
+        result = NULL;
+    }
+    else
+    {
+        if (key_info->Algorithm.pszObjId == NULL)
+        {
+            LogError("PKCS#8 private key does not carry an algorithm identifier");
+            result = NULL;
+        }
+        else if (strcmp(key_info->Algorithm.pszObjId, szOID_RSA_RSA) == 0)
+        {
+            if ((result = decode_private_key_blob(pkcs1_rsa_private_key_type, key_info->PrivateKey.pbData, key_info->PrivateKey.cbData, blob_size)) == NULL)
+            {
+                /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+                LogErrorWinHTTPWithGetLastErrorAsString("Failed to decode the RSA private key wrapped in the PKCS#8 private key info");
+            }
+            else
+            {
+                *cert_type = x509_TYPE_RSA;
+            }
+        }
+#if _MSC_VER > 1500
+        else if (strcmp(key_info->Algorithm.pszObjId, szOID_ECC_PUBLIC_KEY) == 0)
+        {
+            if ((result = decode_private_key_blob(sec1_ecc_private_key_type, key_info->PrivateKey.pbData, key_info->PrivateKey.cbData, blob_size)) == NULL)
+            {
+                /*the ECPrivateKey carried by a PKCS#8 private key info has no curve OID of its own*/
+                result = decode_ecc_private_key_without_curve_oid(key_info->PrivateKey.pbData, key_info->PrivateKey.cbData, blob_size);
+            }
+            if (result == NULL)
+            {
+                /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+                LogError("Failed to decode the ECC private key wrapped in the PKCS#8 private key info");
+            }
+            else
+            {
+                *cert_type = x509_TYPE_ECC;
+            }
+        }
+#endif
+        else
+        {
+            LogError("Unsupported PKCS#8 private key algorithm \"%s\", only RSA and ECC private keys are supported", key_info->Algorithm.pszObjId);
+            result = NULL;
+        }
+        (void)LocalFree(key_info);
+    }
+
+    return result;
+}
+
+/*returns TRUE when the DER blob is a PKCS#8 EncryptedPrivateKeyInfo ("-----BEGIN ENCRYPTED PRIVATE KEY-----")*/
+static BOOL is_encrypted_pkcs8_private_key(const unsigned char* private_key, DWORD key_length)
+{
+    BOOL result;
+    void* encrypted_key_info = NULL;
+    DWORD encrypted_key_info_size = 0;
+
+    if (CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, pkcs8_encrypted_private_key_info_type, private_key, key_length, CRYPT_DECODE_ALLOC_FLAG, NULL, &encrypted_key_info, &encrypted_key_info_size))
+    {
+        if (encrypted_key_info != NULL)
+        {
+            (void)LocalFree(encrypted_key_info);
+        }
+        result = TRUE;
+    }
+    else
+    {
+        result = FALSE;
+    }
+    return result;
+}
+
+static unsigned char* decode_crypt_object(unsigned char* private_key, DWORD key_length, DWORD* blob_size, x509_CERT_TYPE* cert_type)
+{
+    unsigned char* result;
+    LPCSTR key_type = pkcs1_rsa_private_key_type;
+    DWORD private_key_blob_size = 0;
+
+    *cert_type = x509_TYPE_UNKNOWN;
+
+    /*Codes_SRS_X509_SCHANNEL_02_004: [ x509_schannel_create shall decode the private key by calling CryptDecodeObjectEx. ]*/
+    /*PKCS#1 RSAPrivateKey, "-----BEGIN RSA PRIVATE KEY-----"*/
+    if (CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, key_type, private_key, key_length, 0, NULL, NULL, &private_key_blob_size))
+    {
         *cert_type = x509_TYPE_RSA;
     }
+#if _MSC_VER > 1500
+    else
+    {
+        /*RFC 5915 / SEC1 ECPrivateKey, "-----BEGIN EC PRIVATE KEY-----"*/
+        key_type = sec1_ecc_private_key_type;
+        if (CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, key_type, private_key, key_length, 0, NULL, NULL, &private_key_blob_size))
+        {
+            *cert_type = x509_TYPE_ECC;
+        }
+    }
+#endif
 
     if (*cert_type != x509_TYPE_UNKNOWN)
     {
@@ -143,9 +347,18 @@ static unsigned char* decode_crypt_object(unsigned char* private_key, DWORD key_
             }
         }
     }
-    else
+    /*PKCS#8 PrivateKeyInfo, "-----BEGIN PRIVATE KEY-----", the format emitted by current tooling*/
+    else if ((result = decode_pkcs8_private_key(private_key, key_length, blob_size, cert_type)) == NULL)
     {
-        result = NULL;
+        /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+        if (is_encrypted_pkcs8_private_key(private_key, key_length))
+        {
+            LogError("The x509 private key is an encrypted PKCS#8 private key, which is not supported. Supply an unencrypted PKCS#8, PKCS#1 or EC private key instead");
+        }
+        else
+        {
+            LogErrorWinHTTPWithGetLastErrorAsString("Failed to CryptDecodeObjectEx x509 private key");
+        }
     }
 
     return result;

--- a/adapters/x509_schannel.c
+++ b/adapters/x509_schannel.c
@@ -206,14 +206,16 @@ static unsigned char* decode_ecc_private_key_without_curve_oid(const unsigned ch
 
 /* Handles a PKCS#8 PrivateKeyInfo ("-----BEGIN PRIVATE KEY-----"). The inner, algorithm specific
    private key is unwrapped and then decoded as PKCS#1 (RSA) or RFC 5915 (ECC).
-   Returns NULL without logging when the input is not a PKCS#8 PrivateKeyInfo at all. */
-static unsigned char* decode_pkcs8_private_key(const unsigned char* private_key, DWORD key_length, DWORD* blob_size, x509_CERT_TYPE* cert_type)
+   Returns NULL without logging when the input is not a PKCS#8 PrivateKeyInfo at all; is_pkcs8 tells
+   the caller which of the two happened, so that it does not report an already reported failure. */
+static unsigned char* decode_pkcs8_private_key(const unsigned char* private_key, DWORD key_length, DWORD* blob_size, x509_CERT_TYPE* cert_type, BOOL* is_pkcs8)
 {
     unsigned char* result;
     CRYPT_PRIVATE_KEY_INFO* key_info = NULL;
     DWORD key_info_size = 0;
 
     *cert_type = x509_TYPE_UNKNOWN;
+    *is_pkcs8 = FALSE;
 
     if (!CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, pkcs8_private_key_info_type, private_key, key_length, CRYPT_DECODE_ALLOC_FLAG, NULL, &key_info, &key_info_size))
     {
@@ -222,11 +224,14 @@ static unsigned char* decode_pkcs8_private_key(const unsigned char* private_key,
     }
     else if (key_info == NULL)
     {
+        *is_pkcs8 = TRUE;
         LogError("CryptDecodeObjectEx returned a NULL PKCS#8 private key info");
         result = NULL;
     }
     else
     {
+        *is_pkcs8 = TRUE;
+
         if (key_info->Algorithm.pszObjId == NULL)
         {
             LogError("PKCS#8 private key does not carry an algorithm identifier");
@@ -352,16 +357,24 @@ static unsigned char* decode_crypt_object(unsigned char* private_key, DWORD key_
         }
     }
     /*PKCS#8 PrivateKeyInfo, "-----BEGIN PRIVATE KEY-----", the format emitted by current tooling*/
-    else if ((result = decode_pkcs8_private_key(private_key, key_length, blob_size, cert_type)) == NULL)
+    else
     {
-        /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
-        if (is_encrypted_pkcs8_private_key(private_key, key_length))
+        BOOL is_pkcs8 = FALSE;
+
+        if (((result = decode_pkcs8_private_key(private_key, key_length, blob_size, cert_type, &is_pkcs8)) == NULL) &&
+            !is_pkcs8)
         {
-            LogError("The x509 private key is an encrypted PKCS#8 private key, which is not supported. Supply an unencrypted PKCS#8, PKCS#1 or EC private key instead");
-        }
-        else
-        {
-            LogErrorWinHTTPWithGetLastErrorAsString("Failed to CryptDecodeObjectEx x509 private key");
+            /*the key is in none of the supported encodings; a PKCS#8 private key info that failed to
+              decode has already been reported in detail by decode_pkcs8_private_key*/
+            /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+            if (is_encrypted_pkcs8_private_key(private_key, key_length))
+            {
+                LogError("The x509 private key is an encrypted PKCS#8 private key, which is not supported. Supply an unencrypted PKCS#8, PKCS#1 or EC private key instead");
+            }
+            else
+            {
+                LogErrorWinHTTPWithGetLastErrorAsString("Failed to CryptDecodeObjectEx x509 private key");
+            }
         }
     }
 

--- a/adapters/x509_schannel.c
+++ b/adapters/x509_schannel.c
@@ -280,6 +280,7 @@ static BOOL is_encrypted_pkcs8_private_key(const unsigned char* private_key, DWO
     BOOL result;
     void* encrypted_key_info = NULL;
     DWORD encrypted_key_info_size = 0;
+    DWORD last_error = GetLastError();
 
     if (CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, pkcs8_encrypted_private_key_info_type, private_key, key_length, CRYPT_DECODE_ALLOC_FLAG, NULL, &encrypted_key_info, &encrypted_key_info_size))
     {
@@ -291,6 +292,9 @@ static BOOL is_encrypted_pkcs8_private_key(const unsigned char* private_key, DWO
     }
     else
     {
+        /*the caller reports the error of the decode that actually failed, so this probe must not
+          leave its own error behind*/
+        SetLastError(last_error);
         result = FALSE;
     }
     return result;

--- a/devdoc/x509_schannel.md
+++ b/devdoc/x509_schannel.md
@@ -34,6 +34,23 @@ x509_schannel_create creates a handle wrapping a PCCERT_CONTEXT and other inform
 
 **SRS_X509_SCHANNEL_02_004: [** `x509_schannel_create` shall decode the private key by calling `CryptDecodeObjectEx`. **]**
 
+The private key is accepted in any of the following PEM/DER encodings:
+
+| PEM header | Structure | How it is decoded |
+|---|---|---|
+| `-----BEGIN RSA PRIVATE KEY-----` | PKCS#1 `RSAPrivateKey` | `CryptDecodeObjectEx` with `PKCS_RSA_PRIVATE_KEY` |
+| `-----BEGIN EC PRIVATE KEY-----` | RFC 5915 / SEC1 `ECPrivateKey` | `CryptDecodeObjectEx` with `X509_ECC_PRIVATE_KEY` |
+| `-----BEGIN PRIVATE KEY-----` | PKCS#8 `PrivateKeyInfo` | `CryptDecodeObjectEx` with `PKCS_PRIVATE_KEY_INFO`, then the wrapped key is decoded as PKCS#1 (`szOID_RSA_RSA`) or RFC 5915 (`szOID_ECC_PUBLIC_KEY`) according to the algorithm identifier |
+
+RFC 5915 requires the `parameters [0]` (curve OID) field of `ECPrivateKey` to be omitted when the key is
+carried inside a PKCS#8 `PrivateKeyInfo`. If `X509_ECC_PRIVATE_KEY` rejects that encoding, the private key
+scalar is recovered from the raw `ECPrivateKey` `SEQUENCE` instead (`X509_SEQUENCE_OF_ANY` followed by
+`X509_OCTET_STRING`); the public point comes from the certificate and the curve from the scalar length, so
+the curve OID is not needed.
+
+`-----BEGIN ENCRYPTED PRIVATE KEY-----` (PKCS#8 `EncryptedPrivateKeyInfo`) is not supported. It is detected
+so that the failure is reported with an actionable message rather than as a generic decode error.
+
 **SRS_X509_SCHANNEL_07_001: [** `x509_schannel_create` shall determine whether the certificate is of type RSA or ECC. **]** 
 
 **SRS_X509_SCHANNEL_02_005: [** `x509_schannel_create` shall call `CryptAcquireContext`. **]**

--- a/tests/x509_schannel_ut/x509_schannel_ut.c
+++ b/tests/x509_schannel_ut/x509_schannel_ut.c
@@ -943,8 +943,8 @@ TEST_FUNCTION(x509_schannel_create_with_pkcs8_private_key_of_unsupported_algorit
 
     g_pkcs8_algorithm_oid = "1.3.101.112"; /*id-Ed25519*/
     setup_x509_schannel_create_pkcs8_common_mocks();
-    /*an unusable private key is checked against the encrypted PKCS#8 shape so that the error says why*/
-    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_ENCRYPTED_PRIVATE_KEY_INFO, IGNORED_ARG, IGNORED_ARG, CRYPT_DECODE_ALLOC_FLAG, NULL, IGNORED_ARG, IGNORED_ARG)).SetReturn(FALSE);
+    /*the private key info decoded, so the failure has already been reported in detail and the
+      encrypted PKCS#8 shape is not probed for*/
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));

--- a/tests/x509_schannel_ut/x509_schannel_ut.c
+++ b/tests/x509_schannel_ut/x509_schannel_ut.c
@@ -181,6 +181,9 @@ static TEST_MUTEX_HANDLE g_testByTest;
 static const unsigned char TEST_DATA_INFO[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10 };
 #define TEST_KEY_SIZE       10
 
+/*algorithm OID handed back by the PKCS_PRIVATE_KEY_INFO mock, chosen by each test*/
+static const char* g_pkcs8_algorithm_oid = szOID_RSA_RSA;
+
 
 static CERT_CONTEXT testCertContextToVerify;
 
@@ -253,7 +256,69 @@ static BOOL my_CryptDecodeObjectEx(
     (void)lpszStructType;
     (void)dwCertEncodingType;
 #if _MSC_VER > 1500
-    if (lpszStructType == X509_ECC_PRIVATE_KEY)
+    if (lpszStructType == PKCS_PRIVATE_KEY_INFO)
+    {
+        /*the production code asks for CRYPT_DECODE_ALLOC_FLAG, so hand back a LocalAlloc'd structure*/
+        if (pcbStructInfo != NULL)
+        {
+            *pcbStructInfo = sizeof(CRYPT_PRIVATE_KEY_INFO);
+        }
+        if (pvStructInfo != NULL)
+        {
+            CRYPT_PRIVATE_KEY_INFO* key_info = (CRYPT_PRIVATE_KEY_INFO*)LocalAlloc(LPTR, sizeof(CRYPT_PRIVATE_KEY_INFO));
+            if (key_info == NULL)
+            {
+                return FALSE;
+            }
+            key_info->Version = 0;
+            key_info->Algorithm.pszObjId = (LPSTR)g_pkcs8_algorithm_oid;
+            key_info->PrivateKey.cbData = TEST_KEY_SIZE;
+            key_info->PrivateKey.pbData = (BYTE*)TEST_DATA_INFO;
+            key_info->pAttributes = NULL;
+            *(CRYPT_PRIVATE_KEY_INFO**)pvStructInfo = key_info;
+        }
+    }
+    else if (lpszStructType == X509_SEQUENCE_OF_ANY)
+    {
+        if (pcbStructInfo != NULL)
+        {
+            *pcbStructInfo = sizeof(CRYPT_SEQUENCE_OF_ANY);
+        }
+        if (pvStructInfo != NULL)
+        {
+            CRYPT_SEQUENCE_OF_ANY* sequence = (CRYPT_SEQUENCE_OF_ANY*)LocalAlloc(LPTR, sizeof(CRYPT_SEQUENCE_OF_ANY) + 2 * sizeof(CRYPT_DER_BLOB));
+            if (sequence == NULL)
+            {
+                return FALSE;
+            }
+            sequence->cValue = 2;
+            sequence->rgValue = (PCRYPT_DER_BLOB)(sequence + 1);
+            sequence->rgValue[0].cbData = TEST_KEY_SIZE;
+            sequence->rgValue[0].pbData = (BYTE*)TEST_DATA_INFO;
+            sequence->rgValue[1].cbData = TEST_KEY_SIZE;
+            sequence->rgValue[1].pbData = (BYTE*)TEST_DATA_INFO;
+            *(CRYPT_SEQUENCE_OF_ANY**)pvStructInfo = sequence;
+        }
+    }
+    else if (lpszStructType == X509_OCTET_STRING)
+    {
+        if (pcbStructInfo != NULL)
+        {
+            *pcbStructInfo = sizeof(CRYPT_DATA_BLOB);
+        }
+        if (pvStructInfo != NULL)
+        {
+            CRYPT_DATA_BLOB* octets = (CRYPT_DATA_BLOB*)LocalAlloc(LPTR, sizeof(CRYPT_DATA_BLOB));
+            if (octets == NULL)
+            {
+                return FALSE;
+            }
+            octets->cbData = TEST_KEY_SIZE;
+            octets->pbData = (BYTE*)TEST_DATA_INFO;
+            *(CRYPT_DATA_BLOB**)pvStructInfo = octets;
+        }
+    }
+    else if (lpszStructType == X509_ECC_PRIVATE_KEY)
     {
         if (pcbStructInfo != NULL)
         {
@@ -545,6 +610,7 @@ TEST_SUITE_CLEANUP(TestClassCleanup)
 TEST_FUNCTION_INITIALIZE(initialize)
 {
     umock_c_reset_all_calls();
+    g_pkcs8_algorithm_oid = szOID_RSA_RSA;
     memset(&testCertContextToVerify, 0, sizeof(testCertContextToVerify));
 }
 
@@ -733,6 +799,195 @@ TEST_FUNCTION(x509_schannel_create_ecc_succeeds)
 
     ///cleanup
     x509_schannel_destroy(h);
+}
+#endif
+
+#if _MSC_VER > 1500
+static void setup_x509_schannel_create_pkcs8_common_mocks(void)
+{
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is creating the handle storage space*/
+    STRICT_EXPECTED_CALL(CryptStringToBinaryA("certificate", 0, CRYPT_STRING_ANY, NULL, IGNORED_ARG, NULL, NULL));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is creating the binary storage for the certificate*/
+    STRICT_EXPECTED_CALL(CryptStringToBinaryA("certificate", 0, CRYPT_STRING_ANY, IGNORED_ARG, IGNORED_ARG, NULL, NULL));
+    STRICT_EXPECTED_CALL(CryptStringToBinaryA("private key", 0, CRYPT_STRING_ANY, NULL, IGNORED_ARG, NULL, NULL));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is creating the binary storage for the private key*/
+    STRICT_EXPECTED_CALL(CryptStringToBinaryA("private key", 0, CRYPT_STRING_ANY, IGNORED_ARG, IGNORED_ARG, NULL, NULL));
+    /*a PKCS#8 private key info is neither a PKCS#1 RSA private key nor a bare RFC 5915 ECC private key*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_RSA_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, NULL, IGNORED_ARG)).SetReturn(FALSE);
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, X509_ECC_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, NULL, IGNORED_ARG)).SetReturn(FALSE);
+    /*so it is decoded as a PKCS#8 private key info*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_PRIVATE_KEY_INFO, IGNORED_ARG, IGNORED_ARG, CRYPT_DECODE_ALLOC_FLAG, NULL, IGNORED_ARG, IGNORED_ARG));
+}
+
+/*Tests_SRS_X509_SCHANNEL_02_004: [ x509_schannel_create shall decode the private key by calling CryptDecodeObjectEx. ]*/
+/*Tests_SRS_X509_SCHANNEL_02_009: [ If all the operations above succeed, then x509_schannel_create shall succeeds and return a non-NULL X509_SCHANNEL_HANDLE. ]*/
+TEST_FUNCTION(x509_schannel_create_with_pkcs8_rsa_private_key_succeeds)
+{
+    ///arrange
+    X509_SCHANNEL_HANDLE h;
+
+    g_pkcs8_algorithm_oid = szOID_RSA_RSA;
+    setup_x509_schannel_create_pkcs8_common_mocks();
+    /*the RSA private key wrapped by the PKCS#8 private key info is a PKCS#1 RSA private key*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_RSA_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, NULL, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is allocating space for the decoded private key*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_RSA_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(CryptAcquireContextA(IGNORED_ARG, NULL, MS_ENH_RSA_AES_PROV, PROV_RSA_AES, CRYPT_VERIFYCONTEXT));
+    STRICT_EXPECTED_CALL(CryptImportKey((HCRYPTPROV)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, (HCRYPTKEY)NULL, 0, IGNORED_ARG))
+        .IgnoreArgument_hProv();
+    STRICT_EXPECTED_CALL(CertSetCertificateContextProperty(IGNORED_ARG, CERT_KEY_PROV_HANDLE_PROP_ID, 0, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+
+    ///act
+    h = x509_schannel_create("certificate", "private key");
+
+    ///assert
+    ASSERT_IS_NOT_NULL(h);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///cleanup
+    x509_schannel_destroy(h);
+}
+
+/*Tests_SRS_X509_SCHANNEL_07_001: [ x509_schannel_create shall determine whether the certificate is of type RSA or ECC. ]*/
+TEST_FUNCTION(x509_schannel_create_with_pkcs8_ecc_private_key_succeeds)
+{
+    ///arrange
+    X509_SCHANNEL_HANDLE h;
+
+    g_pkcs8_algorithm_oid = szOID_ECC_PUBLIC_KEY;
+    setup_x509_schannel_create_pkcs8_common_mocks();
+    /*the ECC private key wrapped by the PKCS#8 private key info is an RFC 5915 ECC private key*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, X509_ECC_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, NULL, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is allocating space for the decoded private key*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, X509_ECC_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(NCryptOpenStorageProvider(IGNORED_ARG, MS_KEY_STORAGE_PROVIDER, 0))
+        .IgnoreArgument_pszProviderName();
+    STRICT_EXPECTED_CALL(NCryptImportKey((NCRYPT_PROV_HANDLE)IGNORED_ARG, (NCRYPT_KEY_HANDLE)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NCRYPT_OVERWRITE_KEY_FLAG))
+        .IgnoreArgument_hProvider()
+        .IgnoreArgument_hImportKey();
+    STRICT_EXPECTED_CALL(NCryptFreeObject((HCRYPTKEY)IGNORED_ARG))
+        .IgnoreArgument_hObject();
+    STRICT_EXPECTED_CALL(NCryptFreeObject((HCRYPTKEY)IGNORED_ARG))
+        .IgnoreArgument_hObject();
+    STRICT_EXPECTED_CALL(CertSetCertificateContextProperty(IGNORED_ARG, CERT_KEY_PROV_INFO_PROP_ID, 0, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+
+    ///act
+    h = x509_schannel_create("certificate", "private key");
+
+    ///assert
+    ASSERT_IS_NOT_NULL(h);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///cleanup
+    x509_schannel_destroy(h);
+}
+
+/*Tests_SRS_X509_SCHANNEL_07_001: [ x509_schannel_create shall determine whether the certificate is of type RSA or ECC. ]*/
+TEST_FUNCTION(x509_schannel_create_with_pkcs8_ecc_private_key_without_curve_oid_succeeds)
+{
+    ///arrange
+    X509_SCHANNEL_HANDLE h;
+
+    g_pkcs8_algorithm_oid = szOID_ECC_PUBLIC_KEY;
+    setup_x509_schannel_create_pkcs8_common_mocks();
+    /*RFC 5915 requires the curve OID to be omitted inside a PKCS#8 private key info, so the
+      ECC private key decoder can reject the wrapped key ...*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, X509_ECC_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, NULL, IGNORED_ARG)).SetReturn(FALSE);
+    /*... in which case the private key scalar is recovered from the raw ECPrivateKey sequence*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, X509_SEQUENCE_OF_ANY, IGNORED_ARG, IGNORED_ARG, CRYPT_DECODE_ALLOC_FLAG, NULL, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, X509_OCTET_STRING, IGNORED_ARG, IGNORED_ARG, CRYPT_DECODE_ALLOC_FLAG, NULL, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is allocating the rebuilt ECC private key info*/
+    STRICT_EXPECTED_CALL(CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(NCryptOpenStorageProvider(IGNORED_ARG, MS_KEY_STORAGE_PROVIDER, 0))
+        .IgnoreArgument_pszProviderName();
+    STRICT_EXPECTED_CALL(NCryptImportKey((NCRYPT_PROV_HANDLE)IGNORED_ARG, (NCRYPT_KEY_HANDLE)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NCRYPT_OVERWRITE_KEY_FLAG))
+        .IgnoreArgument_hProvider()
+        .IgnoreArgument_hImportKey();
+    STRICT_EXPECTED_CALL(NCryptFreeObject((HCRYPTKEY)IGNORED_ARG))
+        .IgnoreArgument_hObject();
+    STRICT_EXPECTED_CALL(NCryptFreeObject((HCRYPTKEY)IGNORED_ARG))
+        .IgnoreArgument_hObject();
+    STRICT_EXPECTED_CALL(CertSetCertificateContextProperty(IGNORED_ARG, CERT_KEY_PROV_INFO_PROP_ID, 0, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+
+    ///act
+    h = x509_schannel_create("certificate", "private key");
+
+    ///assert
+    ASSERT_IS_NOT_NULL(h);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///cleanup
+    x509_schannel_destroy(h);
+}
+
+/*Tests_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+TEST_FUNCTION(x509_schannel_create_with_pkcs8_private_key_of_unsupported_algorithm_fails)
+{
+    ///arrange
+    X509_SCHANNEL_HANDLE h;
+
+    g_pkcs8_algorithm_oid = "1.3.101.112"; /*id-Ed25519*/
+    setup_x509_schannel_create_pkcs8_common_mocks();
+    /*an unusable private key is checked against the encrypted PKCS#8 shape so that the error says why*/
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_ENCRYPTED_PRIVATE_KEY_INFO, IGNORED_ARG, IGNORED_ARG, CRYPT_DECODE_ALLOC_FLAG, NULL, IGNORED_ARG, IGNORED_ARG)).SetReturn(FALSE);
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+
+    ///act
+    h = x509_schannel_create("certificate", "private key");
+
+    ///assert
+    ASSERT_IS_NULL(h);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///cleanup
+}
+
+/*Tests_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+TEST_FUNCTION(x509_schannel_create_with_a_private_key_that_cannot_be_decoded_fails)
+{
+    ///arrange
+    X509_SCHANNEL_HANDLE h;
+
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is creating the handle storage space*/
+    STRICT_EXPECTED_CALL(CryptStringToBinaryA("certificate", 0, CRYPT_STRING_ANY, NULL, IGNORED_ARG, NULL, NULL));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(CryptStringToBinaryA("certificate", 0, CRYPT_STRING_ANY, IGNORED_ARG, IGNORED_ARG, NULL, NULL));
+    STRICT_EXPECTED_CALL(CryptStringToBinaryA("private key", 0, CRYPT_STRING_ANY, NULL, IGNORED_ARG, NULL, NULL));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(CryptStringToBinaryA("private key", 0, CRYPT_STRING_ANY, IGNORED_ARG, IGNORED_ARG, NULL, NULL));
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_RSA_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, NULL, IGNORED_ARG)).SetReturn(FALSE);
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, X509_ECC_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, NULL, IGNORED_ARG)).SetReturn(FALSE);
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_PRIVATE_KEY_INFO, IGNORED_ARG, IGNORED_ARG, CRYPT_DECODE_ALLOC_FLAG, NULL, IGNORED_ARG, IGNORED_ARG)).SetReturn(FALSE);
+    STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_ENCRYPTED_PRIVATE_KEY_INFO, IGNORED_ARG, IGNORED_ARG, CRYPT_DECODE_ALLOC_FLAG, NULL, IGNORED_ARG, IGNORED_ARG)).SetReturn(FALSE);
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
+
+    ///act
+    h = x509_schannel_create("certificate", "private key");
+
+    ///assert
+    ASSERT_IS_NULL(h);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///cleanup
 }
 #endif
 


### PR DESCRIPTION
Fixes #649.

`decode_crypt_object()` in `adapters/x509_schannel.c` only asked `CryptDecodeObjectEx` for `PKCS_RSA_PRIVATE_KEY` (PKCS#1) and `X509_ECC_PRIVATE_KEY` (RFC 5915/SEC1). A PKCS#8 `PrivateKeyInfo` is `SEQUENCE{INTEGER, SEQUENCE{OID, params}, OCTET STRING}`, so the PKCS#1 template finds `SEQUENCE` where it wants `INTEGER` and the SEC1 template finds `SEQUENCE` where it wants `OCTET STRING`. Both fail with `CRYPT_E_ASN1_BADTAG` and `x509_schannel_create()` returns NULL, so the connection never opens.

PKCS#8 (`-----BEGIN PRIVATE KEY-----`) is what OpenSSL 3.x `genpkey`, most CAs and most cloud key exports emit, so those keys cannot be used on Windows at all. The OpenSSL adapter is unaffected — `x509_openssl.c` uses `PEM_read_bio_PrivateKey()`, which accepts PKCS#1, PKCS#8 and SEC1 transparently.

Note the library already *emits* PKCS#8: `adapters/csr_gen_schannel.c` encodes with `PKCS_PRIVATE_KEY_INFO`. It could not read back what it writes.

## Change

- Try `PKCS_PRIVATE_KEY_INFO` when the two existing attempts fail, then decode the wrapped key as `PKCS_RSA_PRIVATE_KEY` or `X509_ECC_PRIVATE_KEY` according to `Algorithm.pszObjId` (`szOID_RSA_RSA` / `szOID_ECC_PUBLIC_KEY`). Any other algorithm is reported by OID.
- RFC 5915 §3 requires the `ECPrivateKey` `parameters [0]` curve OID to be omitted inside a PKCS#8 container, and OpenSSL does omit it. If `X509_ECC_PRIVATE_KEY` rejects that encoding, recover the private scalar with `X509_SEQUENCE_OF_ANY` then `X509_OCTET_STRING` and rebuild `CRYPT_ECC_PRIVATE_KEY_INFO` with `szCurveOid` NULL. This is safe because `set_ecc_certificate_info()` reads only `PrivateKey` — it takes the public point from the certificate and the curve from the scalar length.
- Encrypted PKCS#8 remains unsupported, but is now detected with a `PKCS_ENCRYPTED_PRIVATE_KEY_INFO` probe and reported with an actionable message instead of a generic ASN.1 error. There is no passphrase parameter anywhere in the public API, so accepting it would be a new feature rather than a fix.
- Factored the repeated size-probe/alloc/decode triple into a helper, and materialised the `CryptDecodeObjectEx` structure-type constants once inside a single `C4306` suppression instead of an ad-hoc one.

The existing PKCS#1 and SEC1 paths are unchanged: the same calls, in the same order, with the same arguments. The new code runs only when both already fail. The ordering is unambiguous — a PKCS#1 blob and a SEC1 blob are themselves rejected as `PKCS_PRIVATE_KEY_INFO`, so no input can be claimed by the wrong branch.

`devdoc/x509_schannel.md` documents the accepted encodings; five tests were added to `tests/x509_schannel_ut`.

### Why not CNG

`NCryptImportKey` with `NCRYPT_PKCS8_PRIVATE_KEY_BLOB` would let Windows parse the whole container and would sidestep the curve-OID question, but it is Windows 8 / Server 2012 and later, and it would move the RSA path off `CryptAcquireContext`/`CryptImportKey`/`CERT_KEY_PROV_HANDLE_PROP_ID` onto a persisted CNG key for every existing Windows consumer. This change raises no OS floor: `PKCS_PRIVATE_KEY_INFO`, `PKCS_ENCRYPTED_PRIVATE_KEY_INFO`, `X509_SEQUENCE_OF_ANY` and `X509_OCTET_STRING` all predate Vista, and the ECC paths keep the file's existing `_MSC_VER > 1500` guard.

## Impact

No API/ABI change: no header changes, no new exported symbols, all new functions `static`. Strictly additive — inputs that succeed today take the same path, inputs that fail today either now succeed or fail with a better message, and failure is still a NULL handle. No matching change is needed in azure-iot-sdk-c, azure-uamqp-c, azure-umqtt-c, azure-uhttp-c or azure-utpm-c; they consume this repo as a submodule and carry no copy of this code.

## Verification

- Linux build clean; `ctest` 49/49 passed, identical before and after. `x509_schannel.c` is not compiled on Linux, so this is a regression guard only.
- `x509_schannel.c` cross-compiles clean against the Win32 headers (mingw-w64 12, `-Wall -Wextra`, zero warnings) for x86_64 and i686, with and without `_MSC_VER` defined so the ECC and PKCS#8-ECC branches are covered.
- Format detection was validated against real keys generated with OpenSSL 3.0.20 — PKCS#1 RSA, PKCS#8 RSA, encrypted PKCS#8 RSA, SEC1 EC P-256/P-384, PKCS#8 EC P-256/P-384, Ed25519, and a certificate as a negative control. All nine are classified correctly, including the PKCS#8 EC keys via the curve-OID fallback, whose recovered scalars are 32 and 48 bytes — exactly the `ECC_256_MAGIC_NUMBER` and `ECC_384_MAGIC_NUMBER` that `set_ecc_certificate_info()` keys off. Driven by the old logic the same check fails PKCS#8 RSA and PKCS#8 EC, reproducing the reported defect.

**Not verified, and worth a reviewer's attention:** `tests/CMakeLists.txt` gates `x509_schannel_ut` and `x509_schannel_int` behind `if(WIN32)`, so the new tests were not compiled or run here and there was no MSVC build and no TLS handshake. Their `STRICT_EXPECTED_CALL` sequences were traced against the production flow call-for-call and independently re-reviewed, but they need a Windows CI run to confirm. In particular, whether Microsoft's `X509_ECC_PRIVATE_KEY` template accepts the parameters-less inner `ECPrivateKey` decides which of the two ECC branches is live; the other becomes dead code. One run against an OpenSSL-generated PKCS#8 P-256 key settles it.
