### PR TITLE
test: keep socketio_int owning its port, and scope the valgrind suppressions

### DIFF
--- a/tests/socketio_int/socketio_int.c
+++ b/tests/socketio_int/socketio_int.c
@@ -72,50 +72,34 @@ static void on_io_error(void* context)
     (void)context;
 }
 
-// Binds an ephemeral loopback port and immediately releases it. Connecting to the returned
-// port is then refused until the test brings a listener up on it.
-static int reserve_unused_port(void)
+// Binds an ephemeral loopback port and keeps the socket bound, so the port stays owned by
+// this test for its whole lifetime and no other process can take it. The socket is not
+// listening yet, so connecting to it is refused until begin_listening is called on it.
+static TEST_SOCKET reserve_port(int* port)
 {
     struct sockaddr_in address;
     test_socklen_t address_length = sizeof(address);
-    int result;
-    TEST_SOCKET probe = socket(AF_INET, SOCK_STREAM, 0);
+    TEST_SOCKET reserved = socket(AF_INET, SOCK_STREAM, 0);
 
-    ASSERT_IS_TRUE(probe != TEST_INVALID_SOCKET, "could not create the probe socket");
+    ASSERT_IS_TRUE(reserved != TEST_INVALID_SOCKET, "could not create the reservation socket");
 
     (void)memset(&address, 0, sizeof(address));
     address.sin_family = AF_INET;
     address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     address.sin_port = 0;
 
-    ASSERT_ARE_EQUAL(int, 0, bind(probe, (struct sockaddr*)&address, sizeof(address)), "could not bind the probe socket");
-    ASSERT_ARE_EQUAL(int, 0, getsockname(probe, (struct sockaddr*)&address, &address_length), "could not read the probe socket port");
+    ASSERT_ARE_EQUAL(int, 0, bind(reserved, (struct sockaddr*)&address, sizeof(address)), "could not bind the reservation socket");
+    ASSERT_ARE_EQUAL(int, 0, getsockname(reserved, (struct sockaddr*)&address, &address_length), "could not read the reserved port");
 
-    result = (int)ntohs(address.sin_port);
-    test_close_socket(probe);
+    *port = (int)ntohs(address.sin_port);
 
-    return result;
+    return reserved;
 }
 
-static TEST_SOCKET start_listener(int port)
+// Turns the reserved socket into a listening one. The port never changes hands.
+static void begin_listening(TEST_SOCKET reserved)
 {
-    struct sockaddr_in address;
-    int reuse = 1;
-    TEST_SOCKET listener = socket(AF_INET, SOCK_STREAM, 0);
-
-    ASSERT_IS_TRUE(listener != TEST_INVALID_SOCKET, "could not create the listener socket");
-
-    (void)setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, (const char*)&reuse, sizeof(reuse));
-
-    (void)memset(&address, 0, sizeof(address));
-    address.sin_family = AF_INET;
-    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    address.sin_port = htons((unsigned short)port);
-
-    ASSERT_ARE_EQUAL(int, 0, bind(listener, (struct sockaddr*)&address, sizeof(address)), "could not bind the listener socket");
-    ASSERT_ARE_EQUAL(int, 0, listen(listener, 4), "could not listen on the listener socket");
-
-    return listener;
+    ASSERT_ARE_EQUAL(int, 0, listen(reserved, 4), "could not listen on the reserved socket");
 }
 
 // Opens the io and drives it to a decision. Returns true only when the open completed
