### PR TITLE
Export required MSVC preprocessor options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,16 @@ endif()
 add_library(aziotsharedutil ${source_c_files} ${source_h_files} ${aziotsharedutil_md_files})
 setTargetBuildProperties(aziotsharedutil)
 
+# Public headers require MSVC's conforming preprocessor. Suppress C5105 as
+# well because Windows SDK headers can emit it when that preprocessor is used.
+set(msvc_preprocessor_interface_options
+    $<$<COMPILE_LANG_AND_ID:C,MSVC>:/Zc:preprocessor>
+    $<$<COMPILE_LANG_AND_ID:C,MSVC>:/wd5105>
+    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:preprocessor>
+    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/wd5105>
+)
+target_compile_options(aziotsharedutil INTERFACE ${msvc_preprocessor_interface_options})
+
 target_include_directories(aziotsharedutil PUBLIC $<BUILD_INTERFACE:${SHARED_UTIL_INC_FOLDER}>)
 target_link_libraries(aziotsharedutil PUBLIC macro_utils_c)
 # c_logging_v2 and umock_c provide headers needed by aziotsharedutil sources.
@@ -609,6 +619,7 @@ if(${build_as_dynamic})
         VERSION ${C_SHARED_VERSION}
         SOVERSION ${C_SHARED_VERSION_MAJOR}
     )
+    target_compile_options(aziotsharedutil_dll INTERFACE ${msvc_preprocessor_interface_options})
 endif()
 
 set(aziotsharedutil_target_libs)

--- a/tests/install_export_int/consumer/CMakeLists.txt
+++ b/tests/install_export_int/consumer/CMakeLists.txt
@@ -85,6 +85,9 @@ endif()
 add_executable(install_export_consumer main.c)
 target_link_libraries(install_export_consumer aziotsharedutil)
 
+add_executable(install_export_consumer_cpp main.cpp)
+target_link_libraries(install_export_consumer_cpp aziotsharedutil)
+
 add_custom_command(TARGET install_export_consumer POST_BUILD
     COMMAND "$<TARGET_FILE:install_export_consumer>"
     WORKING_DIRECTORY "$<TARGET_FILE_DIR:install_export_consumer>"
@@ -99,4 +102,7 @@ if(TARGET aziotsharedutil_dll)
 
     add_executable(install_export_consumer_dll main.c)
     target_link_libraries(install_export_consumer_dll aziotsharedutil_dll)
+
+    add_executable(install_export_consumer_dll_cpp main.cpp)
+    target_link_libraries(install_export_consumer_dll_cpp aziotsharedutil_dll)
 endif()

--- a/tests/install_export_int/consumer/CMakeLists.txt
+++ b/tests/install_export_int/consumer/CMakeLists.txt
@@ -79,23 +79,11 @@ if(TARGET c_logging_v2_core)
     assert_exported_include_dirs_exist(c_logging_v2_core)
 endif()
 
-# macro_utils_generated.h, which the public headers pull in, defines
-# MU_THE_NTH_ARG with 141 parameters. MSVC's traditional preprocessor caps macro
-# parameters at 127 and rejects the header with C1112, so the conforming
-# preprocessor has to be selected. It is available from VS2019 16.6, and
-# macro_utils.h already refuses to build on anything older than VS2019.
-function(use_conforming_preprocessor target)
-    if(MSVC)
-        target_compile_options(${target} PRIVATE /Zc:preprocessor)
-    endif()
-endfunction()
-
 # The assertions above describe the contract; the build below proves it, by
 # compiling and linking a translation unit that includes the public headers and
 # calls into the library using nothing but the imported target.
 add_executable(install_export_consumer main.c)
 target_link_libraries(install_export_consumer aziotsharedutil)
-use_conforming_preprocessor(install_export_consumer)
 
 add_custom_command(TARGET install_export_consumer POST_BUILD
     COMMAND "$<TARGET_FILE:install_export_consumer>"
@@ -111,5 +99,4 @@ if(TARGET aziotsharedutil_dll)
 
     add_executable(install_export_consumer_dll main.c)
     target_link_libraries(install_export_consumer_dll aziotsharedutil_dll)
-    use_conforming_preprocessor(install_export_consumer_dll)
 endif()

--- a/tests/install_export_int/consumer/main.cpp
+++ b/tests/install_export_int/consumer/main.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Compiling this public header as C++ verifies the imported target's CXX usage
+// requirements independently from the C consumer in main.c.
+#include "azure_c_shared_utility/xlogging.h"
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
## Problem

An installed `azure-c-shared-utility` package is not self-sufficient for MSVC consumers. Including `azure_c_shared_utility/xlogging.h` transitively includes `macro_utils_generated.h`, where `MU_THE_NTH_ARG` has 141 parameters. MSVC's traditional preprocessor supports at most 127 and fails with:

```text
error C1112: compiler limit: '141' too many macro parameters, only '127' allowed
```

The in-tree build does not expose this because `deps/c-build-tools` globally adds `/Zc:preprocessor /wd5105` to `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` on supported MSVC versions. Those directory-level build flags are not part of the installed target's usage requirements, so a separate project using `find_package(azure_c_shared_utility CONFIG)` receives neither option.

`/wd5105` needs to travel with `/Zc:preprocessor`: affected Windows SDK headers emit C5105 under the conforming preprocessor, which would otherwise break downstream projects that compile with warnings as errors.

## Fix

Export `/Zc:preprocessor` and `/wd5105` through `INTERFACE_COMPILE_OPTIONS` on both `aziotsharedutil` and `aziotsharedutil_dll`. Generator expressions restrict the options to MSVC C and C++ compilation.

Remove the consumer test's private `/Zc:preprocessor` workaround. The standalone installed-package consumer now succeeds only when the imported library target supplies its required preprocessor options.

This changes MSVC package usage metadata only. There is no API or ABI change, and non-MSVC consumers receive no new options.

## Verification

Windows x64 with Visual Studio 2022, MSVC 19.44.35228, Windows SDK 10.0.26100.0, and CMake 4.0.3.

- Simulated the pre-fix installed target by clearing only its `INTERFACE_COMPILE_OPTIONS` in a separate consumer project. Compilation reproduced C1112 at `macro_utils_generated.h` with 141 macro parameters versus the 127-parameter limit.
- Ran `ctest -C Debug --output-on-failure -R install_export_int` from `cmake/shared-util_x64` with `build_as_dynamic=OFF`: 1/1 passed.
- Reconfigured with `build_as_dynamic=ON` and reran the same test, exercising both static and DLL imported targets: 1/1 passed.
- Confirmed the installed `azure_c_shared_utilityTargets.cmake` contains the language/compiler-guarded interface options for both exported targets.
