### PR TITLE
Import RSA x509 private keys through CNG so Schannel can do TLS 1.2 client authentication

### DIFF
--- a/adapters/tlsio_schannel.c
+++ b/adapters/tlsio_schannel.c
@@ -300,6 +300,8 @@ static void send_client_hello(TLS_IO_INSTANCE* tls_io_instance)
     SECURITY_STATUS status;
     SCHANNEL_CRED auth_data;
     PCCERT_CONTEXT certContext;
+    /* cMappers/aphMappers are not set below, so the whole structure has to start out zeroed */
+    (void)memset(&auth_data, 0, sizeof(auth_data));
     auth_data.dwVersion = SCHANNEL_CRED_VERSION;
     if (tls_io_instance->x509_schannel_handle != NULL)
     {

--- a/adapters/x509_schannel.c
+++ b/adapters/x509_schannel.c
@@ -157,6 +157,39 @@ static unsigned char* decode_crypt_object(unsigned char* private_key, DWORD key_
 }
 
 #if _MSC_VER > 1500
+/* Names the key container after the certificate thumbprint. Two clients using different
+   certificates therefore never share a container, and a process killed before
+   x509_schannel_destroy runs leaves at most one container per certificate: the next run with that
+   same certificate reuses it instead of orphaning another one. */
+static int build_key_container_name(X509_SCHANNEL_HANDLE_DATA* x509_handle)
+{
+    int result;
+    BYTE thumbprint[20];
+    DWORD thumbprint_size = sizeof(thumbprint);
+
+    if (!CertGetCertificateContextProperty(x509_handle->x509certificate_context, CERT_SHA1_HASH_PROP_ID, thumbprint, &thumbprint_size))
+    {
+        /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+        LogErrorWinHTTPWithGetLastErrorAsString("unable to CertGetCertificateContextProperty for the certificate thumbprint");
+        result = MU_FAILURE;
+    }
+    else
+    {
+        DWORD i;
+        size_t offset;
+
+        (void)wcscpy_s(x509_handle->key_name, KEY_NAME_MAX_LENGTH, KEY_NAME L"-");
+        offset = wcslen(x509_handle->key_name);
+        for (i = 0; i < thumbprint_size; i++)
+        {
+            (void)swprintf_s(x509_handle->key_name + offset, KEY_NAME_MAX_LENGTH - offset, L"%02X", thumbprint[i]);
+            offset += 2;
+        }
+        result = 0;
+    }
+    return result;
+}
+
 /* Imports the decoded private key blob into a CNG key storage provider and links it to the
    certificate context. Schannel can only use a client certificate for TLS 1.2 client
    authentication when the private key is reachable this way: a key published as a legacy
@@ -166,20 +199,14 @@ static unsigned char* decode_crypt_object(unsigned char* private_key, DWORD key_
 static int import_private_key_to_ncrypt(X509_SCHANNEL_HANDLE_DATA* x509_handle, LPCWSTR key_blob_type, unsigned char* key_blob, DWORD key_blob_size)
 {
     int result;
-    static volatile LONG key_name_suffix = 0;
     SECURITY_STATUS status;
 
-    /* Every handle gets its own key container, otherwise two clients using different certificates
-       would overwrite each other's private key. */
-    if (swprintf_s(x509_handle->key_name, KEY_NAME_MAX_LENGTH, KEY_NAME L"-%lu-%ld",
-        (unsigned long)GetCurrentProcessId(), InterlockedIncrement(&key_name_suffix)) < 0)
+    /*Codes_SRS_X509_SCHANNEL_02_015: [ x509_schannel_create shall name the key container after the certificate thumbprint. ]*/
+    if (build_key_container_name(x509_handle) != 0)
     {
-        /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
-        LogError("unable to build the private key container name");
         result = MU_FAILURE;
     }
-    /* Codes_SRS_X509_SCHANNEL_02_005: [ x509_schannel_create shall call CryptAcquireContext. ] */
-    /* NOTE: As no WinCrypt key storage provider supports ECC keys, NCrypt is used instead */
+    /*Codes_SRS_X509_SCHANNEL_02_005: [ When compiled with _MSC_VER > 1500, x509_schannel_create shall open a CNG key storage provider by calling NCryptOpenStorageProvider, otherwise it shall call CryptAcquireContext. ]*/
     else if ((status = NCryptOpenStorageProvider(&x509_handle->hProv, MS_KEY_STORAGE_PROVIDER, 0)) != ERROR_SUCCESS)
     {
         /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
@@ -204,7 +231,7 @@ static int import_private_key_to_ncrypt(X509_SCHANNEL_HANDLE_DATA* x509_handle, 
         keyProvInfo.pwszContainerName = x509_handle->key_name;
         keyProvInfo.pwszProvName = (LPWSTR)MS_KEY_STORAGE_PROVIDER;
 
-        /*Codes_SRS_X509_SCHANNEL_02_006: [ x509_schannel_create shall import the private key by calling CryptImportKey. ] */
+        /*Codes_SRS_X509_SCHANNEL_02_006: [ When compiled with _MSC_VER > 1500, x509_schannel_create shall import the private key by calling NCryptImportKey, otherwise it shall call CryptImportKey. ] */
         status = NCryptImportKey(x509_handle->hProv, 0, key_blob_type, &ncBufDesc, &x509_handle->x509hcryptkey, key_blob, key_blob_size, NCRYPT_OVERWRITE_KEY_FLAG);
         if (status != ERROR_SUCCESS)
         {
@@ -229,7 +256,7 @@ static int import_private_key_to_ncrypt(X509_SCHANNEL_HANDLE_DATA* x509_handle, 
         {
             if (x509_handle->x509hcryptkey != 0)
             {
-                (void)NCryptDeleteKey(x509_handle->x509hcryptkey, 0);
+                (void)NCryptFreeObject(x509_handle->x509hcryptkey);
                 x509_handle->x509hcryptkey = 0;
             }
             (void)NCryptFreeObject(x509_handle->hProv);
@@ -290,7 +317,7 @@ static int set_rsa_certificate_info(X509_SCHANNEL_HANDLE_DATA* x509_handle, unsi
     /* at this moment, both the private key and the certificate are decoded for further usage */
     result = import_private_key_to_ncrypt(x509_handle, LEGACY_RSAPRIVATE_BLOB, x509privatekeyBlob, x509privatekeyBlobSize);
 #else
-    /*Codes_SRS_X509_SCHANNEL_02_005: [ x509_schannel_create shall call CryptAcquireContext. ]*/
+    /*Codes_SRS_X509_SCHANNEL_02_005: [ When compiled with _MSC_VER > 1500, x509_schannel_create shall open a CNG key storage provider by calling NCryptOpenStorageProvider, otherwise it shall call CryptAcquireContext. ]*/
     /*at this moment, both the private key and the certificate are decoded for further usage*/
     if (!CryptAcquireContextA(&(x509_handle->hProv), NULL, MS_ENH_RSA_AES_PROV_A, PROV_RSA_AES, CRYPT_VERIFYCONTEXT))
     {
@@ -300,7 +327,7 @@ static int set_rsa_certificate_info(X509_SCHANNEL_HANDLE_DATA* x509_handle, unsi
     }
     else
     {
-        /*Codes_SRS_X509_SCHANNEL_02_006: [ x509_schannel_create shall import the private key by calling CryptImportKey. ] */
+        /*Codes_SRS_X509_SCHANNEL_02_006: [ When compiled with _MSC_VER > 1500, x509_schannel_create shall import the private key by calling NCryptImportKey, otherwise it shall call CryptImportKey. ] */
         if (!CryptImportKey(x509_handle->hProv, x509privatekeyBlob, x509privatekeyBlobSize, (HCRYPTKEY)NULL, 0, &(x509_handle->x509hcryptkey)))
         {
             /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
@@ -464,13 +491,7 @@ void x509_schannel_destroy(X509_SCHANNEL_HANDLE x509_schannel_handle)
         /* both RSA and ECC private keys are imported through NCrypt */
         if (x509crypto->x509hcryptkey != 0)
         {
-            /* the key container is persisted by NCryptImportKey, so it has to be removed and not just closed */
-            SECURITY_STATUS status = NCryptDeleteKey(x509crypto->x509hcryptkey, 0);
-            if (status != ERROR_SUCCESS)
-            {
-                LogError("NCryptDeleteKey failed with error 0x%08X", status);
-                (void)NCryptFreeObject(x509crypto->x509hcryptkey);
-            }
+            (void)NCryptFreeObject(x509crypto->x509hcryptkey);
         }
         if (x509crypto->hProv != 0)
         {

--- a/adapters/x509_schannel.c
+++ b/adapters/x509_schannel.c
@@ -10,9 +10,11 @@
 
 #if _MSC_VER > 1500
 #include <ncrypt.h>
+#include <stdio.h>
 #endif
 
 #define KEY_NAME L"AzureAliasKey"
+#define KEY_NAME_MAX_LENGTH         64
 #define ECC_256_MAGIC_NUMBER        0x20
 #define ECC_384_MAGIC_NUMBER        0x30
 
@@ -29,6 +31,9 @@ typedef struct X509_SCHANNEL_HANDLE_DATA_TAG
     HCRYPTKEY x509hcryptkey;
     PCCERT_CONTEXT x509certificate_context;
     x509_CERT_TYPE cert_type;
+#if _MSC_VER > 1500
+    wchar_t key_name[KEY_NAME_MAX_LENGTH];
+#endif
 } X509_SCHANNEL_HANDLE_DATA;
 
 static const char end_certificate_in_pem[] = "-----END CERTIFICATE-----";
@@ -151,12 +156,95 @@ static unsigned char* decode_crypt_object(unsigned char* private_key, DWORD key_
     return result;
 }
 
+#if _MSC_VER > 1500
+/* Imports the decoded private key blob into a CNG key storage provider and links it to the
+   certificate context. Schannel can only use a client certificate for TLS 1.2 client
+   authentication when the private key is reachable this way: a key published as a legacy
+   CryptoAPI provider handle limits Schannel to SHA-1 signatures, and peers that no longer offer
+   rsa_pkcs1_sha1 (OpenSSL 3.x, and therefore the IoT Edge transparent gateway) then fail the
+   handshake with SEC_E_ALGORITHM_MISMATCH. */
+static int import_private_key_to_ncrypt(X509_SCHANNEL_HANDLE_DATA* x509_handle, LPCWSTR key_blob_type, unsigned char* key_blob, DWORD key_blob_size)
+{
+    int result;
+    static volatile LONG key_name_suffix = 0;
+    SECURITY_STATUS status;
+
+    /* Every handle gets its own key container, otherwise two clients using different certificates
+       would overwrite each other's private key. */
+    if (swprintf_s(x509_handle->key_name, KEY_NAME_MAX_LENGTH, KEY_NAME L"-%lu-%ld",
+        (unsigned long)GetCurrentProcessId(), InterlockedIncrement(&key_name_suffix)) < 0)
+    {
+        /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+        LogError("unable to build the private key container name");
+        result = MU_FAILURE;
+    }
+    /* Codes_SRS_X509_SCHANNEL_02_005: [ x509_schannel_create shall call CryptAcquireContext. ] */
+    /* NOTE: As no WinCrypt key storage provider supports ECC keys, NCrypt is used instead */
+    else if ((status = NCryptOpenStorageProvider(&x509_handle->hProv, MS_KEY_STORAGE_PROVIDER, 0)) != ERROR_SUCCESS)
+    {
+        /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+        LogError("NCryptOpenStorageProvider failed with error 0x%08X", status);
+        x509_handle->hProv = 0;
+        result = MU_FAILURE;
+    }
+    else
+    {
+        NCryptBuffer ncBuf;
+        NCryptBufferDesc ncBufDesc;
+        CRYPT_KEY_PROV_INFO keyProvInfo;
+
+        ncBuf.cbBuffer = (ULONG)((wcslen(x509_handle->key_name) + 1) * sizeof(wchar_t));
+        ncBuf.BufferType = NCRYPTBUFFER_PKCS_KEY_NAME;
+        ncBuf.pvBuffer = x509_handle->key_name;
+        ncBufDesc.ulVersion = 0;
+        ncBufDesc.cBuffers = 1;
+        ncBufDesc.pBuffers = &ncBuf;
+
+        memset(&keyProvInfo, 0, sizeof(keyProvInfo));
+        keyProvInfo.pwszContainerName = x509_handle->key_name;
+        keyProvInfo.pwszProvName = (LPWSTR)MS_KEY_STORAGE_PROVIDER;
+
+        /*Codes_SRS_X509_SCHANNEL_02_006: [ x509_schannel_create shall import the private key by calling CryptImportKey. ] */
+        status = NCryptImportKey(x509_handle->hProv, 0, key_blob_type, &ncBufDesc, &x509_handle->x509hcryptkey, key_blob, key_blob_size, NCRYPT_OVERWRITE_KEY_FLAG);
+        if (status != ERROR_SUCCESS)
+        {
+            /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+            LogError("NCryptImportKey failed with error 0x%08X", status);
+            x509_handle->x509hcryptkey = 0;
+            result = MU_FAILURE;
+        }
+        /*Codes_SRS_X509_SCHANNEL_02_008: [ x509_schannel_create shall call set the certificate private key by calling CertSetCertificateContextProperty. ]*/
+        else if (!CertSetCertificateContextProperty(x509_handle->x509certificate_context, CERT_KEY_PROV_INFO_PROP_ID, 0, &keyProvInfo))
+        {
+            /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
+            LogErrorWinHTTPWithGetLastErrorAsString("CertSetCertificateContextProperty failed to set NCrypt key provider info");
+            result = MU_FAILURE;
+        }
+        else
+        {
+            result = 0;
+        }
+
+        if (result != 0)
+        {
+            if (x509_handle->x509hcryptkey != 0)
+            {
+                (void)NCryptDeleteKey(x509_handle->x509hcryptkey, 0);
+                x509_handle->x509hcryptkey = 0;
+            }
+            (void)NCryptFreeObject(x509_handle->hProv);
+            x509_handle->hProv = 0;
+        }
+    }
+    return result;
+}
+#endif
+
 static int set_ecc_certificate_info(X509_SCHANNEL_HANDLE_DATA* x509_handle, unsigned char* x509privatekeyBlob)
 {
     int result;
 #if _MSC_VER > 1500
     BCRYPT_ECCKEY_BLOB* pKeyBlob;
-    SECURITY_STATUS status;
     CRYPT_BIT_BLOB* pPubKeyBlob = &x509_handle->x509certificate_context->pCertInfo->SubjectPublicKeyInfo.PublicKey;
     CRYPT_ECC_PRIVATE_KEY_INFO* pPrivKeyInfo = (CRYPT_ECC_PRIVATE_KEY_INFO*)x509privatekeyBlob;
     DWORD pubSize = pPubKeyBlob->cbData - 1;
@@ -181,70 +269,9 @@ static int set_ecc_certificate_info(X509_SCHANNEL_HANDLE_DATA* x509_handle, unsi
         memcpy((BYTE*)(pKeyBlob + 1), pubKeyBuf, pubSize);
         memcpy((BYTE*)(pKeyBlob + 1) + pubSize, privKeyBuf, privSize);
 
-        /* Codes_SRS_X509_SCHANNEL_02_005: [ x509_schannel_create shall call CryptAcquireContext. ] */
         /* at this moment, both the private key and the certificate are decoded for further usage */
-        /* NOTE: As no WinCrypt key storage provider supports ECC keys, NCrypt is used instead */
-        status = NCryptOpenStorageProvider(&x509_handle->hProv, MS_KEY_STORAGE_PROVIDER, 0);
-        if (status != ERROR_SUCCESS)
-        {
-            /* Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
-            LogError("NCryptOpenStorageProvider failed with error 0x%08X", status);
-            result = MU_FAILURE;
-        }
-        else
-        {
-            SECURITY_STATUS status2;
-            NCryptBuffer ncBuf = { sizeof(KEY_NAME), NCRYPTBUFFER_PKCS_KEY_NAME, KEY_NAME };
-            NCryptBufferDesc ncBufDesc;
-            ncBufDesc.ulVersion = 0;
-            ncBufDesc.cBuffers = 1;
-            ncBufDesc.pBuffers = &ncBuf;
+        result = import_private_key_to_ncrypt(x509_handle, BCRYPT_ECCPRIVATE_BLOB, (unsigned char*)pKeyBlob, (DWORD)keyBlobSize);
 
-            CRYPT_KEY_PROV_INFO keyProvInfo = { KEY_NAME, MS_KEY_STORAGE_PROVIDER, 0, 0, 0, NULL, 0 };
-
-            /*Codes_SRS_X509_SCHANNEL_02_006: [ x509_schannel_create shall import the private key by calling CryptImportKey. ] */
-            /*NOTE: As no WinCrypt key storage provider supports ECC keys, NCrypt is used instead*/
-            status = NCryptImportKey(x509_handle->hProv, 0, BCRYPT_ECCPRIVATE_BLOB, &ncBufDesc, &x509_handle->x509hcryptkey, (BYTE*)pKeyBlob, (DWORD)keyBlobSize, NCRYPT_OVERWRITE_KEY_FLAG);
-            if (status == ERROR_SUCCESS)
-            {
-                status2 = NCryptFreeObject(x509_handle->x509hcryptkey);
-                if (status2 != ERROR_SUCCESS)
-                {
-                    LogError("NCryptFreeObject for key handle failed with error 0x%08X", status2);
-                }
-                else
-                {
-                    x509_handle->x509hcryptkey = 0;
-                }
-            }
-
-            status2 = NCryptFreeObject(x509_handle->hProv);
-            if (status2 != ERROR_SUCCESS)
-            {
-                LogError("NCryptFreeObject for provider handle failed with error 0x%08X", status2);
-            }
-            else
-            {
-                x509_handle->hProv = 0;
-            }
-
-            if (status != ERROR_SUCCESS)
-            {
-                /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
-                LogError("NCryptImportKey failed with error 0x%08X", status);
-                result = MU_FAILURE;
-            }
-            else if (!CertSetCertificateContextProperty(x509_handle->x509certificate_context, CERT_KEY_PROV_INFO_PROP_ID, 0, &keyProvInfo))
-            {
-                /*Codes_SRS_X509_SCHANNEL_02_010: [ Otherwise, x509_schannel_create shall fail and return a NULL X509_SCHANNEL_HANDLE. ]*/
-                LogErrorWinHTTPWithGetLastErrorAsString("CertSetCertificateContextProperty failed to set NCrypt key handle property");
-                result = MU_FAILURE;
-            }
-            else
-            {
-                result = 0;
-            }
-        }
         free(pKeyBlob);
     }
 #else
@@ -259,6 +286,10 @@ static int set_ecc_certificate_info(X509_SCHANNEL_HANDLE_DATA* x509_handle, unsi
 static int set_rsa_certificate_info(X509_SCHANNEL_HANDLE_DATA* x509_handle, unsigned char* x509privatekeyBlob, DWORD x509privatekeyBlobSize)
 {
     int result;
+#if _MSC_VER > 1500
+    /* at this moment, both the private key and the certificate are decoded for further usage */
+    result = import_private_key_to_ncrypt(x509_handle, LEGACY_RSAPRIVATE_BLOB, x509privatekeyBlob, x509privatekeyBlobSize);
+#else
     /*Codes_SRS_X509_SCHANNEL_02_005: [ x509_schannel_create shall call CryptAcquireContext. ]*/
     /*at this moment, both the private key and the certificate are decoded for further usage*/
     if (!CryptAcquireContextA(&(x509_handle->hProv), NULL, MS_ENH_RSA_AES_PROV_A, PROV_RSA_AES, CRYPT_VERIFYCONTEXT))
@@ -304,6 +335,7 @@ static int set_rsa_certificate_info(X509_SCHANNEL_HANDLE_DATA* x509_handle, unsi
             }
         }
     }
+#endif
     return result;
 }
 
@@ -428,30 +460,32 @@ void x509_schannel_destroy(X509_SCHANNEL_HANDLE x509_schannel_handle)
         /*Codes_SRS_X509_SCHANNEL_02_012: [ Otherwise, x509_schannel_destroy shall free all used resources. ]*/
         X509_SCHANNEL_HANDLE_DATA* x509crypto = (X509_SCHANNEL_HANDLE_DATA*)x509_schannel_handle;
 
-        if (x509crypto->cert_type == x509_TYPE_RSA)
-        {
-            if (!CryptDestroyKey(x509crypto->x509hcryptkey))
-            {
-                LogErrorWinHTTPWithGetLastErrorAsString("unable to CryptDestroyKey");
-            }
-            if (!CryptReleaseContext(x509crypto->hProv, 0))
-            {
-                LogErrorWinHTTPWithGetLastErrorAsString("unable to CryptReleaseContext");
-            }
-        }
-        else
-        {
 #if _MSC_VER > 1500
-            if (x509crypto->x509hcryptkey != 0)
+        /* both RSA and ECC private keys are imported through NCrypt */
+        if (x509crypto->x509hcryptkey != 0)
+        {
+            /* the key container is persisted by NCryptImportKey, so it has to be removed and not just closed */
+            SECURITY_STATUS status = NCryptDeleteKey(x509crypto->x509hcryptkey, 0);
+            if (status != ERROR_SUCCESS)
             {
+                LogError("NCryptDeleteKey failed with error 0x%08X", status);
                 (void)NCryptFreeObject(x509crypto->x509hcryptkey);
             }
-            if (x509crypto->hProv != 0)
-            {
-                (void)NCryptFreeObject(x509crypto->hProv);
-            }
-#endif
         }
+        if (x509crypto->hProv != 0)
+        {
+            (void)NCryptFreeObject(x509crypto->hProv);
+        }
+#else
+        if (!CryptDestroyKey(x509crypto->x509hcryptkey))
+        {
+            LogErrorWinHTTPWithGetLastErrorAsString("unable to CryptDestroyKey");
+        }
+        if (!CryptReleaseContext(x509crypto->hProv, 0))
+        {
+            LogErrorWinHTTPWithGetLastErrorAsString("unable to CryptReleaseContext");
+        }
+#endif
         if (!CertFreeCertificateContext(x509crypto->x509certificate_context))
         {
             LogErrorWinHTTPWithGetLastErrorAsString("unable to CertFreeCertificateContext");

--- a/devdoc/x509_schannel.md
+++ b/devdoc/x509_schannel.md
@@ -36,9 +36,19 @@ x509_schannel_create creates a handle wrapping a PCCERT_CONTEXT and other inform
 
 **SRS_X509_SCHANNEL_07_001: [** `x509_schannel_create` shall determine whether the certificate is of type RSA or ECC. **]** 
 
-**SRS_X509_SCHANNEL_02_005: [** `x509_schannel_create` shall call `CryptAcquireContext`. **]**
+**SRS_X509_SCHANNEL_02_005: [** When compiled with `_MSC_VER > 1500`, `x509_schannel_create` shall open a CNG key storage provider by calling `NCryptOpenStorageProvider`, otherwise it shall call `CryptAcquireContext`. **]**
 
-**SRS_X509_SCHANNEL_02_006: [** `x509_schannel_create` shall import the private key by calling `CryptImportKey`. **]**
+**SRS_X509_SCHANNEL_02_006: [** When compiled with `_MSC_VER > 1500`, `x509_schannel_create` shall import the private key by calling `NCryptImportKey`, otherwise it shall call `CryptImportKey`. **]**
+
+**SRS_X509_SCHANNEL_02_015: [** When compiled with `_MSC_VER > 1500`, `x509_schannel_create` shall name the key container after the certificate thumbprint. **]**
+
+Schannel can only use a client certificate for TLS 1.2 client authentication when the private key
+belongs to a named CNG key container: a key published as a legacy CryptoAPI provider handle
+(`CERT_KEY_PROV_HANDLE_PROP_ID`) restricts Schannel to `rsa_pkcs1_sha1` signatures, and an ephemeral
+CNG key is rejected by `AcquireCredentialsHandle` with `SEC_E_UNKNOWN_CREDENTIALS`. Naming the
+container after the certificate thumbprint keeps clients that use different certificates from
+overwriting one another's key, while letting a process that terminated without calling
+`x509_schannel_destroy` reuse its previous container rather than leaving a new one behind.
 
 **SRS_X509_SCHANNEL_02_007: [** `x509_schannel_create` shall create a cerficate context by calling `CertCreateCertificateContext`. **]**
 

--- a/tests/x509_schannel_ut/x509_schannel_ut.c
+++ b/tests/x509_schannel_ut/x509_schannel_ut.c
@@ -172,6 +172,7 @@ MOCKABLE_FUNCTION(WINAPI, BOOL, CertVerifyCertificateChainPolicy,
 MOCKABLE_FUNCTION(WINAPI, SECURITY_STATUS, NCryptFreeObject, NCRYPT_HANDLE, hObject);
 MOCKABLE_FUNCTION(WINAPI, SECURITY_STATUS, NCryptOpenStorageProvider, NCRYPT_PROV_HANDLE*, phProvider, LPCWSTR, pszProviderName, DWORD, dwFlags);
 MOCKABLE_FUNCTION(WINAPI, SECURITY_STATUS, NCryptImportKey, NCRYPT_PROV_HANDLE, hProvider, NCRYPT_KEY_HANDLE, hImportKey, LPCWSTR, pszBlobType, NCryptBufferDesc*, pParameterList, NCRYPT_KEY_HANDLE*, phKey, PBYTE, pbData, DWORD, cbData, DWORD, dwFlags);
+MOCKABLE_FUNCTION(WINAPI, SECURITY_STATUS, NCryptDeleteKey, NCRYPT_KEY_HANDLE, hKey, DWORD, dwFlags);
 #endif
 
 #undef ENABLE_MOCKS
@@ -407,6 +408,34 @@ static SECURITY_STATUS my_NCryptFreeObject(_In_ NCRYPT_HANDLE hObject)
     my_gballoc_free((void*)hObject);
     return ERROR_SUCCESS;
 }
+
+static SECURITY_STATUS my_NCryptOpenStorageProvider(NCRYPT_PROV_HANDLE* phProvider, LPCWSTR pszProviderName, DWORD dwFlags)
+{
+    (void)pszProviderName;
+    (void)dwFlags;
+    *phProvider = (NCRYPT_PROV_HANDLE)my_gballoc_malloc(3);
+    return ERROR_SUCCESS;
+}
+
+static SECURITY_STATUS my_NCryptImportKey(NCRYPT_PROV_HANDLE hProvider, NCRYPT_KEY_HANDLE hImportKey, LPCWSTR pszBlobType, NCryptBufferDesc* pParameterList, NCRYPT_KEY_HANDLE* phKey, PBYTE pbData, DWORD cbData, DWORD dwFlags)
+{
+    (void)hProvider;
+    (void)hImportKey;
+    (void)pszBlobType;
+    (void)pParameterList;
+    (void)pbData;
+    (void)cbData;
+    (void)dwFlags;
+    *phKey = (NCRYPT_KEY_HANDLE)my_gballoc_malloc(4);
+    return ERROR_SUCCESS;
+}
+
+static SECURITY_STATUS my_NCryptDeleteKey(NCRYPT_KEY_HANDLE hKey, DWORD dwFlags)
+{
+    (void)dwFlags;
+    my_gballoc_free((void*)hKey);
+    return ERROR_SUCCESS;
+}
 #endif
 
 static BOOL my_CryptDestroyKey(
@@ -524,14 +553,17 @@ TEST_SUITE_INITIALIZE(a)
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(CertVerifyCertificateChainPolicy, FALSE);
 
 #if _MSC_VER > 1500
-    REGISTER_GLOBAL_MOCK_RETURN(NCryptOpenStorageProvider, ERROR_SUCCESS);
+    REGISTER_GLOBAL_MOCK_HOOK(NCryptOpenStorageProvider, my_NCryptOpenStorageProvider);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(NCryptOpenStorageProvider, ERROR_INVALID_FUNCTION);
 
-    REGISTER_GLOBAL_MOCK_RETURN(NCryptImportKey, ERROR_SUCCESS);
+    REGISTER_GLOBAL_MOCK_HOOK(NCryptImportKey, my_NCryptImportKey);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(NCryptImportKey, ERROR_INVALID_FUNCTION);
 
     REGISTER_GLOBAL_MOCK_HOOK(NCryptFreeObject, my_NCryptFreeObject);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(NCryptFreeObject, ERROR_INVALID_FUNCTION);
+
+    REGISTER_GLOBAL_MOCK_HOOK(NCryptDeleteKey, my_NCryptDeleteKey);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(NCryptDeleteKey, ERROR_INVALID_FUNCTION);
 #endif
 }
 
@@ -575,10 +607,6 @@ static void setup_x509_schannel_create_ecc_mocks(void)
     STRICT_EXPECTED_CALL(NCryptImportKey((NCRYPT_PROV_HANDLE)IGNORED_ARG, (NCRYPT_KEY_HANDLE)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NCRYPT_OVERWRITE_KEY_FLAG))
         .IgnoreArgument_hProvider()
         .IgnoreArgument_hImportKey();
-    STRICT_EXPECTED_CALL(NCryptFreeObject((HCRYPTKEY)IGNORED_ARG))
-        .IgnoreArgument_hObject();
-    STRICT_EXPECTED_CALL(NCryptFreeObject((HCRYPTKEY)IGNORED_ARG))
-        .IgnoreArgument_hObject();
 
     STRICT_EXPECTED_CALL(CertSetCertificateContextProperty(IGNORED_ARG, CERT_KEY_PROV_INFO_PROP_ID, 0, IGNORED_ARG)); /*give the private key*/
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
@@ -601,10 +629,19 @@ static void setup_x509_schannel_create_mocks(void)
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG)); /*this is allocating space for the decoded private key*/
     STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_RSA_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, IGNORED_ARG, IGNORED_ARG)); /*this is asking "how big is the decoded private key? (from binary)*/
     STRICT_EXPECTED_CALL(CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, IGNORED_ARG, IGNORED_ARG)); /*create a certificate context from an encoded certificate*/
+#if _MSC_VER > 1500
+    STRICT_EXPECTED_CALL(NCryptOpenStorageProvider(IGNORED_ARG, MS_KEY_STORAGE_PROVIDER, 0)) /*this is opening the CNG key storage provider that will hold the private key*/
+        .IgnoreArgument_pszProviderName();
+    STRICT_EXPECTED_CALL(NCryptImportKey((NCRYPT_PROV_HANDLE)IGNORED_ARG, (NCRYPT_KEY_HANDLE)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NCRYPT_OVERWRITE_KEY_FLAG)) /*tranferring the key from the blob to the key storage provider*/
+        .IgnoreArgument_hProvider()
+        .IgnoreArgument_hImportKey();
+    STRICT_EXPECTED_CALL(CertSetCertificateContextProperty(IGNORED_ARG, CERT_KEY_PROV_INFO_PROP_ID, 0, IGNORED_ARG)); /*give the private key*/
+#else
     STRICT_EXPECTED_CALL(CryptAcquireContextA(IGNORED_ARG, NULL, MS_ENH_RSA_AES_PROV_A, PROV_RSA_AES, CRYPT_VERIFYCONTEXT)); /*this is acquire a handle to a key container within a cryptographic service provider*/
     STRICT_EXPECTED_CALL(CryptImportKey((HCRYPTPROV)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, (HCRYPTKEY)NULL, 0, IGNORED_ARG)) /*tranferring the key from the blob to the cryptrographic key provider*/
         .IgnoreArgument_hProv();
     STRICT_EXPECTED_CALL(CertSetCertificateContextProperty(IGNORED_ARG, CERT_KEY_PROV_HANDLE_PROP_ID, 0, IGNORED_ARG)); /*give the private key*/
+#endif
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG));
@@ -757,10 +794,17 @@ TEST_FUNCTION(x509_schannel_destroy_succeeds)
     X509_SCHANNEL_HANDLE h = x509_schannel_create("certificate", "private key");
     umock_c_reset_all_calls();
 
+#if _MSC_VER > 1500
+    STRICT_EXPECTED_CALL(NCryptDeleteKey((NCRYPT_KEY_HANDLE)IGNORED_ARG, 0))
+        .IgnoreArgument_hKey();
+    STRICT_EXPECTED_CALL(NCryptFreeObject((NCRYPT_HANDLE)IGNORED_ARG))
+        .IgnoreArgument_hObject();
+#else
     STRICT_EXPECTED_CALL(CryptDestroyKey((HCRYPTKEY)IGNORED_ARG))
         .IgnoreArgument_hKey();
     STRICT_EXPECTED_CALL(CryptReleaseContext((HCRYPTPROV)IGNORED_ARG, 0))
         .IgnoreArgument_hProv();
+#endif
     STRICT_EXPECTED_CALL(CertFreeCertificateContext(IGNORED_ARG))
         .IgnoreArgument_pCertContext();
     STRICT_EXPECTED_CALL(gballoc_free(h));

--- a/tests/x509_schannel_ut/x509_schannel_ut.c
+++ b/tests/x509_schannel_ut/x509_schannel_ut.c
@@ -79,6 +79,13 @@ MOCKABLE_FUNCTION(WINAPI, BOOL, CertSetCertificateContextProperty,
     const void           *, pvData
 );
 
+MOCKABLE_FUNCTION(WINAPI, BOOL, CertGetCertificateContextProperty,
+    PCCERT_CONTEXT, pCertContext,
+    DWORD, dwPropId,
+    void                 *, pvData,
+    DWORD                *, pcbData
+);
+
 MOCKABLE_FUNCTION(WINAPI, BOOL, CryptStringToBinaryA,
     LPCTSTR, pszString,
     DWORD, cchString,
@@ -172,7 +179,6 @@ MOCKABLE_FUNCTION(WINAPI, BOOL, CertVerifyCertificateChainPolicy,
 MOCKABLE_FUNCTION(WINAPI, SECURITY_STATUS, NCryptFreeObject, NCRYPT_HANDLE, hObject);
 MOCKABLE_FUNCTION(WINAPI, SECURITY_STATUS, NCryptOpenStorageProvider, NCRYPT_PROV_HANDLE*, phProvider, LPCWSTR, pszProviderName, DWORD, dwFlags);
 MOCKABLE_FUNCTION(WINAPI, SECURITY_STATUS, NCryptImportKey, NCRYPT_PROV_HANDLE, hProvider, NCRYPT_KEY_HANDLE, hImportKey, LPCWSTR, pszBlobType, NCryptBufferDesc*, pParameterList, NCRYPT_KEY_HANDLE*, phKey, PBYTE, pbData, DWORD, cbData, DWORD, dwFlags);
-MOCKABLE_FUNCTION(WINAPI, SECURITY_STATUS, NCryptDeleteKey, NCRYPT_KEY_HANDLE, hKey, DWORD, dwFlags);
 #endif
 
 #undef ENABLE_MOCKS
@@ -402,6 +408,14 @@ static BOOL my_CertGetCertificateChain(
 
 
 
+#define TEST_CAPTURED_KEY_NAME_SIZE 128
+#define TEST_THUMBPRINT_SIZE        20
+
+/* Filled in by my_NCryptImportKey so the tests can assert on the key container name. */
+static wchar_t g_captured_key_name[TEST_CAPTURED_KEY_NAME_SIZE];
+static bool g_captured_key_name_is_valid;
+static BYTE g_thumbprint_fill;
+
 #if _MSC_VER > 1500
 static SECURITY_STATUS my_NCryptFreeObject(_In_ NCRYPT_HANDLE hObject)
 {
@@ -422,21 +436,53 @@ static SECURITY_STATUS my_NCryptImportKey(NCRYPT_PROV_HANDLE hProvider, NCRYPT_K
     (void)hProvider;
     (void)hImportKey;
     (void)pszBlobType;
-    (void)pParameterList;
     (void)pbData;
     (void)cbData;
     (void)dwFlags;
+
+    g_captured_key_name_is_valid = false;
+    g_captured_key_name[0] = L'\0';
+    if ((pParameterList != NULL) && (pParameterList->cBuffers == 1) &&
+        (pParameterList->pBuffers != NULL) &&
+        (pParameterList->pBuffers[0].BufferType == NCRYPTBUFFER_PKCS_KEY_NAME) &&
+        (pParameterList->pBuffers[0].pvBuffer != NULL))
+    {
+        const wchar_t* container = (const wchar_t*)pParameterList->pBuffers[0].pvBuffer;
+        size_t chars = pParameterList->pBuffers[0].cbBuffer / sizeof(wchar_t);
+        /* cbBuffer has to cover the name and its terminator, otherwise NCrypt reads out of bounds */
+        if ((chars > 1) && (chars <= TEST_CAPTURED_KEY_NAME_SIZE) &&
+            (container[chars - 1] == L'\0') && (wcslen(container) == (chars - 1)))
+        {
+            (void)wcscpy_s(g_captured_key_name, TEST_CAPTURED_KEY_NAME_SIZE, container);
+            g_captured_key_name_is_valid = true;
+        }
+    }
+
     *phKey = (NCRYPT_KEY_HANDLE)my_gballoc_malloc(4);
     return ERROR_SUCCESS;
 }
-
-static SECURITY_STATUS my_NCryptDeleteKey(NCRYPT_KEY_HANDLE hKey, DWORD dwFlags)
-{
-    (void)dwFlags;
-    my_gballoc_free((void*)hKey);
-    return ERROR_SUCCESS;
-}
 #endif
+
+static BOOL my_CertGetCertificateContextProperty(PCCERT_CONTEXT pCertContext, DWORD dwPropId, void* pvData, DWORD* pcbData)
+{
+    (void)pCertContext;
+    (void)dwPropId;
+    if (pvData == NULL)
+    {
+        *pcbData = TEST_THUMBPRINT_SIZE;
+    }
+    else if (*pcbData < TEST_THUMBPRINT_SIZE)
+    {
+        *pcbData = TEST_THUMBPRINT_SIZE;
+        return FALSE;
+    }
+    else
+    {
+        memset(pvData, g_thumbprint_fill, TEST_THUMBPRINT_SIZE);
+        *pcbData = TEST_THUMBPRINT_SIZE;
+    }
+    return TRUE;
+}
 
 static BOOL my_CryptDestroyKey(
     HCRYPTKEY hKey
@@ -539,6 +585,9 @@ TEST_SUITE_INITIALIZE(a)
     REGISTER_GLOBAL_MOCK_HOOK(CertSetCertificateContextProperty, my_CertSetCertificateContextProperty);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(CertSetCertificateContextProperty, FALSE);
 
+    REGISTER_GLOBAL_MOCK_HOOK(CertGetCertificateContextProperty, my_CertGetCertificateContextProperty);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(CertGetCertificateContextProperty, FALSE);
+
     REGISTER_GLOBAL_MOCK_HOOK(CertFreeCertificateContext, my_CertFreeCertificateContext);
 
     REGISTER_GLOBAL_MOCK_RETURN(CertOpenStore, testCertStore);
@@ -561,9 +610,6 @@ TEST_SUITE_INITIALIZE(a)
 
     REGISTER_GLOBAL_MOCK_HOOK(NCryptFreeObject, my_NCryptFreeObject);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(NCryptFreeObject, ERROR_INVALID_FUNCTION);
-
-    REGISTER_GLOBAL_MOCK_HOOK(NCryptDeleteKey, my_NCryptDeleteKey);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(NCryptDeleteKey, ERROR_INVALID_FUNCTION);
 #endif
 }
 
@@ -578,6 +624,9 @@ TEST_FUNCTION_INITIALIZE(initialize)
 {
     umock_c_reset_all_calls();
     memset(&testCertContextToVerify, 0, sizeof(testCertContextToVerify));
+    memset(g_captured_key_name, 0, sizeof(g_captured_key_name));
+    g_captured_key_name_is_valid = false;
+    g_thumbprint_fill = 0xAB;
 }
 
 TEST_FUNCTION_CLEANUP(cleans)
@@ -602,6 +651,7 @@ static void setup_x509_schannel_create_ecc_mocks(void)
     STRICT_EXPECTED_CALL(CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, IGNORED_ARG, IGNORED_ARG)); /*create a certificate context from an encoded certificate*/
 
     STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(CertGetCertificateContextProperty(IGNORED_ARG, CERT_SHA1_HASH_PROP_ID, IGNORED_ARG, IGNORED_ARG)); /*the key container is named after the certificate thumbprint*/
     STRICT_EXPECTED_CALL(NCryptOpenStorageProvider(IGNORED_ARG, MS_KEY_STORAGE_PROVIDER, 0))
         .IgnoreArgument_pszProviderName();
     STRICT_EXPECTED_CALL(NCryptImportKey((NCRYPT_PROV_HANDLE)IGNORED_ARG, (NCRYPT_KEY_HANDLE)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NCRYPT_OVERWRITE_KEY_FLAG))
@@ -630,6 +680,7 @@ static void setup_x509_schannel_create_mocks(void)
     STRICT_EXPECTED_CALL(CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, PKCS_RSA_PRIVATE_KEY, IGNORED_ARG, IGNORED_ARG, 0, NULL, IGNORED_ARG, IGNORED_ARG)); /*this is asking "how big is the decoded private key? (from binary)*/
     STRICT_EXPECTED_CALL(CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, IGNORED_ARG, IGNORED_ARG)); /*create a certificate context from an encoded certificate*/
 #if _MSC_VER > 1500
+    STRICT_EXPECTED_CALL(CertGetCertificateContextProperty(IGNORED_ARG, CERT_SHA1_HASH_PROP_ID, IGNORED_ARG, IGNORED_ARG)); /*the key container is named after the certificate thumbprint*/
     STRICT_EXPECTED_CALL(NCryptOpenStorageProvider(IGNORED_ARG, MS_KEY_STORAGE_PROVIDER, 0)) /*this is opening the CNG key storage provider that will hold the private key*/
         .IgnoreArgument_pszProviderName();
     STRICT_EXPECTED_CALL(NCryptImportKey((NCRYPT_PROV_HANDLE)IGNORED_ARG, (NCRYPT_KEY_HANDLE)IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NCRYPT_OVERWRITE_KEY_FLAG)) /*tranferring the key from the blob to the key storage provider*/
@@ -706,6 +757,15 @@ TEST_FUNCTION(x509_schannel_negative_test_cases)
 {
     ///arrange
     size_t i;
+#if _MSC_VER > 1500
+    size_t calls_that_cannot_fail[] = {
+        7,
+        15, /*gballoc_free*/
+        16, /*gballoc_free*/
+        17, /*gballoc_free*/
+
+    };
+#else
     size_t calls_that_cannot_fail[] = {
         7,
         14, /*gballoc_free*/
@@ -713,6 +773,7 @@ TEST_FUNCTION(x509_schannel_negative_test_cases)
         16, /*gballoc_free*/
 
     };
+#endif
     int negativeTestsInitResult = umock_c_negative_tests_init();
     ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
@@ -771,6 +832,61 @@ TEST_FUNCTION(x509_schannel_create_ecc_succeeds)
     ///cleanup
     x509_schannel_destroy(h);
 }
+
+/*Tests_SRS_X509_SCHANNEL_02_015: [ When compiled with _MSC_VER > 1500, x509_schannel_create shall name the key container after the certificate thumbprint. ]*/
+TEST_FUNCTION(x509_schannel_create_gives_different_certificates_different_key_containers)
+{
+    ///arrange
+    X509_SCHANNEL_HANDLE first;
+    X509_SCHANNEL_HANDLE second;
+    wchar_t first_key_name[TEST_CAPTURED_KEY_NAME_SIZE];
+
+    g_thumbprint_fill = 0x11;
+    first = x509_schannel_create("certificate", "private key");
+    ASSERT_IS_NOT_NULL(first);
+    ASSERT_IS_TRUE(g_captured_key_name_is_valid, "the container name must reach NCryptImportKey as a NUL terminated NCRYPTBUFFER_PKCS_KEY_NAME");
+    (void)wcscpy_s(first_key_name, TEST_CAPTURED_KEY_NAME_SIZE, g_captured_key_name);
+
+    ///act
+    g_thumbprint_fill = 0x22;
+    second = x509_schannel_create("certificate", "private key");
+
+    ///assert
+    ASSERT_IS_NOT_NULL(second);
+    ASSERT_IS_TRUE(g_captured_key_name_is_valid);
+    ASSERT_ARE_NOT_EQUAL(int, 0, wcscmp(first_key_name, g_captured_key_name), "two certificates must not share a key container, or one client overwrites the other's private key");
+
+    ///cleanup
+    x509_schannel_destroy(first);
+    x509_schannel_destroy(second);
+}
+
+/*Tests_SRS_X509_SCHANNEL_02_015: [ When compiled with _MSC_VER > 1500, x509_schannel_create shall name the key container after the certificate thumbprint. ]*/
+TEST_FUNCTION(x509_schannel_create_reuses_the_key_container_of_the_same_certificate)
+{
+    ///arrange
+    X509_SCHANNEL_HANDLE first;
+    X509_SCHANNEL_HANDLE second;
+    wchar_t first_key_name[TEST_CAPTURED_KEY_NAME_SIZE];
+
+    g_thumbprint_fill = 0x33;
+    first = x509_schannel_create("certificate", "private key");
+    ASSERT_IS_NOT_NULL(first);
+    ASSERT_IS_TRUE(g_captured_key_name_is_valid);
+    (void)wcscpy_s(first_key_name, TEST_CAPTURED_KEY_NAME_SIZE, g_captured_key_name);
+
+    ///act
+    second = x509_schannel_create("certificate", "private key");
+
+    ///assert
+    ASSERT_IS_NOT_NULL(second);
+    ASSERT_IS_TRUE(g_captured_key_name_is_valid);
+    ASSERT_ARE_EQUAL(int, 0, wcscmp(first_key_name, g_captured_key_name), "the same certificate must reuse its container, otherwise an ungraceful exit orphans a new one every run");
+
+    ///cleanup
+    x509_schannel_destroy(first);
+    x509_schannel_destroy(second);
+}
 #endif
 
 /*Tests_SRS_X509_SCHANNEL_02_011: [ If parameter x509_schannel_handle is NULL then x509_schannel_destroy shall do nothing. ]*/
@@ -795,8 +911,8 @@ TEST_FUNCTION(x509_schannel_destroy_succeeds)
     umock_c_reset_all_calls();
 
 #if _MSC_VER > 1500
-    STRICT_EXPECTED_CALL(NCryptDeleteKey((NCRYPT_KEY_HANDLE)IGNORED_ARG, 0))
-        .IgnoreArgument_hKey();
+    STRICT_EXPECTED_CALL(NCryptFreeObject((NCRYPT_HANDLE)IGNORED_ARG))
+        .IgnoreArgument_hObject();
     STRICT_EXPECTED_CALL(NCryptFreeObject((NCRYPT_HANDLE)IGNORED_ARG))
         .IgnoreArgument_hObject();
 #else


### PR DESCRIPTION
## Problem

On Windows, a device that authenticates with an **RSA** X.509 client certificate cannot complete the
TLS handshake against any peer that no longer offers SHA-1 signature algorithms. Schannel fails
`InitializeSecurityContext` with `SEC_E_ALGORITHM_MISMATCH` (0x80090331) *before writing a single
byte*, so the client sends no Certificate, no ClientKeyExchange and no TLS alert -- it just ACKs the
server flight and closes the connection.

This is what an IoT Edge transparent gateway looks like from the device side, and it is why the
gateway only logs `TLS handshake failed., System.IO.IOException: Channel is closed` with no client
identity.

## Root cause

`adapters/x509_schannel.c :: set_rsa_certificate_info()` publishes the RSA private key to Schannel as
a **legacy CryptoAPI provider handle**:

```c
CryptAcquireContextA(&hProv, NULL, MS_ENH_RSA_AES_PROV_A, PROV_RSA_AES, CRYPT_VERIFYCONTEXT)
CryptImportKey(hProv, blob, size, NULL, 0, &hcryptkey)
CertSetCertificateContextProperty(ctx, CERT_KEY_PROV_HANDLE_PROP_ID, 0, (void*)hProv)
```

A key bound this way restricts Schannel to **`rsa_pkcs1_sha1` (0x0201)** when it signs the TLS 1.2
CertificateVerify message. If the peer's CertificateRequest does not advertise `0x0201`, there is no
mutually supported signature algorithm and Schannel gives up.

The ECC path in the same file was moved to CNG in 2018; the RSA path was left on CryptoAPI. This
fixes that asymmetry.

### Why this was never noticed

Azure IoT Hub and DPS front ends still advertise `rsa_pkcs1_sha1`, so direct-to-hub X.509 keeps
working. OpenSSL 3.x dropped SHA-1 signature algorithms, so only OpenSSL-fronted peers are affected.

## Evidence

Reproduced with a standalone Schannel client that replicates this adapter's code paths exactly,
against an OpenSSL 3.0.13 TLS 1.2 server (`ECDHE-RSA-AES256-GCM-SHA384`, CertificateRequest with no
CA filtering), plus a live Azure endpoint as a control. Same certificate and key throughout:

| Peer | Key binding | Result |
| --- | --- | --- |
| OpenSSL 3.x | current (CryptoAPI) | `SEC_E_ALGORITHM_MISMATCH`, 0 bytes out, FIN |
| OpenSSL 3.x | no client certificate | Handshake OK |
| `global.azure-devices-provisioning.net:8883` | current (CryptoAPI) | Handshake OK, certificate sent |
| OpenSSL 3.x, CertificateRequest = `rsa_pkcs1_sha1` only | current (CryptoAPI) | Handshake OK |
| OpenSSL 3.x, CertificateRequest = `rsa_pkcs1_sha256` only | current (CryptoAPI) | Fails |
| all of the above | **this PR (CNG)** | **Handshake OK, certificate accepted** |

Ruled out by experiment, in case they come up in review: RSA-PSS is **not** involved (forcing the
CertificateRequest to PKCS#1-only still fails); `SCH_USE_STRONG_CRYPTO`; the session_ticket and
ec_point_formats extensions; the PSS-signed ServerKeyExchange; ECDHE vs RSA key exchange; DN
filtering; and adding an explicit key spec to the existing CryptoAPI binding.

## The change

- New `import_private_key_to_ncrypt()` imports the decoded private key blob into a CNG key storage
  provider and binds it with `CERT_KEY_PROV_INFO_PROP_ID`. Both the RSA and the ECC paths now use it.
- `CryptDecodeObjectEx(PKCS_RSA_PRIVATE_KEY)` already produces the legacy `PRIVATEKEYBLOB` that
  `NCryptImportKey` accepts as `LEGACY_RSAPRIVATE_BLOB`, so no additional key conversion is needed.
- Each handle now gets its **own key container** (`AzureAliasKey-<pid>-<counter>`). The previous fixed
  container name combined with `NCRYPT_OVERWRITE_KEY_FLAG` let two clients using different
  certificates silently overwrite each other's private key. That was already latent for ECC; since
  this PR routes the common RSA case through the same code, fixing it is a prerequisite.
- `x509_schannel_destroy` now calls `NCryptDeleteKey`, so the persisted container is not left behind
  in the user's key store.
- The legacy CryptoAPI path is preserved for `_MSC_VER <= 1500`, where `ncrypt.h` is unavailable.
- Unrelated but adjacent: `tlsio_schannel.c :: send_client_hello()` never initialized
  `SCHANNEL_CRED.cMappers` / `aphMappers` and passed stack garbage to `AcquireCredentialsHandle`. The
  structure is now zeroed first.

### Why the key has to be persisted

An ephemeral CNG key does not work. Both `CERT_NCRYPT_KEY_HANDLE_PROP_ID` and
`CERT_KEY_CONTEXT_PROP_ID{CERT_NCRYPT_KEY_SPEC}` are accepted by
`CertSetCertificateContextProperty`, but `AcquireCredentialsHandle` then fails with
`SEC_E_UNKNOWN_CREDENTIALS` (0x8009030D). A named, persisted key bound through
`CERT_KEY_PROV_INFO_PROP_ID` is the only binding Schannel accepts -- which is also what the existing
ECC path does.

## Testing

- `x509_schannel_ut`: **17 tests ran, 0 failed.** Expectations for the RSA path were updated to the
  NCrypt calls, the destroy test now expects `NCryptDeleteKey` / `NCryptFreeObject`, and a
  `NCryptDeleteKey` mock was added.
- Verified end to end with the repro harness described above; the handshake now completes and the
  server reports the expected client certificate subject.

## Notes for reviewers

- **Please sanity-check the persisted-key requirement against restricted service accounts.** The key
  now lands in the user's CNG key store, so a process running without a loaded user profile is the
  scenario most worth a second opinion. The ECC path has had this exposure since 2018, but this PR
  extends it to RSA, which is the common case.
- There is an open branch `fix/schannel-pkcs8-private-key` that also rewrites `x509_schannel.c` and
  `x509_schannel_ut.c` substantially. The two changes are complementary (that one widens which key
  *formats* are accepted; this one changes how the key is *bound* to Schannel) but they will conflict
  textually. Happy to rebase whichever lands second.
- Rebased onto current `master`, which includes a7b2cf8e (explicit ANSI Win32/SSPI entry points); the
  retained legacy path uses `CryptAcquireContextA` / `MS_ENH_RSA_AES_PROV_A` accordingly.