@@ -196,7 +180,9 @@ TEST_FUNCTION(socketio_open_succeeds_when_retried_after_a_connect_failure)
 {
     ///arrange
     SOCKETIO_CONFIG config;
-    int port = reserve_unused_port();
+    int port;
+
+    g_listener = reserve_port(&port);
 
     config.hostname = TEST_HOSTNAME;
     config.port = port;
@@ -207,7 +193,7 @@ TEST_FUNCTION(socketio_open_succeeds_when_retried_after_a_connect_failure)
 
     ASSERT_IS_FALSE(open_completes_successfully(g_io), "the open must fail while nothing is listening");
 
-    g_listener = start_listener(port);
+    begin_listening(g_listener);
 
     ///act
     ///assert
@@ -219,7 +205,9 @@ TEST_FUNCTION(socketio_open_succeeds_when_retried_after_a_connect_failure_and_a_
 {
     ///arrange
     SOCKETIO_CONFIG config;
-    int port = reserve_unused_port();
+    int port;
+
+    g_listener = reserve_port(&port);
 
     config.hostname = TEST_HOSTNAME;
     config.port = port;
@@ -231,7 +219,7 @@ TEST_FUNCTION(socketio_open_succeeds_when_retried_after_a_connect_failure_and_a_
     ASSERT_IS_FALSE(open_completes_successfully(g_io), "the open must fail while nothing is listening");
     ASSERT_ARE_EQUAL(int, 0, xio_close(g_io, NULL, NULL), "xio_close failed after the failed open");
 
-    g_listener = start_listener(port);
+    begin_listening(g_listener);
 
     ///act
     ///assert
@@ -244,9 +232,10 @@ TEST_FUNCTION(socketio_open_succeeds_after_a_successful_open_and_close)
 {
     ///arrange
     SOCKETIO_CONFIG config;
-    int port = reserve_unused_port();
+    int port;
 
-    g_listener = start_listener(port);
+    g_listener = reserve_port(&port);
+    begin_listening(g_listener);
 
     config.hostname = TEST_HOSTNAME;
     config.port = port;

--- a/tests/valgrind_suppressions.supp
+++ b/tests/valgrind_suppressions.supp
@@ -58,20 +58,24 @@
    fun:(below main)
 }
 # The dynamic loader runs library destructors after the process is already tearing
-# down, and some of them (p11-kit, pulled in through OpenSSL) destroy mutexes that
-# valgrind no longer recognises. Version-independent form of the entries above.
+# down, and p11-kit (pulled in through OpenSSL) destroys mutexes that valgrind no
+# longer recognises. Version-independent form of the entries above: the library and
+# vgpreload paths are wildcarded, but the p11-kit frame is still required so this
+# does not hide genuine mutex-destruction defects in other libraries.
 {
-   Mutex destroy during loader teardown (helgrind)
+   Mutex destroy by p11-kit during loader teardown (helgrind)
    Helgrind:Misc
    obj:*vgpreload_helgrind*
+   obj:*libp11-kit*
    ...
    fun:_dl_fini
    ...
 }
 {
-   Mutex destroy during loader teardown (drd)
+   Mutex destroy by p11-kit during loader teardown (drd)
    drd:MutexErr
    fun:pthread_mutex_destroy*
+   obj:*libp11-kit*
    ...
    fun:_dl_fini
    ...

--- a/tests/valgrind_suppressions.supp
+++ b/tests/valgrind_suppressions.supp
@@ -1,71 +1,13 @@
-{
-   Suppress pthread destroy with invalid arg
-   Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
-   obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
-   fun:_dl_fini
-   fun:__run_exit_handlers
-   fun:exit
-   fun:(below main)
-}
-{
-   <insert_a_suppression_name_here>
-   Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
-   fun:_dl_fini
-   fun:__run_exit_handlers
-   fun:exit
-   fun:(below main)
-}
-{
-   Suppress "is not a mutex"
-   drd:MutexErr
-   fun:pthread_mutex_destroy
-   obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
-   fun:_dl_fini
-   fun:__run_exit_handlers
-   fun:exit
-   fun:(below main)
-}
-{
-   Suppress "is not a mutex"
-   drd:MutexErr
-   fun:pthread_mutex_destroy
-   fun:_dl_fini
-   fun:__run_exit_handlers
-   fun:exit
-   fun:(below main)
-}
-{
-   <insert_a_suppression_name_here>
-   drd:MutexErr
-   fun:pthread_mutex_destroy_intercept
-   fun:pthread_mutex_destroy
-   obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
-   fun:_dl_fini
-   fun:__run_exit_handlers
-   fun:exit
-   fun:(below main)
-}
-{
-   <insert_a_suppression_name_here>
-   drd:MutexErr
-   fun:pthread_mutex_destroy_intercept
-   fun:pthread_mutex_destroy
-   fun:_dl_fini
-   fun:__run_exit_handlers
-   fun:exit
-   fun:(below main)
-}
-# The dynamic loader runs library destructors after the process is already tearing
-# down, and p11-kit (pulled in through OpenSSL) destroys mutexes that valgrind no
-# longer recognises. Version-independent form of the entries above: the library and
-# vgpreload paths are wildcarded, but the p11-kit frame is still required so this
-# does not hide genuine mutex-destruction defects in other libraries.
+# The dynamic loader runs library destructors after the process has already begun tearing
+# down, and p11-kit (pulled in through OpenSSL) destroys mutexes that valgrind no longer
+# recognises. Only p11-kit teardown is suppressed, so genuine mutex-destruction defects in
+# other libraries are still reported. The library, vgpreload and intermediate frames are
+# wildcarded so this keeps matching as those paths and glibc's internals change.
 {
    Mutex destroy by p11-kit during loader teardown (helgrind)
    Helgrind:Misc
    obj:*vgpreload_helgrind*
+   ...
    obj:*libp11-kit*
    ...
    fun:_dl_fini
@@ -75,6 +17,7 @@
    Mutex destroy by p11-kit during loader teardown (drd)
    drd:MutexErr
    fun:pthread_mutex_destroy*
+   ...
    obj:*libp11-kit*
    ...
    fun:_dl_fini


### PR DESCRIPTION
Follow-up to #688, addressing two review comments there.

**1. Port ownership (`tests/socketio_int/socketio_int.c`)**

The helper bound an ephemeral port, read it, then closed the socket before the test used it. Between that close and the `listen`, another process could take the port — making the open that must fail succeed, or making the later bind fail.

The socket now stays bound for the whole test and is switched to listening in place, so the port never leaves the test's ownership. A bound, non-listening socket still refuses connections, so the failed-open phase is unchanged.

**2. Suppression scope (`tests/valgrind_suppressions.supp`)**

The loader-teardown entries matched any `Helgrind:Misc` under `_dl_fini` and any `pthread_mutex_destroy*` under `_dl_fini`, so they could hide genuine mutex-destruction defects in other libraries. They now also require a `obj:*libp11-kit*` frame; paths stay wildcarded for version independence.

**Verification (local, Linux, gcc 12)**
- `socketio_int` 3/3, run repeatedly.
- Full `ctest` 46/46.
- helgrind and drd: 0 errors, suppression file parses with no errors.
- Still gates the regression: with `adapters/` and `src/` reverted to the commit before the socketio open/cleanup changes, `socketio_open_succeeds_when_retried_after_a_connect_failure` fails.

**Caveat:** the p11-kit teardown noise does not occur in the local environment (`suppressed: 0 from 0`), so local runs confirm the narrowed suppressions parse and do not break anything, but cannot confirm they still match the stack seen on the CI agents. The ubuntu2404 helgrind/drd jobs are the check for that — if they report the p11-kit teardown again, the p11-kit frame needs loosening.